### PR TITLE
Add support for docker and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+\.git
+Dockerfile
+\.gitignore
+\.prettierrc
+LICENSE
+\.next
+node_modules
+README\.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:lts-alpine as build
+
+WORKDIR /app
+COPY . .
+
+RUN yarn install --frozen-lockfile
+RUN yarn build
+
+FROM node:lts-alpine
+
+WORKDIR /app
+COPY public public
+COPY --from=build /app/package.json package.json
+COPY --from=build /app/yarn.lock yarn.lock
+COPY --from=build /app/.next .next
+
+RUN yarn install --production --frozen-lockfile
+
+EXPOSE 3000
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=build /app/.next .next
 RUN yarn install --production --frozen-lockfile
 
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["yarn", "start:next"]

--- a/README.md
+++ b/README.md
@@ -484,13 +484,16 @@ This example fetches some random cat facts and pass them on to the page. Some mo
 Build and run the frontend with these commands:
 
 ```
-yarn build
 yarn start
 ```
 
-This will trigger a production build. It will also summarize the size of all output artifacts.
+This will trigger a production build (`docker` and `docker-compose` need to be installed). To stop the created docker image, run:
 
-To get detailed information about bundle size, run this:
+```
+yarn stop
+```
+
+To get detailed information about bundle size and a summarize of all output artifacts, run this:
 
 ```
 yarn analyze

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  frontend:
+    build:
+      context: .
+    ports:
+      - '3000:3000'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start",
+    "start": "docker-compose up --build --detach",
+    "start:next": "next start",
+    "stop": "docker-compose down",
     "typecheck": "yarn tsc --noEmit",
     "prettify": "yarn prettier --write \"{src,pages}/**/*.{js,tsx,ts}\"",
     "analyze": "cross-env ANALYZE=true yarn build"


### PR DESCRIPTION
Docker is needed so that we can add the frontend to our Kubernetes cluster ( https://github.com/serlo/infrastructure-env-production/issues/16 ). To test it you can run `yarn start`. Nextjs gets deployed via docker and is still available via `localhost:3000`. `yarn stop` will stop and remove the created container.