### PR TITLE
Auth: refresh access tokens

### DIFF
--- a/src/auth/oauth2.ts
+++ b/src/auth/oauth2.ts
@@ -4,6 +4,7 @@ import {
   AuthorizationCode,
   OAuthClient,
   Token,
+  AccessToken,
 } from 'simple-oauth2'
 
 const HYDRA_HOST =
@@ -41,6 +42,8 @@ const config =
         },
       }
 
+export const scope = ['offline_access', 'openid']
+
 export function getAuthorizationCode():
   | OAuthClient['authorizationCode']
   | null {
@@ -50,7 +53,7 @@ export function getAuthorizationCode():
 }
 
 export function getClientCredentials(): {
-  createToken(token: Token): Token
+  createToken(token: Token): AccessToken
 } | null {
   if (config === null) return null
   return new ClientCredentials(config)

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 import { NextApiRequest, NextApiResponse } from 'next'
 import * as util from 'util'
 
-import { getAuthorizationCode } from '@/auth/oauth2'
+import { getAuthorizationCode, scope } from '@/auth/oauth2'
 
 const generateSecret = util.promisify(randomBytes)
 
@@ -19,7 +19,7 @@ async function login(req: NextApiRequest, res: NextApiResponse) {
   const csrf = await generateCsrf()
   const authorizationUri = oauth2AuthorizationCode.authorizeURL({
     redirect_uri: `${origin}/api/auth/callback`,
-    scope: ['offline_access', 'openid'],
+    scope,
     state: JSON.stringify({
       csrf,
       referer,

--- a/src/pages/api/auth/refresh-token.ts
+++ b/src/pages/api/auth/refresh-token.ts
@@ -1,0 +1,52 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import {
+  getAuthorizationCode,
+  getClientCredentials,
+  scope,
+} from '@/auth/oauth2'
+
+async function refreshToken(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405)
+    res.end()
+    return
+  }
+
+  const oauth2ClientCredentials = getClientCredentials()
+  const oauth2AuthorizationCode = getAuthorizationCode()
+
+  if (oauth2ClientCredentials === null || oauth2AuthorizationCode === null) {
+    return fail('Auth not configured correctly')
+  }
+
+  try {
+    const accessToken = oauth2ClientCredentials.createToken(
+      JSON.parse(req.cookies['auth-token'])
+    )
+    const token = await accessToken.refresh({
+      scope,
+    })
+    res.setHeader(
+      'Set-Cookie',
+      `auth-token=${JSON.stringify(
+        token.token
+      )}; Path=/; SameSite=Lax; Max-Age=2592000;`
+    )
+    res.end()
+  } catch (e) {
+    console.log(e)
+    res.setHeader(
+      'Set-Cookie',
+      `auth-token=; Path=/; Expires=${new Date(0).toUTCString()};`
+    )
+    fail('Token not valid')
+  }
+
+  function fail(message: string) {
+    res.status(500)
+    res.send(message)
+  }
+}
+
+export default refreshToken


### PR DESCRIPTION
First PR of an upcoming sequence of PRs to implement notifications.

Adds POST route `/api/auth/refresh-token` that tries to refresh the token. Its intended to be used when an API request fails with an authentication error. Gonna add a helper for that in an upcoming PR.