### PR TITLE
Search rework

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -50,6 +50,12 @@ export default class MyDocument extends Document {
         <Head>
           <meta property="og:site_name" content="Serlo" />
           <meta property="og:type" content="website" />
+          <link
+            href="/opensearch.de.xml"
+            rel="search"
+            type="application/opensearchdescription+xml"
+            title="Serlo (de)"
+          />
         </Head>
         <body style={bodyStyles}>
           <Main />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Landing() {
   return (
     <>
       <Head>
-        <title>Serlo - Die freie Lernplattform</title>
+        <title>Serlo.org - Die freie Lernplattform</title>
       </Head>
       <Header />
       <SubjectsSection>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styled from 'styled-components'
+import Head from 'next/head'
+import Header from '../src/components/navigation/Header'
+import SearchResults from '../src/components/navigation/SearchResults'
+import CookieBar from '../src/components/content/CookieBar'
+import Footer from '../src/components/navigation/Footer'
+
+export default function SearchPage() {
+  return (
+    <>
+      <Head>
+        <title>Serlo.org - Suche</title>
+      </Head>
+      <Header />
+      <StyledSearchResults>
+        <div className="gcse-searchresults"></div>
+      </StyledSearchResults>
+      <Footer />
+      <CookieBar />
+    </>
+  )
+}
+
+const StyledSearchResults = styled(SearchResults)`
+  padding: 50px 0;
+`

--- a/pages/spenden.tsx
+++ b/pages/spenden.tsx
@@ -29,7 +29,7 @@ const footerEntries = [
   }
 ]
 
-export default function Landing() {
+export default function DonationPage() {
   const twingleID = '0001'
 
   React.useEffect(() => {

--- a/public/opensearch.de.xml
+++ b/public/opensearch.de.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Serlo (de)</ShortName>
+<Description>Serlo.org – Die freie Lernplattform</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<Image width="16" height="16" type="image/x-icon">https://de.serlo.org/favicon.ico</Image>
+<Url type="text/html" method="get" template="https://de.serlo.org/search?q={searchTerms}"/>
+<moz:SearchForm>https://de.serlo.org/search</moz:SearchForm>
+</OpenSearchDescription>

--- a/src/components/navigation/SearchInput.tsx
+++ b/src/components/navigation/SearchInput.tsx
@@ -77,8 +77,8 @@ export default function SearchInput() {
         <div
           className={isSearchPage ? 'gcse-searchbox' : 'gcse-searchbox-only'}
           data-autocompletemaxcompletions="7"
-          data-resultsUrl="/search"
-          data-enableHistory="true"
+          data-resultsurl="/search"
+          data-enablehistory="true"
         ></div>
       </SearchForm>
 

--- a/src/components/navigation/SearchInput.tsx
+++ b/src/components/navigation/SearchInput.tsx
@@ -3,11 +3,9 @@ import styled, { createGlobalStyle, css } from 'styled-components'
 import { lighten } from 'polished'
 import { inputFontReset } from '../../helper/csshelper'
 import SearchIcon from '../../../public/_assets/img/search-icon.svg'
-import SearchResults from './SearchResults'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { theme } from '../../theme'
-import Modal from '../Modal'
 
 /*
 This components starts with only a placeholder that looks like a searchbar (basically a button).

--- a/src/components/navigation/SearchInput.tsx
+++ b/src/components/navigation/SearchInput.tsx
@@ -7,18 +7,27 @@ import SearchResults from './SearchResults'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { theme } from '../../theme'
+import Modal from '../Modal'
 
 /*
 This components starts with only a placeholder that looks like a searchbar (basically a button).
 When activated (by click) it loads the Google Custom Search scrips that generate the real input button and alot of markup.
 We style this markup and use it to silenty replace the placeholder.
-From this point on it's a styled GSC that displays the results in an overlay.
+From this point on it's a styled GSC that loads /search to display the results.
 It's a bit hacky, but it's free and works quite well.
 */
 
 export default function SearchInput() {
   const [searchLoaded, setSearchLoaded] = React.useState(false)
   const [searchActive, setSearchActive] = React.useState(false)
+  const [isSearchPage, setIsSearchPage] = React.useState(false)
+
+  React.useEffect(() => {
+    if (window.location.pathname === '/search') {
+      setIsSearchPage(true)
+      activateSearch()
+    }
+  }, [])
 
   const checkElement = async selector => {
     while (document.querySelector(selector) === null) {
@@ -31,7 +40,8 @@ export default function SearchInput() {
     if (searchActive) return
 
     if (!searchLoaded) {
-      const cx = '016022363195733463411:78jhtkzhbhc'
+      // const cx = '016022363195733463411:78jhtkzhbhc'
+      const cx = '017461339636837994840:ifahsiurxu4' //"old version" with better autocomplete
       const gcse = document.createElement('script')
       gcse.type = 'text/javascript'
       gcse.async = true
@@ -43,13 +53,7 @@ export default function SearchInput() {
     }
 
     checkElement('#gsc-i-id1').then(input => {
-      // const placeholder = input.getAttribute('placeholder') stopped working
-      const placeholder = 'Custom Search'
       input.setAttribute('placeholder', 'Suche')
-      document
-        .querySelector('#___gcse_1 .gsc-results-wrapper-overlay')
-        .setAttribute('data-customsearch', placeholder)
-
       input.focus()
       setSearchActive(true)
     })
@@ -71,16 +75,14 @@ export default function SearchInput() {
           </>
         )}
         <div
-          className="gcse-searchbox"
-          data-autocompletemaxcompletions="5"
+          className={isSearchPage ? 'gcse-searchbox' : 'gcse-searchbox-only'}
+          data-autocompletemaxcompletions="7"
+          data-resultsUrl="/search"
+          data-enableHistory="true"
         ></div>
       </SearchForm>
 
       <AutocompleteStyle />
-
-      <SearchResults>
-        <div className="gcse-searchresults"></div>
-      </SearchResults>
     </>
   )
 }
@@ -117,6 +119,7 @@ const sharedButtonStyles = css`
   transition: background-color 0.2s ease-in;
   text-align: center;
   pointer-events: none;
+  cursor: pointer;
 
   @media (min-width: ${props => props.theme.breakpoints.sm}) {
     border-radius: 5rem;
@@ -259,7 +262,7 @@ const SearchForm = styled.div`
     top: 133px;
     right: 32px;
     height: ${smHeightPx};
-    width: 200px;
+    width: 300px;
     background-color: transparent;
     border-radius: 18px;
     transition: all 0.4s ease;

--- a/src/components/navigation/SearchResults.tsx
+++ b/src/components/navigation/SearchResults.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { inputFontReset } from '../../helper/csshelper'
 
 export default function SearchResults(props) {
-  return <SearchResultsWrap>{props.children}</SearchResultsWrap>
+  return <SearchResultsWrap {...props}>{props.children}</SearchResultsWrap>
 }
 
 const SearchResultsWrap = styled.div`
@@ -41,7 +41,8 @@ const SearchResultsWrap = styled.div`
     margin: 0 auto;
 
     .gsc-results-wrapper-visible::before {
-      content: attr(data-customsearch);
+      /* content: attr(data-customsearch); */
+      content: 'Custom Search';
       font-weight: bold;
       display: block;
       color: ${props => props.theme.colors.brand};


### PR DESCRIPTION
- add standalone search page and opensearch (closes #88)
- submitting a search now redirects to `/search` 
- add full history support (closes #240)
- make it work with old gcs code where autocomplete suggestions are way better probably because they get better with use (closes #153)

Test here:
https://frontend-git-single-search-page.serlo.now.sh/