### PR TITLE
Use dynamic import for TimeAgo languages

### DIFF
--- a/src/components/time-ago.tsx
+++ b/src/components/time-ago.tsx
@@ -1,24 +1,8 @@
-/* eslint-disable import/no-internal-modules */
+import React from 'react'
 import ReactTimeAgo from 'timeago-react'
 import * as timeago from 'timeago.js'
-import de from 'timeago.js/lib/lang/de'
-import es from 'timeago.js/lib/lang/es'
-import fr from 'timeago.js/lib/lang/fr'
-import hi from 'timeago.js/lib/lang/hi_IN'
-import ta from 'timeago.js/lib/lang/ta'
 
 import { useInstanceData } from '@/contexts/instance-context'
-import { Instance } from '@/fetcher/query'
-
-//TODO: dynamically import only the current language data?
-
-const languageFunctions = {
-  de: de,
-  es: es,
-  fr: fr,
-  hi: hi,
-  ta: ta,
-}
 
 interface TimeAgoProps {
   datetime: timeago.TDate
@@ -33,10 +17,22 @@ export function TimeAgo({
   className,
   dateAsTitle,
 }: TimeAgoProps) {
+  const [languageLoaded, setLanguageLoaded] = React.useState(false)
   const { lang } = useInstanceData()
 
-  // @ts-expect-error
-  if (lang !== 'en') timeago.register(lang, languageFunctions[lang as Instance])
+  if (lang !== 'en') {
+    void import(
+      /* webpackInclude: /de\.js$|en\.js$|es\.js$|fr\.js$|hi\.js$|ta\.js$/ */
+      `timeago.js/lib/lang/${lang}`
+    ).then((module) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      timeago.register(lang, module.default)
+      setLanguageLoaded(true)
+    })
+  }
+
+  if (!languageLoaded && lang !== 'en')
+    return <>datetime.toLocaleString(lang)</>
 
   return (
     <span title={dateAsTitle ? datetime.toLocaleString(lang) : undefined}>

--- a/src/components/time-ago.tsx
+++ b/src/components/time-ago.tsx
@@ -3,6 +3,7 @@ import ReactTimeAgo from 'timeago-react'
 import * as timeago from 'timeago.js'
 
 import { useInstanceData } from '@/contexts/instance-context'
+import { getTimeAgoLang } from '@/helper/feature-i18n'
 
 interface TimeAgoProps {
   datetime: timeago.TDate
@@ -21,14 +22,14 @@ export function TimeAgo({
   const { lang } = useInstanceData()
 
   if (lang !== 'en') {
-    void import(
-      /* webpackInclude: /de\.js$|en\.js$|es\.js$|fr\.js$|hi\.js$|ta\.js$/ */
-      `timeago.js/lib/lang/${lang}`
-    ).then((module) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      timeago.register(lang, module.default)
-      setLanguageLoaded(true)
-    })
+    const promise = getTimeAgoLang(lang)
+    if (promise) {
+      void promise.then((module) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        timeago.register(lang, module.default)
+        setLanguageLoaded(true)
+      })
+    }
   }
 
   if (!languageLoaded && lang !== 'en')

--- a/src/components/time-ago.tsx
+++ b/src/components/time-ago.tsx
@@ -3,7 +3,6 @@ import ReactTimeAgo from 'timeago-react'
 import * as timeago from 'timeago.js'
 
 import { useInstanceData } from '@/contexts/instance-context'
-import { getTimeAgoLang } from '@/helper/feature-i18n'
 
 interface TimeAgoProps {
   datetime: timeago.TDate
@@ -45,4 +44,12 @@ export function TimeAgo({
       />
     </span>
   )
+}
+
+function getTimeAgoLang(lang: string) {
+  if (lang == 'de') return import('timeago.js/lib/lang/de')
+  if (lang == 'es') return import('timeago.js/lib/lang/es')
+  if (lang == 'fr') return import('timeago.js/lib/lang/fr')
+  if (lang == 'hi') return import('timeago.js/lib/lang/hi_IN')
+  if (lang == 'ta') return import('timeago.js/lib/lang/ta')
 }

--- a/src/helper/feature-i18n.ts
+++ b/src/helper/feature-i18n.ts
@@ -136,11 +136,3 @@ export function getLoggedInData(lang: string) {
 
   return mergeDeepRight(enData, data) as typeof enLoggedInData
 }
-
-export function getTimeAgoLang(lang: string) {
-  if (lang == 'de') return import('timeago.js/lib/lang/de')
-  if (lang == 'es') return import('timeago.js/lib/lang/es')
-  if (lang == 'fr') return import('timeago.js/lib/lang/fr')
-  if (lang == 'hi') return import('timeago.js/lib/lang/hi_IN')
-  if (lang == 'ta') return import('timeago.js/lib/lang/ta')
-}

--- a/src/helper/feature-i18n.ts
+++ b/src/helper/feature-i18n.ts
@@ -136,3 +136,11 @@ export function getLoggedInData(lang: string) {
 
   return mergeDeepRight(enData, data) as typeof enLoggedInData
 }
+
+export function getTimeAgoLang(lang: string) {
+  if (lang == 'de') return import('timeago.js/lib/lang/de')
+  if (lang == 'es') return import('timeago.js/lib/lang/es')
+  if (lang == 'fr') return import('timeago.js/lib/lang/fr')
+  if (lang == 'hi') return import('timeago.js/lib/lang/hi_IN')
+  if (lang == 'ta') return import('timeago.js/lib/lang/ta')
+}


### PR DESCRIPTION
@Entkenntnis as per your suggestion in #531 here is a draft. 

Should work?
Downside: Regex in `webpackInclude` magic comment has to be maintained manually.

### examples
http://localhost:3000/160832
http://localhost:3000/en/160832