### PR TITLE
Add search engines for other instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ At the moment, the frontend implements these features:
 
 - **Horizon**. The german version contains a horizon that features selected items.
 
-- **Google Custom Search**. Search with the built-in search input or by visiting the search page: https://frontend.serlo.org/search?q=hypotenuse
+- **Google Programmable Search**. Search with the built-in search input or by visiting the search page: https://frontend.serlo.org/search?q=hypotenuse
 
 - **Login**. You can login to your account with your username (not e-mail) and the password `123456` (currently only available on staging and localhost).
 

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -72,10 +72,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
     }
 
     if (!searchLoaded) {
-      const spanishEngineId = '5bd728bf64beb7e94'
-      // const frontendTestEngineId = '016022363195733463411:78jhtkzhbhc' //autocomplete is way worse, so we use the "old one"
-      const germanEngineId = '017461339636837994840:ifahsiurxu4'
-      const id = lang === 'es' ? spanishEngineId : germanEngineId
+      const id = getSearchEngineId(lang)
 
       const gcse = document.createElement('script')
       gcse.type = 'text/javascript'
@@ -132,6 +129,24 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
       },
       false
     )
+  }
+
+  function getSearchEngineId(instance: string) {
+    switch (instance) {
+      case 'de':
+        return '017461339636837994840:ifahsiurxu4'
+      case 'es':
+        return '5bd728bf64beb7e94'
+      case 'fr':
+        return 'b31aebc4f2a4db942'
+      case 'ta':
+        return '65f223ba41d6c4383'
+      case 'hi':
+        return 'd1ded9becf410cea7'
+      case 'en':
+      default:
+        return 'b3d3ba59c482534d2'
+    }
   }
 
   return (

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -72,12 +72,10 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
     }
 
     if (!searchLoaded) {
-      const id = getSearchEngineId(lang)
-
       const gcse = document.createElement('script')
       gcse.type = 'text/javascript'
       gcse.async = true
-      gcse.src = 'https://cse.google.com/cse.js?cx=' + id
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + getSearchEngineId(lang)
 
       const s = document.getElementsByTagName('script')[0]
       s.parentNode!.insertBefore(gcse, s)

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -72,12 +72,16 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
     }
 
     if (!searchLoaded) {
-      // const cx = '016022363195733463411:78jhtkzhbhc'
-      const cx = '017461339636837994840:ifahsiurxu4' //"old version" with better autocomplete
+      const spanishEngineId = '5bd728bf64beb7e94'
+      // const frontendTestEngineId = '016022363195733463411:78jhtkzhbhc' //autocomplete is way worse, so we use the "old one"
+      const germanEngineId = '017461339636837994840:ifahsiurxu4'
+      const id = lang === 'es' ? spanishEngineId : germanEngineId
+
       const gcse = document.createElement('script')
       gcse.type = 'text/javascript'
       gcse.async = true
-      gcse.src = 'https://cse.google.com/cse.js?cx=' + cx
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + id
+
       const s = document.getElementsByTagName('script')[0]
       s.parentNode!.insertBefore(gcse, s)
 

--- a/src/components/navigation/search-results.tsx
+++ b/src/components/navigation/search-results.tsx
@@ -36,24 +36,6 @@ export const SearchResults = styled.div`
     max-width: 800px;
     margin: 0 auto;
 
-    .gsc-results-wrapper-visible::before {
-      /* content: attr(data-customsearch); */
-      content: 'Custom Search';
-      font-weight: bold;
-      display: block;
-      color: ${(props) => props.theme.colors.brand};
-      width: 100%;
-      padding: 10px 0;
-      background: url('//www.google.com/cse/static/images/1x/googlelogo_lightgrey_46x16dp.png')
-        left center no-repeat;
-      text-indent: 50px;
-
-      @media (min-width: ${(props) => props.theme.breakpoints.sm}) {
-        max-width: 800px;
-        margin: 0 auto;
-      }
-    }
-
     .gsc-url-top,
     div.gs-per-result-labels {
       display: none;


### PR DESCRIPTION
**Testlinks:**
- https://frontend-git-spanish-search.serlo.now.sh/es/search?q=sobre
- https://frontend-git-spanish-search.serlo.now.sh/es
- https://frontend-git-spanish-search.serlo.now.sh/search?q=serlo
- https://frontend-git-spanish-search.serlo.now.sh/en/search?q=serlo
- https://frontend-git-spanish-search.serlo.now.sh/es/search?q=serlo
- https://frontend-git-spanish-search.serlo.now.sh/fr/search?q=serlo
- https://frontend-git-spanish-search.serlo.now.sh/ta/search?q=serlo
- https://frontend-git-spanish-search.serlo.now.sh/hi/search?q=serlo (using english version – already an improvement, will just work when crowdin pr is merged later)


**Also:**
- removed custom google branding. According to [this](https://support.google.com/programmable-search/answer/10026723) it's not required any more (and also not allowed).

closes #612