### PR TITLE
Sentry intergration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 module.exports = withBundleAnalyzer({
+  env: {
+    SENTRY_DSN:
+      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333'
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@serlo/frontend",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/serlo/frontend.git"
@@ -20,6 +21,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.0.0",
     "@fortawesome/free-solid-svg-icons": "^5.0.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
+    "@sentry/browser": "^5.15.4",
     "@tippyjs/react": "^4.0.0-alpha.0",
     "graphql-request": "^1.8.2",
     "htmlparser2": "^4.1.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -11,6 +11,27 @@ import '../public/fonts/katex/katex.css'
 import { ThemeProvider } from 'styled-components'
 import { theme } from '../src/theme'
 
+import * as Sentry from '@sentry/browser'
+
+const { version } = require('../package.json')
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN, //process.env.NODE_ENV === 'production' ?  : undefined,
+  release: `serlo-org-client@${version}`
+})
+
+/*
+docs say it's not available for js anyway:
+,
+  whitelistUrls: [
+    'serlo.org',
+    'serlo-development.dev',
+    'serlo-staging.dev',
+    'frontend-sooty-ten.now.sh',
+    'frontend.dal123.now.sh'
+  ]
+*/
+
 class MyApp extends App {
   render() {
     const { Component, pageProps } = this.props

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,11 +1,20 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
+import * as Sentry from '@sentry/browser'
 
 const bodyStyles = {
   margin: 0,
   fontFamily: 'Karmilla, sans-serif',
   letterSpacing: '-0.007em'
 }
+
+process.on('unhandledRejection', err => {
+  Sentry.captureException(err)
+})
+
+process.on('uncaughtException', err => {
+  Sentry.captureException(err)
+})
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,6 +1357,58 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.0.tgz#09a7a352a40508156e1256efdc015593feca28e0"
   integrity sha512-ntN5t5spqhQv28cLfmmt1dYabsudzR5A7PU15gr/gzcT/gzqAOnYFQPaLPFraDa7ZCJG2eJ1JsO7pgXbYXGIrw==
 
+"@sentry/browser@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.15.4.tgz#5a7e7bad088556665ed8e69bceb0e18784e4f6c7"
+  integrity sha512-l/auT1HtZM3KxjCGQHYO/K51ygnlcuOrM+7Ga8gUUbU9ZXDYw6jRi0+Af9aqXKmdDw1naNxr7OCSy6NBrLWVZw==
+  dependencies:
+    "@sentry/core" "5.15.4"
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/core@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.4.tgz#08b617e093a636168be5aebad141d1f744217085"
+  integrity sha512-9KP4NM4SqfV5NixpvAymC7Nvp36Zj4dU2fowmxiq7OIbzTxGXDhwuN/t0Uh8xiqlkpkQqSECZ1OjSFXrBldetQ==
+  dependencies:
+    "@sentry/hub" "5.15.4"
+    "@sentry/minimal" "5.15.4"
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.15.4.tgz#cb64473725a60eec63b0be58ed1143eaaf894bee"
+  integrity sha512-1XJ1SVqadkbUT4zLS0TVIVl99si7oHizLmghR8LMFl5wOkGEgehHSoOydQkIAX2C7sJmaF5TZ47ORBHgkqclUg==
+  dependencies:
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.4.tgz#113f01fefb86b7830994c3dfa7ad4889ba7b2003"
+  integrity sha512-GL4GZ3drS9ge+wmxkHBAMEwulaE7DMvAEfKQPDAjg2p3MfcCMhAYfuY4jJByAC9rg9OwBGGehz7UmhWMFjE0tw==
+  dependencies:
+    "@sentry/hub" "5.15.4"
+    "@sentry/types" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/types@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.15.4.tgz#37f30e35b06e8e12ad1101f1beec3e9b88ca1aab"
+  integrity sha512-quPHPpeAuwID48HLPmqBiyXE3xEiZLZ5D3CEbU3c3YuvvAg8qmfOOTI6z4Z3Eedi7flvYpnx3n7N3dXIEz30Eg==
+
+"@sentry/utils@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.15.4.tgz#02865ab3c9b745656cea0ab183767ec26c96f6e6"
+  integrity sha512-lO8SLBjrUDGADl0LOkd55R5oL510d/1SaI08/IBHZCxCUwI4TiYo5EPECq8mrj3XGfgCyq9osw33bymRlIDuSQ==
+  dependencies:
+    "@sentry/types" "5.15.4"
+    tslib "^1.9.3"
+
 "@svgr/babel-plugin-add-jsx-attribute@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.0.1.tgz#744853b6533e83ce712d41d1873200b3e0a0b6fc"
@@ -7106,7 +7158,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
Basic implementation.
Server- and clientside report errors:

![image](https://user-images.githubusercontent.com/1258870/79737601-d9c21980-82fb-11ea-8769-91c570084d3c.png)


If we need more (e.g. build-id) at some point:
https://github.com/zeit/next.js/tree/canary/examples/with-sentry

If we need sourcemaps above check here:
https://github.com/zeit/next.js/tree/canary/examples/with-sentry
https://github.com/zeit/next-plugins/issues/309
https://spectrum.chat/next-js/general/config-nextjs-sourcemaps-in-sentry~630c66f8-69b4-41bf-8cad-98590b782322

I removed the whitelisted URLs because [the docs say](https://docs.sentry.io/error-reporting/configuration/?platform=javascript#whitelist-urls) this is not available for js.
