### PR TITLE
Add Analytics

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 module.exports = withBundleAnalyzer({
-  env: {
-    SENTRY_DSN:
-      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333'
-  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 module.exports = withBundleAnalyzer({
   env: {
     SENTRY_DSN:
-      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333'
+      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333',
+    GA_TRACKING_ID: 'UA-20283862-5'
   },
   webpack(config) {
     config.module.rules.push({

--- a/next.config.js
+++ b/next.config.js
@@ -5,8 +5,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 module.exports = withBundleAnalyzer({
   env: {
     SENTRY_DSN:
-      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333',
-    GA_TRACKING_ID: 'UA-20283862-3'
+      'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333'
   },
   webpack(config) {
     config.module.rules.push({

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ module.exports = withBundleAnalyzer({
   env: {
     SENTRY_DSN:
       'https://b7a5f46510b945b7a3a78c47c6a6048a@o115070.ingest.sentry.io/5206333',
-    GA_TRACKING_ID: 'UA-20283862-5'
+    GA_TRACKING_ID: 'UA-20283862-3'
   },
   webpack(config) {
     config.module.rules.push({

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,11 +15,11 @@ import * as Sentry from '@sentry/browser'
 
 const { version } = require('../package.json')
 
-Sentry.init({
-  dsn:
-    process.env.NODE_ENV === 'production' ? process.env.SENTRY_DSN : undefined,
-  release: `serlo-org-client@${version}`
-})
+if (process.env.SENTRY_DSN !== undefined)
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: `serlo-org-client@${version}`
+  })
 
 class MyApp extends App {
   render() {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -16,21 +16,10 @@ import * as Sentry from '@sentry/browser'
 const { version } = require('../package.json')
 
 Sentry.init({
-  dsn: process.env.SENTRY_DSN, //process.env.NODE_ENV === 'production' ?  : undefined,
+  dsn:
+    process.env.NODE_ENV === 'production' ? process.env.SENTRY_DSN : undefined,
   release: `serlo-org-client@${version}`
 })
-
-/*
-docs say it's not available for js anyway:
-,
-  whitelistUrls: [
-    'serlo.org',
-    'serlo-development.dev',
-    'serlo-staging.dev',
-    'frontend-sooty-ten.now.sh',
-    'frontend.dal123.now.sh'
-  ]
-*/
 
 class MyApp extends App {
   render() {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,13 +9,15 @@ const bodyStyles = {
   letterSpacing: '-0.007em'
 }
 
-process.on('unhandledRejection', err => {
-  Sentry.captureException(err)
-})
+if (process.env.SENTRY_DSN !== undefined) {
+  process.on('unhandledRejection', err => {
+    Sentry.captureException(err)
+  })
 
-process.on('uncaughtException', err => {
-  Sentry.captureException(err)
-})
+  process.on('uncaughtException', err => {
+    Sentry.captureException(err)
+  })
+}
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 import * as Sentry from '@sentry/browser'
+import GoogleAnalytics from '../src/components/GoogleAnalytics'
 
 const bodyStyles = {
   margin: 0,
@@ -52,6 +53,7 @@ export default class MyDocument extends Document {
         <body style={bodyStyles}>
           <Main />
           <NextScript />
+          <GoogleAnalytics />
         </body>
       </Html>
     )

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -53,7 +53,7 @@ export default class MyDocument extends Document {
         <body style={bodyStyles}>
           <Main />
           <NextScript />
-          <GoogleAnalytics />
+          {process.env.NODE_ENV === 'production' && <GoogleAnalytics />}
         </body>
       </Html>
     )

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -53,7 +53,7 @@ export default class MyDocument extends Document {
         <body style={bodyStyles}>
           <Main />
           <NextScript />
-          {process.env.NODE_ENV === 'production' && <GoogleAnalytics />}
+          {process.env.GA_TRACKING_ID !== undefined && <GoogleAnalytics />}
         </body>
       </Html>
     )

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,69 @@
+export default function GoogleAnalytics() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+   var disableStr = "ga-disable-${process.env.GA_TRACKING_ID}";
+   if (document.cookie.indexOf(disableStr + "=true") > -1) {
+     window[disableStr] = true;
+   }
+   function gaOptout() {
+     document.cookie =
+       disableStr + "=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/";
+     window[disableStr] = true;
+   }
+   (function (i, s, o, g, r, a, m) {
+       i["GoogleAnalyticsObject"] = r;
+       (i[r] =
+         i[r] ||
+         function () {
+           (i[r].q = i[r].q || []).push(arguments);
+         }),
+         (i[r].l = 1 * new Date());
+       (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+       a.async = 1;
+       a.src = g;
+       m.parentNode.insertBefore(a, m);
+     })(window, document, "script", "//www.google-analytics.com/analytics.js", "ga");
+   ga("create", "${process.env.GA_TRACKING_ID}", "auto");
+   ga("require", "displayfeatures");
+   ga("require", "linkid", "linkid.js");
+   ga("set", "anonymizeIp", true);
+   ga('set', 'dimension1', 'redesign');
+   ga("send", "pageview");
+   var visitTookTime = false;
+   var didScroll = false;
+   var bounceSent = false;
+   var scrollCount = 0;
+   function testScroll() {
+     ++scrollCount;
+     if (scrollCount == 2) {
+       didScroll = true;
+     }
+     sendNoBounce();
+   }
+   function timeElapsed() {
+     visitTookTime = true;
+     sendNoBounce();
+   }
+   function sendNoBounce() {
+     if (didScroll && visitTookTime && !bounceSent) {
+       bounceSent = true;
+       ga(
+         "send",
+         "event",
+         "no bounce",
+         "resist",
+         "User scrolled and spent 30 seconds on page."
+       );
+     }
+   }
+   setTimeout("timeElapsed()", 3e4);
+   window.addEventListener
+     ? window.addEventListener("scroll", testScroll, false)
+     : window.attachEvent("onScroll", testScroll);
+`
+      }}
+    />
+  )
+}


### PR DESCRIPTION
Working now. Basically the same implementation we currently use.
Closes #77.

I added a custom dimension "redesign" that should help us differentiate traffic from the new frontend.
Atm. it's not tracking into the main Serlo.org analytics project while we are still debugging. 

Just tracks on pageload. If we switch to routing at any point we need to add code for that.


Backlog: Easiest way for nextjs would be this plugin, that is not stable atm
https://github.com/zeit/next.js/tree/canary/packages/next-plugin-google-analytics
