### PR TITLE
add swr cache header

### DIFF
--- a/src/fetcher/get-initial-props.ts
+++ b/src/fetcher/get-initial-props.ts
@@ -67,6 +67,8 @@ export async function getInitialProps(
       }
     }
 
+    props.res!.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate')
+
     return buildInitialProps(fetchedData, origin)
   } else {
     //client


### PR DESCRIPTION
Allow the html response to be cache with stale-while-revalidate, fixes #383

I'm seeing no downsides here.