### PR TITLE
Privacy confirmation for google search

### DIFF
--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -31,6 +31,8 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
     typeof window !== 'undefined' &&
     sessionStorage.GoogleSearchConsent === 'true'
 
+  const searchFormRef = React.useRef<HTMLDivElement>(null)
+
   // const [isSearchPage, setIsSearchPage] = React.useState(false)
   const { lang, strings } = useInstanceData()
   const router = useRouter()
@@ -63,7 +65,10 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
 
   function activateSearch() {
     if (searchActive) return
-    if (!consentGiven) return
+    if (!consentGiven) {
+      searchFormRef.current?.focus()
+      return
+    }
 
     if (!searchLoaded) {
       // const cx = '016022363195733463411:78jhtkzhbhc'
@@ -134,6 +139,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
       >
         <SearchForm
           id="searchform"
+          ref={searchFormRef}
           onClick={activateSearch}
           onKeyDown={(e) => {
             if (e.key == 'Enter') {

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -1,14 +1,15 @@
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Tippy from '@tippyjs/react'
 import { useRouter } from 'next/router'
 import { lighten } from 'polished'
 import React from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 
-import { inputFontReset } from '../../helper/css'
-import { theme } from '../../theme'
 import SearchIcon from '@/assets-webkit/img/search-icon.svg'
 import { useInstanceData } from '@/contexts/instance-context'
+import { inputFontReset, makeLightButton, makePadding } from '@/helper/css'
+import { theme } from '@/theme'
 
 interface SearchInputProps {
   onSearchPage?: boolean
@@ -25,6 +26,11 @@ It's a bit hacky, but it's free and works quite well.
 export function SearchInput({ onSearchPage }: SearchInputProps) {
   const [searchLoaded, setSearchLoaded] = React.useState(false)
   const [searchActive, setSearchActive] = React.useState(false)
+  const [consentJustGiven, setConsentJustGiven] = React.useState(false)
+  const consentGiven =
+    typeof window !== 'undefined' &&
+    sessionStorage.GoogleSearchConsent === 'true'
+
   // const [isSearchPage, setIsSearchPage] = React.useState(false)
   const { lang, strings } = useInstanceData()
   const router = useRouter()
@@ -32,12 +38,16 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
   React.useEffect(() => {
     // note: find a better way to tell search input that it should activate itself
     if (onSearchPage) {
-      // setIsSearchPage(true)
       activateSearch()
     }
     // I only want to run this the first time the page loads
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  React.useEffect(() => {
+    if (consentJustGiven) activateSearch()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [consentJustGiven])
 
   React.useEffect(() => {
     const resultsContainer = document.getElementById('gcs-results')
@@ -53,6 +63,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
 
   function activateSearch() {
     if (searchActive) return
+    if (!consentGiven) return
 
     if (!searchLoaded) {
       // const cx = '016022363195733463411:78jhtkzhbhc'
@@ -76,6 +87,11 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
       const resultsContainer = document.getElementById('gcs-results')
       setupLinkCatcher(resultsContainer)
     })
+  }
+
+  function giveConsent() {
+    sessionStorage.GoogleSearchConsent = 'true'
+    setConsentJustGiven(true)
   }
 
   function setupLinkCatcher(container: HTMLElement | null) {
@@ -110,39 +126,65 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
 
   return (
     <>
-      <SearchForm
-        id="searchform"
-        onClick={activateSearch}
-        onKeyDown={(e) => {
-          if (e.key == 'Enter') {
-            activateSearch()
-          }
-        }}
-        tabIndex={searchActive ? -1 : 0}
+      <Tippy
+        content={renderConsentPop()}
+        trigger="focus click"
+        interactive
+        placement="bottom-end"
       >
-        {!searchActive && (
-          <>
-            <PlaceholderText>{strings.header.search}</PlaceholderText>
-            <PlaceholderButton>
-              {!searchLoaded ? (
-                <PlaceholderIcon />
-              ) : (
-                <LoadingIcon icon={faSpinner} size="1x" spin />
-              )}
-            </PlaceholderButton>
-          </>
-        )}
-        <div
-          className="gcse-searchbox-only"
-          data-autocompletemaxcompletions="7"
-          data-resultsurl="/search"
-          data-enablehistory="true"
-        />
-      </SearchForm>
+        <SearchForm
+          id="searchform"
+          onClick={activateSearch}
+          onKeyDown={(e) => {
+            if (e.key == 'Enter') {
+              activateSearch()
+            }
+          }}
+          tabIndex={searchActive ? -1 : 0}
+        >
+          {!searchActive && (
+            <>
+              <PlaceholderText>{strings.header.search}</PlaceholderText>
+              <PlaceholderButton>
+                {!searchLoaded ? (
+                  <PlaceholderIcon />
+                ) : (
+                  <LoadingIcon icon={faSpinner} size="1x" spin />
+                )}
+              </PlaceholderButton>
+            </>
+          )}
 
+          <div
+            className="gcse-searchbox-only"
+            data-autocompletemaxcompletions="7"
+            data-resultsurl="/search"
+            data-enablehistory="true"
+          />
+        </SearchForm>
+      </Tippy>
       <AutocompleteStyle />
     </>
   )
+  function renderConsentPop() {
+    if (searchActive || consentGiven) return null
+    return (
+      <ConsentPop>
+        This is a important text I dont even know how long it will be
+        <br />
+        <ConsentButton
+          onClick={giveConsent}
+          onKeyDown={(e) => {
+            if (e.key == 'Enter') {
+              giveConsent()
+            }
+          }}
+        >
+          Agree
+        </ConsentButton>
+      </ConsentPop>
+    )
+  }
 }
 
 const height = 40
@@ -305,6 +347,7 @@ const SearchForm = styled.div`
   display: flex;
   transition: background-color 0.4s ease;
   cursor: pointer;
+  outline: none;
 
   &:focus-within {
     background-color: ${(props) =>
@@ -371,5 +414,35 @@ const AutocompleteStyle = createGlobalStyle`
       ${inputFontReset}
       white-space: normal !important;
     }
+  }
+`
+
+//this is overriding the styles of the modal-content only. see doc to change overlay etc.
+
+const ConsentPop = styled.div`
+  background-color: ${(props) => props.theme.colors.brand};
+  color: #fff;
+  width: auto;
+  border-radius: 10px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 2px 4px;
+  ${makePadding};
+  padding-top: 12px;
+  padding-bottom: 12px;
+  z-index: 5;
+  width: 88vw;
+  outline: 0;
+
+  @media (min-width: ${(props) => props.theme.breakpoints.sm}) {
+    width: 277px;
+  }
+`
+
+const ConsentButton = styled.button`
+  ${makeLightButton}
+  font-size: 1rem;
+  margin-top: 12px;
+  &:hover {
+    background-color: #fff;
+    color: ${(props) => props.theme.colors.brand};
   }
 `


### PR DESCRIPTION
### Basic idea
- Small popover, no connection to google before confirmation.
- Confirmation is saved only in session so we don't need a way to reset confirmations just yet (see #641 for discussion).

### TODO
- [x] ~Currently breaks direct access to search page. e.g. [here](https://frontend-git-privacy-pop-for-search.serlo.vercel.app/search?q=was%20ist%20ein%20algorithmus).~
- [ ] Use real text / translate

### Preview
https://frontend-git-privacy-pop-for-search.serlo.vercel.app/

closes #641 