### PR TITLE
RFC: cache GraphQL API via ZEIT Smart CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "katex": "0.11.1",
     "next": "^9.3.2",
+    "next-absolute-url": "^1.0.0",
     "polished": "^3.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -10,6 +10,8 @@ import Breadcrumbs from '../src/components/navigation/Breadcrumbs'
 import HSpace from '../src/components/content/HSpace'
 import Horizon from '../src/components/content/Horizon'
 import { horizonData } from '../src/horizondata'
+import fetch from 'isomorphic-unfetch'
+import absoluteUrl from 'next-absolute-url'
 
 function PageView(props) {
   const { data } = props
@@ -55,7 +57,9 @@ const MaxWidthDiv = styled.div`
 `
 
 export async function getServerSideProps(props) {
-  const data = await fetchContent('/' + props.params.slug.join('/'))
+  const { origin } = absoluteUrl(props.req)
+  const res = await fetch(`${origin}/api/${props.params.slug.join('/')}`)
+  const data = await res.json()
   return { props: { data } }
 }
 

--- a/pages/api/[...slug].tsx
+++ b/pages/api/[...slug].tsx
@@ -1,0 +1,9 @@
+import fetchContent from '../../src/content-api/fetchContentFromSerloOrg'
+
+// Proxy the API Call as GET request to the frontend so that the ZEIT Now CDN is able to cache this
+// We use stale-while-revalidate for that, see also https://zeit.co/docs/v2/network/caching#stale-while-revalidate
+export default async function fetch(req, res) {
+  const data = await fetchContent('/' + req.query.slug.join('/'))
+  res.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate')
+  res.json(data)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,6 +4923,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+next-absolute-url@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/next-absolute-url/-/next-absolute-url-1.2.2.tgz#9aba5adcee8effcffd63271d99e13213ad04c23b"
+  integrity sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
ZEIT updated [their pricing](https://zeit.co/pricing) which makes it way more feasible for us (since there are no Bandwidth limits anymore). For that to work well for our users, we still need to reduce the latency to our API server. For that, I created an API route proxying the actual GraphQL Query as GET Request so that the ZEIT Smart CDN can cache the request. Using [stale-while-revalidate](https://zeit.co/docs/v2/network/caching#stale-while-revalidate), this should introduce latency only when the ZEIT Smart CDN hasn't cached the API request yet and asynchronously update the cache in the background.

So basically my preferred approach (which is open for feedback) would be:
- Deploy frontend via ZEIT Now. This way, we don't need to think about scalability of the frontend at all, only the GraphQL API. And we can basically throw our current caching of HTML away (since ZEIT handles that).
- Deploy API in our cluster (w/ smart caching), so the API should also scale well since we have many reads but few writes.
- When we need a GraphQL Query in frontend, we proxy it via an API route w/ stale-while-revalidate (or other appropriate caching rules) so that ZEIT Smart CDN can cache it. We can decide per use case whether this is only done server-side (as it is currently the case), or client-side / both / something fancy like [zeit/swr](https://swr.now.sh/)
- If the request is only used on client-side (e.g. user-specific requests, or mutations when saving), we can talk to the GraphQL API directly.

Thoughts? You can test out the loading times / latency on https://frontend-r0mxv4d2u.now.sh/mathe