### PR TITLE
API v0.8.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.0.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
     "@sentry/browser": "^5.15.4",
+    "@serlo/api": "^0.8.0",
     "@tippyjs/react": "^4.0.0-alpha.0",
     "@types/jwt-decode": "^2.0.0",
     "@types/nprogress": "^0.2.0",

--- a/src/auth/oauth2.ts
+++ b/src/auth/oauth2.ts
@@ -1,4 +1,5 @@
 import {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error outdated types
   ClientCredentials,
   AuthorizationCode,
@@ -46,6 +47,7 @@ export const scope = ['offline_access', 'openid']
 
 export function getAuthorizationCode() {
   if (config === null) return null
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error outdated types
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   return new AuthorizationCode(config) as OAuthClient['authorizationCode']

--- a/src/components/navigation/breadcrumbs.tsx
+++ b/src/components/navigation/breadcrumbs.tsx
@@ -4,9 +4,9 @@ import { transparentize } from 'polished'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
-import { makeDefaultButton, makeMargin } from '../../helper/css'
 import { Link } from '../content/link'
 import { BreadcrumbsData, BreadcrumbEntry } from '@/data-types'
+import { makeDefaultButton, makeMargin } from '@/helper/css'
 
 export interface BreadcrumbsProps {
   data: BreadcrumbsData
@@ -28,7 +28,7 @@ export function Breadcrumbs({ data, isTaxonomy }: BreadcrumbsProps) {
             arrayLength={completeArray.length}
             key={i}
             isTaxonomy={isTaxonomy}
-          ></BreadcrumbEntries>
+          />
         )
       })}
     </BreadcrumbWrapper>
