### PR TITLE
Explicitly specify Node v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Staging deployment: [frontend-git-staging.serlo.vercel.app](https://frontend-git
 
 ### Local installation
 
-You can run the frontend on your local system. For that, install [Node.js](https://nodejs.org/en/) (current LTS) and [yarn](https://classic.yarnpkg.com/en/docs/install).
+You can run the frontend on your local system. For that, install [Node.js v12](https://nodejs.org/en/) and [yarn](https://classic.yarnpkg.com/en/docs/install).
 
 Then, run following commands:
 

--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
     "react-is": "^17.0.0",
     "react-test-renderer": "^17.0.0",
     "typescript": "^4.0.0"
+  },
+  "engines": {
+    "node": "^12.0.0"
   }
 }


### PR DESCRIPTION
Since Vercel uses AWS under the hood, we can't use the current Node LTS (v14). To avoid any weird issues in the future with mismatching Node versions, this PR fixes the node version to v12.