### PR TITLE
Horizon: add headline and hover styling

### DIFF
--- a/src/components/content/Horizon.tsx
+++ b/src/components/content/Horizon.tsx
@@ -25,7 +25,7 @@ export default function Horizon({ entries }: { entries: HorizonProp[] }) {
 }
 
 const Wrapper = styled.div`
-  align-items: center;
+  align-items: stretch;
   display: flex;
   justify-content: space-between;
   padding: 32px 24px 24px;
@@ -42,6 +42,13 @@ const Item = styled.a`
   text-decoration: none;
   max-width: 400px;
   width: 30%;
+  padding: 15px 10px;
+
+  &:hover {
+    box-shadow: 0px 0px 10px 0px rgba(170,170,170,0.25);
+    color: ${props => props.theme.colors.darkgray};
+  }
+
   @media (max-width: ${props => props.theme.breakpoints.sm}) {
     /* quickfix: slider or not loading them at all would be better */
     display: none;
@@ -63,7 +70,7 @@ const Image = styled.img`
   }
 `
 
-const Headline = styled.p`
+const Headline = styled.h4`
   font-weight: bold;
   font-size: 1.25rem;
   margin: 10px 0 5px;


### PR DESCRIPTION
Fix the styling for headline and hover.
* The headline is now a real headline tag (go with h4 to not interupt with SEO important headline tags)
* implement some hover styling for better UX (text get dark gray like navigation and a box shadow)


<img width="941" alt="Screenshot 2020-03-29 at 11 45 03" src="https://user-images.githubusercontent.com/61757170/77845959-05495c80-71b3-11ea-8157-c1e8c085b9d8.png">
