### PR TITLE
Toast notice rework and improved content restore UX

### DIFF
--- a/src/components/navigation/author-tools-hover-menu.tsx
+++ b/src/components/navigation/author-tools-hover-menu.tsx
@@ -301,7 +301,7 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
 
   function trash(id = data.id) {
     // todo: use graphql mutation
-    if (!data.trashed) {
+    if (data.trashed) {
       return (
         <Li>
           <SubButtonStyle
@@ -313,19 +313,14 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
         </Li>
       )
     }
-    const cookies = cookie.parse(
-      typeof window === 'undefined' ? '' : document.cookie
-    )
     return (
       <Li>
-        <form method="post" action={`/uuid/trash/${id}`}>
-          <input type="hidden" name="csrf" value={cookies['CSRF']} />
-          <SubLink as="button">
-            <SubButtonStyle>
-              {loggedInStrings.authorMenu.moveToTrash}
-            </SubButtonStyle>
-          </SubLink>
-        </form>
+        <SubButtonStyle
+          as="button"
+          onClick={() => fetchLegacyUrl(`/uuid/trash/${id}`, true)}
+        >
+          {loggedInStrings.authorMenu.moveToTrash}
+        </SubButtonStyle>
       </Li>
     )
   }
@@ -418,15 +413,26 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
   }
 
   //quick experiment
