### PR TITLE
CSR and search

### DIFF
--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -24,13 +24,13 @@ It's a bit hacky, but it's free and works quite well.
 export function SearchInput({ onSearchPage }: SearchInputProps) {
   const [searchLoaded, setSearchLoaded] = React.useState(false)
   const [searchActive, setSearchActive] = React.useState(false)
-  const [isSearchPage, setIsSearchPage] = React.useState(false)
+  // const [isSearchPage, setIsSearchPage] = React.useState(false)
   const { strings } = useInstanceData()
 
   React.useEffect(() => {
     // note: find a better way to tell search input that it should activate itself
     if (onSearchPage) {
-      setIsSearchPage(true)
+      // setIsSearchPage(true)
       activateSearch()
     }
     // I only want to run this the first time the page loads
@@ -65,6 +65,32 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
       input.setAttribute('placeholder', strings.header.search)
       input.focus()
       setSearchActive(true)
+
+      const script = document.createElement('script')
+      script.innerHTML = `
+    var resultsContainer = document.getElementById('gcs-results');
+    setupLinkCatcher(resultsContainer);
+
+    function setupLinkCatcher(container){
+      if(!container || container === undefined) return;
+      var className = 'gs-title';
+      
+      document.addEventListener('click', function (e) {
+        
+        var link = null;
+        if( e.target.parentElement.classList.contains(className) ) link = e.target.parentElement;
+        if( e.target.classList.contains(className) ) link = e.target;
+
+        if(link){
+          e.preventDefault();
+          next.router.push('/[[...slug]]', link.dataset.ctorig.replace('https://de.serlo.org','')).then(() => window.scrollTo(0, 0))
+        }
+        
+      }, false);
+    }
+    
+    `
+      document.body.appendChild(script)
     })
   }
 
@@ -84,7 +110,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
           </>
         )}
         <div
-          className={isSearchPage ? 'gcse-searchbox' : 'gcse-searchbox-only'}
+          className="gcse-searchbox-only"
           data-autocompletemaxcompletions="7"
           data-resultsurl="/search"
           data-enablehistory="true"

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -75,7 +75,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
       if(!container || container === undefined) return;
       var className = 'gs-title';
       
-      document.addEventListener('click', function (e) {
+      container.addEventListener('click', function (e) {
         
         var link = null;
         if( e.target.parentElement.classList.contains(className) ) link = e.target.parentElement;

--- a/src/components/navigation/search-results.tsx
+++ b/src/components/navigation/search-results.tsx
@@ -77,6 +77,8 @@ export const SearchResults = styled.div`
     &,
     .gsc-table-result {
       font-size: 1rem;
+      ${inputFontReset}
+      line-height: 1.33rem;
     }
   }
 

--- a/src/components/pages/search.tsx
+++ b/src/components/pages/search.tsx
@@ -7,11 +7,32 @@ import { useInstanceData } from '@/contexts/instance-context'
 
 export function Search() {
   const { strings } = useInstanceData()
+
+  const renderResults = () => {
+    // @ts-expect-error probably need a helper like in get-initial-props
+    if (typeof window.google === 'undefined') {
+      setTimeout(() => {
+        renderResults()
+      }, 100)
+      return false
+    }
+
+    // @ts-expect-error probably need a helper like in get-initial-props
+    window.google.search.cse.element.render({
+      div: 'gcs-results',
+      tag: 'searchresults-only',
+    })
+  }
+
+  React.useEffect(() => {
+    renderResults()
+  })
+
   return (
     <>
       <HeadTags data={{ title: `Serlo.org - ${strings.header.search}` }} />
       <StyledSearchResults>
-        <div className="gcse-searchresults"></div>
+        <div id="gcs-results"></div>
       </StyledSearchResults>
     </>
   )


### PR DESCRIPTION
As expected the hackiest component get's some hacky fixes.

We had some problems with the search since we moved to client side routing. 
This PR addresses them (fixes #350) and also fixes history-navigation for search (mostly).

Also now the links in the search results use CSR as well (#351) and opens the results in the current environment (-> stays on localhost instead of navigating to de.serlo.org).


(downside: seems a bit slower, and there are more white flashes, but it's worth it I'd say :) )