### PR TITLE
Applet fixes

### DIFF
--- a/src/components/content/geogebra-wrapper.tsx
+++ b/src/components/content/geogebra-wrapper.tsx
@@ -1,8 +1,5 @@
 import styled from 'styled-components'
 
-import { makeMargin } from '../../helper/css'
-
 export const GeogebraWrapper = styled.div`
-  ${makeMargin}
   margin-bottom: ${(props) => props.theme.spacing.mb.block};
 `

--- a/src/components/content/geogebra-wrapper.tsx
+++ b/src/components/content/geogebra-wrapper.tsx
@@ -1,5 +1,0 @@
-import styled from 'styled-components'
-
-export const GeogebraWrapper = styled.div`
-  margin-bottom: ${(props) => props.theme.spacing.mb.block};
-`

--- a/src/components/content/geogebra.tsx
+++ b/src/components/content/geogebra.tsx
@@ -8,6 +8,8 @@ export interface GeogebraProps {
 }
 
 export function Geogebra({ id }: GeogebraProps) {
+  const appletId = id.replace('https://www.geogebra.org/m/', '')
+
   return (
     <PrivacyWrapper
       type="applet"
@@ -16,9 +18,9 @@ export function Geogebra({ id }: GeogebraProps) {
     >
       <GeogebraContainer>
         <GeogebraFrame
-          title={id}
+          title={appletId}
           scrolling="no"
-          src={'https://www.geogebra.org/material/iframe/id/' + id}
+          src={'https://www.geogebra.org/material/iframe/id/' + appletId}
         />
       </GeogebraContainer>
     </PrivacyWrapper>

--- a/src/components/content/geogebra.tsx
+++ b/src/components/content/geogebra.tsx
@@ -7,75 +7,14 @@ export interface GeogebraProps {
   id: string
 }
 
-interface ResponseData {
-  responses: {
-    response: {
-      item: {
-        width: number
-        height: number
-      }
-    }
-  }
-}
-
 export function Geogebra({ id }: GeogebraProps) {
-  const [data, setData] = React.useState<{ ratio: number } | undefined>(
-    undefined
-  )
-  React.useEffect(() => {
-    void fetch('https://www.geogebra.org/api/json.php', {
-      method: 'POST',
-      body: JSON.stringify({
-        request: {
-          '-api': '1.0.0',
-          task: {
-            '-type': 'fetch',
-            fields: {
-              field: [
-                { '-name': 'width' },
-                { '-name': 'height' },
-                { '-name': 'preview_url' },
-              ],
-            },
-            filters: {
-              field: [{ '-name': 'id', '#text': id }],
-            },
-            limit: { '-num': '1' },
-          },
-        },
-      }),
-    })
-      .then((res) => res.json())
-      .then((res: ResponseData) => {
-        try {
-          const data = res.responses.response.item
-
-          if (data) {
-            setData({ ratio: data.width / data.height })
-          }
-        } catch (e) {
-          // ignore
-        }
-      })
-  }, [id])
-  if (!data) {
-    return (
-      <Placeholder>
-        <img
-          src="https://cdn.geogebra.org/static/img/GeoGebra-logo.png"
-          alt="GeoGebra"
-        />
-      </Placeholder>
-    )
-  }
   return (
-    // TODO: Get real applet preview image
     <PrivacyWrapper
       type="applet"
-      previewImageUrl="https://cdn.geogebra.org/static/img/GeoGebra-logo.png"
+      previewImageUrl="/_assets/img/blank-preview-image.png"
       provider={Provider.GeoGebra}
     >
-      <GeogebraContainer ratio={data.ratio}>
+      <GeogebraContainer>
         <GeogebraFrame
           title={id}
           scrolling="no"
@@ -85,15 +24,6 @@ export function Geogebra({ id }: GeogebraProps) {
     </PrivacyWrapper>
   )
 }
-
-const Placeholder = styled.div`
-  display: flex;
-  justify-content: center;
-  box-sizing: border-box;
-  border: 2px ${(props) => props.theme.colors.lightgray} solid;
-  border-radius: 4px;
-  padding: 10px;
-`
 
 const GeogebraFrame = styled.iframe`
   position: absolute;
@@ -106,9 +36,8 @@ const GeogebraFrame = styled.iframe`
   background-color: rgba(0, 0, 0, 0.3);
 `
 
-const GeogebraContainer = styled.div<{ ratio: number }>`
+const GeogebraContainer = styled.div`
   padding: 0;
-  padding-top: ${(props) => 100 / props.ratio}%;
   display: block;
   height: 0;
   overflow: hidden;

--- a/src/schema/article-renderer.tsx
+++ b/src/schema/article-renderer.tsx
@@ -4,7 +4,6 @@ import { CSSProperties } from 'styled-components'
 
 import { Col } from '../components/content/col'
 import { ExerciseGroup } from '../components/content/exercises/exercise-group'
-import { GeogebraWrapper } from '../components/content/geogebra-wrapper'
 import { ImageLink } from '../components/content/image-link'
 import { ImgCentered } from '../components/content/img-centered'
 import { Important } from '../components/content/important'
@@ -293,9 +292,7 @@ function renderElement(props: RenderElementProps): React.ReactNode {
   if (element.type === 'geogebra') {
     return (
       <Lazy>
-        <GeogebraWrapper>
-          <Geogebra id={element.id} />
-        </GeogebraWrapper>
+        <Geogebra id={element.id} />
       </Lazy>
     )
   }


### PR DESCRIPTION
- closes #660 (quickfix until we load the real preview image and can extract the ratio from there)
- closes #659 (full urls should now work)
- removes `GeogebraWrapper` (replaced by privacywrapper)
- remove geogebra API call (moved to [here](https://github.com/serlo/serlo.org-cloudflare-worker/issues/66) in the future)