-  function fetchLegacyUrl(url: string) {
+  function fetchLegacyUrl(url: string, csrf?: boolean) {
     NProgress.start()
 
+    const cookies = cookie.parse(
+      typeof window === 'undefined' ? '' : document.cookie
+    )
+
+    const options = csrf
+      ? { method: 'POST', body: JSON.stringify({ csrf: cookies['CSRF'] }) }
+      : {}
+
     try {
-      void fetch(url)
+      void fetch(url, options)
         .then((res) => {
           if (res.status === 200) {
             NProgress.done()
             showToastNotice('Completed', 'success')
+            setTimeout(() => {
+              window.location.reload()
+            }, 1000)
           } else {
             showErrorNotice()
           }

--- a/src/components/navigation/author-tools-hover-menu.tsx
+++ b/src/components/navigation/author-tools-hover-menu.tsx
@@ -2,6 +2,7 @@ import Tippy, { TippyProps } from '@tippyjs/react'
 import cookie from 'cookie'
 import { gql } from 'graphql-request'
 import { useRouter } from 'next/router'
+import NProgress from 'nprogress'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -10,6 +11,7 @@ import { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
 import { useAuth } from '@/auth/use-auth'
 import { useInstanceData } from '@/contexts/instance-context'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
+import { useToastNotice } from '@/contexts/toast-notice-context'
 
 export interface AuthorToolsData {
   type: string
@@ -37,6 +39,7 @@ const tippyDefaultProps: Partial<TippyProps> = {
 export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
   const loggedInData = useLoggedInData()
   const instanceData = useInstanceData()
+  const showToastNotice = useToastNotice()
   const [isSubscriped, setSubscriped] = React.useState(false)
 
   const auth = useAuth()
@@ -298,10 +301,16 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
 
   function trash(id = data.id) {
     // todo: use graphql mutation
-    if (data.trashed) {
-      return renderLi(
-        `/uuid/restore/${id}`,
-        loggedInStrings.authorMenu.restoreContent
+    if (!data.trashed) {
+      return (
+        <Li>
+          <SubButtonStyle
+            as="button"
+            onClick={() => fetchLegacyUrl(`/uuid/restore/${id}`)}
+          >
+            {loggedInStrings.authorMenu.restoreContent}
+          </SubButtonStyle>
+        </Li>
       )
     }
     const cookies = cookie.parse(
@@ -311,12 +320,8 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
       <Li>
         <form method="post" action={`/uuid/trash/${id}`}>
           <input type="hidden" name="csrf" value={cookies['CSRF']} />
-          <SubLink>
-            <SubButtonStyle
-              onClick={(e: any) =>
-                e.target.parentElement.parentElement.submit()
-              }
-            >
+          <SubLink as="button">
+            <SubButtonStyle>
               {loggedInStrings.authorMenu.moveToTrash}
             </SubButtonStyle>
           </SubLink>
@@ -410,6 +415,34 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
         </SubLink>
       </Li>
     )
+  }
+
+  //quick experiment
+  function fetchLegacyUrl(url: string) {
+    NProgress.start()
+
+    try {
+      void fetch(url)
+        .then((res) => {
+          if (res.status === 200) {
+            NProgress.done()
+            showToastNotice('Completed', 'success')
+          } else {
+            showErrorNotice()
+          }
+        })
+        .catch(() => {
+          showErrorNotice()
+        })
+    } catch (e) {
+      console.log(e)
+      showErrorNotice()
+    }
+
+    function showErrorNotice() {
+      NProgress.done()
+      showToastNotice('Something went wrong… Please try again', 'warning')
+    }
   }
 }
 

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -262,4 +262,5 @@ export const SubButtonStyle = styled.span`
   border-radius: 12px;
   font-size: 1rem;
   font-weight: normal;
+  text-align: left;
 `

--- a/src/components/pages/error-page.tsx
+++ b/src/components/pages/error-page.tsx
@@ -10,23 +10,7 @@ import { StyledP } from '@/components/tags/styled-p'
 import { useInstanceData } from '@/contexts/instance-context'
 import { ErrorData } from '@/data-types'
 import { makePrimaryButton } from '@/helper/css'
-
-export interface SentryGlobal {
-  Sentry?: {
-    addBreadcrumb: (arg0: {
-      type?: string
-      category?: string
-      message?: string
-      level?: string
-      timestamp?: string
-      data?: unknown
-    }) => void
-    captureException: (arg0: Error) => void
-    Severity?: {
-      Info: string
-    }
-  }
-}
+import { SentryGlobal } from '@/pages/_app'
 
 export function ErrorPage({ code, message }: ErrorData) {
   const [path, setPath] = React.useState('')
@@ -37,13 +21,13 @@ export function ErrorPage({ code, message }: ErrorData) {
     console.log(message)
 
     if (process.env.NEXT_PUBLIC_SENTRY_DSN !== undefined) {
-      const _window = (window as unknown) as Window & SentryGlobal
-      _window.Sentry?.addBreadcrumb({
+      const windowWithSentry = (window as unknown) as Window & SentryGlobal
+      windowWithSentry.Sentry?.addBreadcrumb({
         category: 'error message',
         message,
-        level: _window.Sentry?.Severity?.Info || 'info',
+        level: windowWithSentry.Sentry?.Severity?.Info || 'info',
       })
-      _window.Sentry?.captureException(
+      windowWithSentry.Sentry?.captureException(
         new Error(`${code}: ${message || 'without message'}`)
       )
     }

--- a/src/components/toast-notice.tsx
+++ b/src/components/toast-notice.tsx
@@ -4,14 +4,13 @@ import Notification, { notify } from 'react-notify-toast'
 import { useAuth } from '@/auth/use-auth'
 import { theme } from '@/theme'
 
-export function ToastNotifications() {
+export function ToastNotice() {
   const auth = useAuth()
 
   const notifyColor = {
     background: theme.colors.brand,
     text: '#fff',
   }
-  // const queue = notify.createShowQueue()
   const showTime = 2000
 
   React.useEffect(() => {

--- a/src/contexts/toast-notice-context.ts
+++ b/src/contexts/toast-notice-context.ts
@@ -1,0 +1,39 @@
+import React from 'react'
+import { notify } from 'react-notify-toast'
+
+import { theme } from '@/theme'
+
+export const ToastNoticeContext = React.createContext<typeof notify | null>(
+  null
+)
+
+export const ToastNoticeProvider = ToastNoticeContext.Provider
+
+export function useToastNotice() {
+  const toastNotice = React.useContext(ToastNoticeContext)
+
+  const colors = {
+    default: {
+      background: theme.colors.brand,
+      text: '#fff',
+    },
+    success: {
+      background: theme.colors.brandGreen,
+      text: '#fff',
+    },
+    warning: {
+      background: theme.colors.orange,
+      text: '#000',
+    },
+  }
+
+  return (message: string, type?: 'default' | 'success' | 'warning') => {
+    if (!toastNotice) return
+    ;((toastNotice as unknown) as typeof notify['show'])(
+      message,
+      'custom',
+      2000,
+      colors[type || 'default']
+    )
+  }
+}

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import React from 'react'
+import { notify } from 'react-notify-toast'
 
 import { useAuth } from '@/auth/use-auth'
 import { RevisionProps } from '@/components/author/revision'
@@ -21,6 +22,7 @@ import { ProfileProps } from '@/components/pages/user/profile'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
 import { OriginProvider } from '@/contexts/origin-context'
+import { ToastNoticeProvider } from '@/contexts/toast-notice-context'
 import {
   InitialProps,
   InstanceData,
@@ -121,6 +123,8 @@ const PageView: NextPage<InitialProps> = (initialProps) => {
     loggedInData,
   ])
 
+  const toastNotice = notify.createShowQueue()
+
   // dev
   //console.dir(initialProps)
 
@@ -130,7 +134,9 @@ const PageView: NextPage<InitialProps> = (initialProps) => {
       <OriginProvider value={initialProps.origin}>
         <InstanceDataProvider value={instanceData}>
           <LoggedInDataProvider value={loggedInData}>
-            {renderPage(initialProps.pageData)}
+            <ToastNoticeProvider value={toastNotice}>
+              {renderPage(initialProps.pageData)}
+            </ToastNoticeProvider>
           </LoggedInDataProvider>
         </InstanceDataProvider>
       </OriginProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,22 +11,42 @@ import '@/assets-webkit/fonts/karmilla.css'
 import '@/assets-webkit/fonts/katex/katex.css'
 
 import { NProgressStyles } from '@/components/navigation/n-progress-styles'
-import { ToastNotifications } from '@/components/toast-notifications'
+import { ToastNotice } from '@/components/toast-notice'
 import { FontFix } from '@/helper/css'
 import { theme } from '@/theme'
 
 config.autoAddCss = false
+
+export interface SentryGlobal {
+  Sentry?: {
+    addBreadcrumb: (arg0: {
+      type?: string
+      category?: string
+      message?: string
+      level?: string
+      timestamp?: string
+      data?: unknown
+    }) => void
+    captureException: (arg0: Error) => void
+    Severity?: {
+      Info: string
+    }
+    init: (arg0: { environment: string; release: string }) => void
+    forceLoad: () => void
+  }
+}
 
 if (
   process.env.NEXT_PUBLIC_SENTRY_DSN !== undefined &&
   process.env.NEXT_PUBLIC_COMMIT_SHA !== undefined &&
   typeof window !== 'undefined'
 ) {
-  ;(window as any).Sentry?.init({
+  const windowWithSentry = (window as unknown) as Window & SentryGlobal
+  windowWithSentry.Sentry?.init({
     environment: process.env.NEXT_PUBLIC_ENV,
     release: `frontend@${process.env.NEXT_PUBLIC_COMMIT_SHA?.substr(0, 7)}`,
   })
-  ;(window as any).Sentry?.forceLoad()
+  windowWithSentry.Sentry?.forceLoad()
 }
 
 Router.events.on('routeChangeStart', () => {
@@ -43,7 +63,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <FontFix />
         <NProgressStyles />
         <Component {...pageProps} />
-        <ToastNotifications />
+        <ToastNotice />
       </ThemeProvider>
     </React.StrictMode>
   )


### PR DESCRIPTION
- toast notification now called toast notice to avoid confusion with our Notifications
- using queue for notifications so we can display more than one
Also:
- using fetch for the restore content call and add feedback via loading bar and toast notice on success or fail
this is an experiment, but since we hopefully use fetch + a mutation in the future this is how we could handle calls like this.
@Entkenntnis what do you think?

**More options:**
- If the call is successful we could also add a simple refresh: `window.location.reload()` or some local overwrite to display the changes that happened.
- ~we could also use fetch to do the post call (instead of that form) until we get a real mutation :)~ try in the PR


PS: Hard to test in preview and locally. Locally you can at least trigger the loading bar and error message. e.g.
http://localhost:3000/1567