### PR TITLE
Support license detail page

### DIFF
--- a/src/components/content/license-notice.tsx
+++ b/src/components/content/license-notice.tsx
@@ -8,7 +8,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styled from 'styled-components'
 
 import { makePadding, makeDefaultButton } from '../../helper/css'
-import { serloDomain } from '../../helper/serlo-domain'
 import { StyledA } from '../tags/styled-a'
 import { Link } from './link'
 import { useInstanceData } from '@/contexts/instance-context'
@@ -64,10 +63,7 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
             {licenseName}
           </StyledA>
           {' → '}
-          <Link
-            href={`https://de.${serloDomain}/license/detail/${data.id}`}
-            noExternalIcon
-          >
+          <Link href={`/license/detail/${data.id}`}>
             <b>{strings.license.readMore}</b>
           </Link>
         </StyledSmall>

--- a/src/components/pages/license-detail.tsx
+++ b/src/components/pages/license-detail.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+// import styled from 'styled-components'
+
+import { HSpace } from '@/components/content/h-space'
+import { StyledH2 } from '@/components/tags/styled-h2'
+import { StyledP } from '@/components/tags/styled-p'
+import { LicenseDetailData } from '@/data-types'
+import { renderArticle } from '@/schema/article-renderer'
+
+export function LicenseDetail({ title, content, iconHref }: LicenseDetailData) {
+  return (
+    <>
+      <HSpace amount={70} />
+      {/* <_StyledP>Was bedeutet das?</_StyledP> TODO: use i18n, not done now to avoid merge problems with other branches*/}
+      <StyledH2>{title}</StyledH2>
+      <HSpace amount={20} />
+      {renderArticle(content)}
+
+      {iconHref && (
+        <StyledP>
+          <img src={iconHref} alt="License Badge" />
+        </StyledP>
+      )}
+    </>
+  )
+}
+
+// const _StyledP = styled(StyledP)`
+//   font-size: 1.25rem;
+//   font-weight: bold;
+//   color: ${(props) => props.theme.colors.lightblue};
+//   margin-bottom: -15px;
+// `

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -90,6 +90,7 @@ export type PageData =
   | DonationPage
   | SearchPage
   | ErrorPage
+  | LicenseDetailPage
   | NotificationsPage
   | SingleEntityPage
   | TaxonomyPage
@@ -117,6 +118,7 @@ export interface DonationPage {
 export interface SearchPage {
   kind: 'search'
 }
+
 export interface NotificationsPage {
   kind: 'user/notifications'
 }
@@ -131,6 +133,19 @@ export interface ErrorPage {
 export interface ErrorData {
   code: number
   message?: string
+}
+
+// License detail page has some additional data
+
+export interface LicenseDetailPage extends EntityPageBase {
+  kind: 'license-detail'
+  licenseData: LicenseDetailData
+}
+
+export interface LicenseDetailData {
+  title: string
+  content: FrontendContentNode[]
+  iconHref: string
 }
 
 // There are several page elements that are common for entities:

--- a/src/fetcher/fetch-page-data.ts
+++ b/src/fetcher/fetch-page-data.ts
@@ -1,3 +1,4 @@
+import * as GraphQL from '@serlo/api'
 import { request } from 'graphql-request'
 
 import { render } from '../../external/legacy_render'
@@ -8,7 +9,7 @@ import { createNavigation } from './create-navigation'
 import { buildTaxonomyData } from './create-taxonomy'
 import { createTitle } from './create-title'
 import { prettifyLinks } from './prettify-links'
-import { dataQuery, QueryResponse } from './query'
+import { dataQuery, QueryResponse, licenseDetailsQuery } from './query'
 import { endpoint } from '@/api/endpoint'
 import { PageData, FrontendContentNode } from '@/data-types'
 import { horizonData } from '@/data/horizon_de'
@@ -24,6 +25,11 @@ export async function fetchPageData(raw_alias: string): Promise<PageData> {
     if (alias == '/') {
       return { kind: 'landing', landingData: getLandingData(instance) }
     }
+    if (alias.startsWith('/license/detail/')) {
+      const id = parseInt(alias.split('license/detail/')[1])
+      return await apiLicensePageRequest(id, instance)
+    }
+
     const pageData = await apiRequest(alias, instance)
     await prettifyLinks(pageData)
     return pageData
@@ -35,6 +41,32 @@ export async function fetchPageData(raw_alias: string): Promise<PageData> {
       ? 503
       : 500
     return { kind: 'error', errorData: { code, message } }
+  }
+}
+
+async function apiLicensePageRequest(
+  id: number,
+  instance: string
+): Promise<PageData> {
+  const { license } = await request<{ license: GraphQL.License }>(
+    endpoint,
+    licenseDetailsQuery(id)
+  )
+  const horizonData = instance == 'de' ? buildHorizonData() : undefined
+
+  return {
+    kind: 'license-detail',
+    licenseData: {
+      content: convertState(license.content),
+      title: license.title,
+      iconHref: license.iconHref,
+    },
+    newsletterPopup: false,
+    horizonData,
+    metaData: {
+      title: license.title,
+      contentType: 'page',
+    },
   }
 }
 

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -478,3 +478,13 @@ export const idQuery = (id: number) => `
     }
   }
 `
+
+export const licenseDetailsQuery = (id: number) => `
+  query {
+    license(id: ${id}) {
+      title
+      content
+      iconHref
+    }
+  }
+`

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -26,6 +26,7 @@ import {
   PageData,
   ErrorData,
   LoggedInData,
+  LicenseDetailData,
 } from '@/data-types'
 import {
   fetcherAdditionalData,
@@ -47,6 +48,9 @@ const Search = dynamic<{}>(() =>
 )
 const Donations = dynamic<{}>(() =>
   import('@/components/pages/donations').then((mod) => mod.Donations)
+)
+const LicenseDetail = dynamic<LicenseDetailData>(() =>
+  import('@/components/pages/license-detail').then((mod) => mod.LicenseDetail)
 )
 const ErrorPage = dynamic<ErrorData>(() =>
   import('@/components/pages/error-page').then((mod) => mod.ErrorPage)
@@ -197,6 +201,9 @@ function renderPage(page: PageData) {
                   )}
                   <main>
                     {(() => {
+                      if (page.kind === 'license-detail') {
+                        return <LicenseDetail {...page.licenseData} />
+                      }
                       if (page.kind === 'single-entity') {
                         return <Entity data={page.entityData} />
                       } /* taxonomy */ else {


### PR DESCRIPTION
closes #520, #518

if added, we could use the frontend to show /license/detail/* pages.


(this PR is based on #517)