### PR TITLE
add canonical tag

### DIFF
--- a/src/components/head-tags.tsx
+++ b/src/components/head-tags.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 
+import { useInstanceData } from '@/contexts/instance-context'
 import { useOrigin } from '@/contexts/origin-context'
 import { HeadData } from '@/data-types'
 
@@ -11,6 +12,7 @@ interface HeadTagsProps {
 export function HeadTags({ data }: HeadTagsProps) {
   const { title, contentType, metaDescription, metaImage } = data
   const origin = useOrigin()
+  const { lang } = useInstanceData()
   const router = useRouter()
 
   return (
@@ -19,7 +21,10 @@ export function HeadTags({ data }: HeadTagsProps) {
       {contentType && <meta name="content_type" content={contentType} />}
       {metaDescription && <meta name="description" content={metaDescription} />}
       <meta property="og:title" content={title} />
-      <link rel="canonical" href={origin + router.asPath} />
+      <link
+        rel="canonical"
+        href={`https://${lang}.serlo.org${router.asPath}`}
+      />
       <meta
         property="og:image"
         content={metaImage ? metaImage : origin + '/_assets/img/meta/serlo.jpg'}

--- a/src/components/head-tags.tsx
+++ b/src/components/head-tags.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 
 import { useOrigin } from '@/contexts/origin-context'
 import { HeadData } from '@/data-types'
@@ -10,12 +11,15 @@ interface HeadTagsProps {
 export function HeadTags({ data }: HeadTagsProps) {
   const { title, contentType, metaDescription, metaImage } = data
   const origin = useOrigin()
+  const router = useRouter()
+
   return (
     <Head>
       <title>{title}</title>
       {contentType && <meta name="content_type" content={contentType} />}
       {metaDescription && <meta name="description" content={metaDescription} />}
       <meta property="og:title" content={title} />
+      <link rel="canonical" href={origin + router.asPath} />
       <meta
         property="og:image"
         content={metaImage ? metaImage : origin + '/_assets/img/meta/serlo.jpg'}


### PR DESCRIPTION
@Entkenntnis is there an easier way of constructing a canonical url than:

```jsx
<link rel="canonical" href={`https://${lang}.serlo.org${router.asPath}`} />
```

closes #672 