@@ -52,11 +52,18 @@ function BreadcrumbEntries({
     return <BreadcrumbLink as="span">…</BreadcrumbLink>
   } else {
     if (arrayLength !== i + 1) {
-      return <BreadcrumbLink href={bcEntry.url}>{bcEntry.label}</BreadcrumbLink>
+      return (
+        <BreadcrumbLink href={bcEntry.url ?? undefined}>
+          {bcEntry.label}
+        </BreadcrumbLink>
+      )
     } else
       return (
         <>
-          <BreadcrumbLinkLast href={bcEntry.url} isTaxonomy={isTaxonomy}>
+          <BreadcrumbLinkLast
+            href={bcEntry.url ?? undefined}
+            isTaxonomy={isTaxonomy}
+          >
             <MobileIcon>
               <FontAwesomeIcon icon={faArrowCircleLeft} size="1x" />
             </MobileIcon>
@@ -73,7 +80,7 @@ function BreadcrumbEntries({
 }
 
 const BreadcrumbWrapper = styled.nav`
-  ${makeMargin}
+  ${makeMargin};
   margin-top: 25px;
 
   @media (min-width: ${(props) => props.theme.breakpoints.sm}) {
@@ -85,7 +92,7 @@ const BreadcrumbLink = styled(Link)`
   display: inline-block;
   color: ${(props) => props.theme.colors.brand};
 
-  ${makeDefaultButton}
+  ${makeDefaultButton};
   padding-top: 2px;
   padding-bottom: 2px;
 
@@ -129,7 +136,7 @@ const BreadcrumbLinkLast = styled(BreadcrumbLink)<{ isTaxonomy: boolean }>`
     css`
       background: ${(props) => props.theme.colors.bluewhite};
       font-weight: bold;
-    `}
+    `};
 
   color: ${(props) => props.theme.colors.brand};
 

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -172,8 +172,8 @@ export type BreadcrumbEntry = BreadcrumbLinkEntry | BreadcrumbEllipsis
 
 export interface BreadcrumbLinkEntry {
   label: string
-  url?: string
-  ellipsis?: boolean | false
+  url?: string | null
+  ellipsis?: boolean
 }
 
 export interface BreadcrumbEllipsis extends BreadcrumbLinkEntry {

--- a/src/fetcher/create-breadcrumbs.tsx
+++ b/src/fetcher/create-breadcrumbs.tsx
@@ -27,6 +27,7 @@ export function createBreadcrumbs(uuid: QueryResponse) {
     let breadcrumbs
 
     for (const child of taxonomyPaths) {
+      if (!child.navigation) continue
       const { path } = child.navigation
       if (!breadcrumbs || breadcrumbs.length > path.length) {
         // compat: some paths are short-circuited, ignore them

--- a/src/fetcher/create-navigation.tsx
+++ b/src/fetcher/create-navigation.tsx
@@ -3,7 +3,7 @@ import { SecondaryNavigationData, SecondaryNavigationEntry } from '@/data-types'
 
 interface NavigationData {
   label: string
-  id: number
+  id?: number
   url?: string
   children?: NavigationData[]
 }
@@ -21,17 +21,13 @@ export function createNavigation(
     return undefined
   }
   if (uuid.navigation?.data) {
-    try {
-      const data = JSON.parse(uuid.navigation.data) as NavigationData
-      return data.children?.flatMap((child) => {
-        if (child.children) {
-          return child.children.map(convertEntry)
-        }
-        return convertEntry(child)
-      })
-    } catch (e) {
-      // ignore
-    }
+    const data = uuid.navigation?.data as NavigationData
+    return data.children?.flatMap((child) => {
+      if (child.children) {
+        return child.children.map(convertEntry)
+      }
+      return convertEntry(child)
+    })
   }
 
   function convertEntry(entry: NavigationData): SecondaryNavigationEntry {

--- a/src/fetcher/create-taxonomy.ts
+++ b/src/fetcher/create-taxonomy.ts
@@ -68,7 +68,7 @@ function collectType(
   return result
 }
 
-function getAlias(child: { alias?: string; id: number }) {
+function getAlias(child: { alias?: string | null; id: number }) {
   if (!child.alias || hasSpecialUrlChars(child.alias)) return `/${child.id}`
   else return child.alias
 }

--- a/src/fetcher/fetch-page-data.ts
+++ b/src/fetcher/fetch-page-data.ts
@@ -39,13 +39,20 @@ export async function fetchPageData(raw_alias: string): Promise<PageData> {
 }
 
 async function apiRequest(alias: string, instance: string): Promise<PageData> {
-  const QUERY = dataQuery(
+  const { uuid } = await request<{ uuid: QueryResponse }>(
+    endpoint,
+    dataQuery,
     /^\/[\d]+$/.test(alias)
-      ? 'id: ' + alias.substring(1)
-      : `alias: { instance: ${instance}, path: "${alias}"}`
+      ? {
+          id: parseInt(alias.substring(1), 10),
+        }
+      : {
+          alias: {
+            instance,
+            path: alias,
+          },
+        }
   )
-
-  const { uuid } = await request<{ uuid: QueryResponse }>(endpoint, QUERY)
 
   if (uuid.__typename === 'Course') {
     const firstPage = uuid.pages[0]?.alias

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -1,3 +1,6 @@
+// These types are auto-generated from the GraphQL schema
+import * as GraphQL from '@serlo/api'
+
 // Keep this file in sync with the graphQL schema.
 // Maybe automate this one day.
 
@@ -13,11 +16,7 @@ const license = `
   }
 `
 
-export interface License {
-  id: number
-  url: string
-  title: string
-}
+export type License = Pick<GraphQL.License, 'id' | 'url' | 'title'>
 
 // This is one breadcrumb path.
 
@@ -28,10 +27,7 @@ const path = `
   }
 `
 
-export type Path = {
-  label: string
-  url?: string
-}[]
+export type Path = Pick<GraphQL.NavigationNode, 'label' | 'url'>[]
 
 // Entities can belong to multiple taxonomy terms, so we load all possible paths.
 
@@ -44,17 +40,16 @@ const taxonomyTerms = `
 `
 
 export type TaxonomyTerms = {
-  navigation: {
-    path: Path
-  }
+  navigation?: GraphQL.Maybe<{ path: Path }>
 }[]
 
 // Basic information about any entity.
-
-interface Entity {
-  id: number
-  alias?: string
-  instance: string
+type Repository = Pick<GraphQL.AbstractRepository, 'id' | 'alias' | 'instance'>
+export interface Entity extends Repository {
+  license: License
+}
+export interface EntityWithTaxonomyTerms extends Entity {
+  taxonomyTerms: TaxonomyTerms
 }
 
 // A page, navigation.data is the secondary menu.
@@ -75,16 +70,12 @@ const onPage = `
   }
 `
 
-export interface Page extends Entity {
+export interface Page extends Repository {
   __typename: 'Page'
-  currentRevision?: {
-    title: string
-    content: string
-  }
-  navigation?: {
-    data: string
-    path: Path
-  }
+  currentRevision?: GraphQL.Maybe<
+    Pick<GraphQL.PageRevision, 'title' | 'content'>
+  >
+  navigation?: GraphQL.Maybe<Pick<GraphQL.Navigation, 'data' | 'path'>>
 }
 
 const onArticle = `
@@ -103,16 +94,14 @@ const onArticle = `
   }
 `
 
-export interface Article extends Entity {
+export interface Article extends EntityWithTaxonomyTerms {
   __typename: 'Article'
-  currentRevision?: {
-    title: string
-    content: string
-    metaTitle: string
-    metaDescription: string
-  }
-  taxonomyTerms: TaxonomyTerms
-  license: License
+  currentRevision?: GraphQL.Maybe<
+    Pick<
+      GraphQL.ArticleRevision,
+      'title' | 'content' | 'metaTitle' | 'metaDescription'
+    >
+  >
 }
 
 const onVideo = `
@@ -130,15 +119,11 @@ const onVideo = `
   }
 `
 
-export interface Video extends Entity {
+export interface Video extends EntityWithTaxonomyTerms {
   __typename: 'Video'
-  currentRevision?: {
-    title: string
-    url: string
-    content: string
-  }
-  taxonomyTerms: TaxonomyTerms
-  license: License
+  currentRevision?: GraphQL.Maybe<
+    Pick<GraphQL.VideoRevision, 'title' | 'url' | 'content'>
+  >
 }
 
 const onApplet = `
@@ -158,17 +143,14 @@ const onApplet = `
   }
 `
 
-export interface Applet extends Entity {
+export interface Applet extends EntityWithTaxonomyTerms {
   __typename: 'Applet'
-  currentRevision?: {
-    title: string
-    content: string
-    url: string
-    metaTitle: string
-    metaDescription: string
-  }
-  taxonomyTerms: TaxonomyTerms
-  license: License
+  currentRevision?: GraphQL.Maybe<
+    Pick<
+      GraphQL.AppletRevision,
+      'title' | 'content' | 'url' | 'metaTitle' | 'metaDescription'
+    >
+  >
 }
 
 const onCoursePage = `
@@ -199,24 +181,18 @@ const onCoursePage = `
 
 export interface CoursePage extends Entity {
   __typename: 'CoursePage'
-  currentRevision?: {
-    content: string
-    title: string
-  }
+  currentRevision?: GraphQL.Maybe<
+    Pick<GraphQL.CoursePageRevision, 'content' | 'title'>
+  >
   course: {
-    currentRevision?: {
-      title: string
-    }
+    currentRevision?: GraphQL.Maybe<Pick<GraphQL.CourseRevision, 'title'>>
     pages: {
       alias?: string
       id: number
-      currentRevision?: {
-        title: string
-      }
+      currentRevision?: Pick<GraphQL.CoursePageRevision, 'title'>
     }[]
     taxonomyTerms: TaxonomyTerms
   }
-  license: License
 }
 
 // We treat a grouped exercise just as a normal exercise.
@@ -235,49 +211,34 @@ const bareExercise = `
 `
 
 export interface BareExercise {
-  currentRevision?: {
-    content: string
-  }
+  currentRevision?: GraphQL.Maybe<
+    Pick<GraphQL.AbstractExerciseRevision, 'content'>
+  >
   solution?: {
-    currentRevision?: {
-      content: string
-    }
+    currentRevision?: GraphQL.Maybe<Pick<GraphQL.SolutionRevision, 'content'>>
     license: License
   }
   license: License
 }
 
 const onExercise = `
-  ... on Exercise {
+  ... on AbstractExercise {
     id
     alias
     instance
     ${bareExercise}
-    ${taxonomyTerms}
   }
-
-  ... on GroupedExercise {
-    id
-    alias
-    instance
-    ${bareExercise}
+  ... on Exercise {
+    ${taxonomyTerms}
   }
 `
 
-export interface Exercise extends Entity, BareExercise {
+export interface Exercise extends EntityWithTaxonomyTerms, BareExercise {
   __typename: 'Exercise'
   taxonomyTerms: TaxonomyTerms
-  license: License
 }
 export interface GroupedExercise extends Entity, BareExercise {
   __typename: 'GroupedExercise'
-  license: License
-}
-
-export interface ExerciseMaybeGrouped extends Entity, BareExercise {
-  __typename: 'Exercise' | 'GroupedExercise'
-  taxonomyTerms: TaxonomyTerms
-  license: License
 }
 
 const onExerciseGroup = `
@@ -295,18 +256,16 @@ const onExerciseGroup = `
     ${license}
   }
 `
-export interface BareExerciseGroup {
+
+export interface BareExerciseGroup extends Entity {
   __typename: 'ExerciseGroup'
-  currentRevision?: {
-    content: string
-  }
+  currentRevision?: GraphQL.Maybe<
+    Pick<GraphQL.ExerciseGroupRevision, 'content'>
+  >
   exercises: BareExercise[]
-  license: License
 }
 
-export interface ExerciseGroup extends BareExerciseGroup, Entity {
-  taxonomyTerms: TaxonomyTerms
-}
+export type ExerciseGroup = BareExerciseGroup & EntityWithTaxonomyTerms
 
 // Events are only used in injections, no support for full page view
 
@@ -321,14 +280,12 @@ const onEvent = `
   }
 `
 
-export interface Event extends Entity {
+export interface Event extends Repository {
   __typename: 'Event'
-  currentRevision?: {
-    content: string
-  }
+  currentRevision?: GraphQL.Maybe<Pick<GraphQL.EventRevision, 'content'>>
 }
 
-// If a course is encoutered, the first page will get loaded
+// If a course is encountered, the first page will get loaded
 
 const onCourse = `
   ... on Course {
@@ -341,29 +298,16 @@ const onCourse = `
   }
 `
 
-export interface Course extends Entity {
+export interface Course extends Repository {
   __typename: 'Course'
   pages: {
     alias?: string
   }[]
 }
 
-// This one is a beast!
+export type TaxonomyTermType = GraphQL.TaxonomyTermType
 
-export type TaxonomyTermType =
-  | 'blog'
-  | 'curriculum'
-  | 'curriculumTopic'
-  | 'curriculumTopicFolder'
-  | 'forum'
-  | 'forumCategory'
-  | 'locale'
-  | 'root'
-  | 'subject'
-  | 'topic'
-  | 'topicFolder'
-
-const onX = (type: string) => `
+const onX = (type: TaxonomyTermChildOnX['__typename']) => `
   ... on ${type} {
     alias
     id
@@ -454,34 +398,28 @@ export interface TaxonomyTermChildExerciseGroup
   __typename: 'ExerciseGroup'
 }
 
-export interface TaxonomyTermChildTaxonomyTerm extends TaxonomyTermChild {
+export interface TaxonomyTermChildTaxonomyTerm
+  extends TaxonomyTermChild,
+    Pick<
+      GraphQL.TaxonomyTerm,
+      'type' | 'name' | 'alias' | 'id' | 'description'
+    > {
   __typename: 'TaxonomyTerm'
-  type: TaxonomyTermType
-  name: string
-  alias?: string
-  id: number
-  description?: string
   children: TaxonomyTermChildrenLevel2[]
 }
 
-export interface SubTaxonomyTermChildTaxonomyTerm extends TaxonomyTermChild {
+export interface SubTaxonomyTermChildTaxonomyTerm
+  extends TaxonomyTermChild,
+    Pick<GraphQL.TaxonomyTerm, 'type' | 'alias' | 'id' | 'name'> {
   __typename: 'TaxonomyTerm'
-  id: number
-  alias?: string
-  type: TaxonomyTermType
-  name: string
   children?: undefined
 }
 
-export interface TaxonomyTerm extends Entity {
+export interface TaxonomyTerm
+  extends Repository,
+    Pick<GraphQL.TaxonomyTerm, 'type' | 'name' | 'description'> {
   __typename: 'TaxonomyTerm'
-  type: TaxonomyTermType
-  name: string
-  description?: string
-  navigation: {
-    data: string
-    path: Path
-  }
+  navigation?: GraphQL.Maybe<Pick<GraphQL.Navigation, 'data' | 'path'>>
   children: TaxonomyTermChildrenLevel1[]
 }
 
@@ -495,9 +433,9 @@ export type TaxonomyTermChildrenLevel2 =
   | TaxonomyTermChildOnX
   | SubTaxonomyTermChildTaxonomyTerm
 
-export const dataQuery = (selector: string) => `
-  {
-    uuid(${selector}) {
+export const dataQuery = `
+  query uuid($id: Int, $alias: AliasInput) {
+    uuid(id: $id, alias: $alias) {
       __typename
 
       ${onPage}
@@ -536,27 +474,11 @@ export type QueryResponse =
   | Course
   | TaxonomyTerm
 
-export type QueryResponseWithLicense =
-  | Article
-  | Video
-  | Applet
-  | CoursePage
-  | Exercise
-  | GroupedExercise
-  | ExerciseGroup
-
-export type QueryResponseWithTaxonomyTerms =
-  | Article
-  | Video
-  | Applet
-  | Exercise
-  | ExerciseGroup
-
 export const idsQuery = (ids: number[]) => {
   const map = ids.map(
     (id) => `
     uuid${id}: uuid(id:${id}) {
-        ... on Entity {
+        ... on AbstractEntity {
           alias
           instance
         }
@@ -578,7 +500,7 @@ export const idsQuery = (ids: number[]) => {
 export const idQuery = (id: number) => `
   {
     uuid(id:${id}) {
-      ... on Entity {
+      ... on AbstractEntity {
         alias
       }
       ... on Page {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,11 @@
     "@sentry/types" "5.19.2"
     tslib "^1.9.3"
 
+"@serlo/api@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@serlo/api/-/api-0.8.0.tgz#cc49c4a46adae4ba6519eef5ad1cb7b6da4cbc2d"
+  integrity sha512-3JhYTusE0MVUoak8dk84SMJ5bKhe6aagCzVR1Z8o9QD/o4IHhlJA/mS+ppSNLG0gQZTi1vBJuQS3tE2ubvH/+w==
+
 "@styled-system/background@^5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@styled-system/background/-/background-5.1.2.tgz#75c63d06b497ab372b70186c0bf608d62847a2ba"


### PR DESCRIPTION
Contains the breaking changes that were introduced in API v0.7.0+ & v0.8.0+ so that we can deploy the new API to staging. Note: this will break notifications for now (which weren't used in production anyways), #445 enables them again.