### PR TITLE
Load exercise on solution id

### DIFF
--- a/src/fetcher/fetch-page-data.ts
+++ b/src/fetcher/fetch-page-data.ts
@@ -87,6 +87,10 @@ async function apiRequest(
     }
   }
 
+  if (uuid.__typename === 'Solution') {
+    return await apiRequest(`/${uuid.exercise.id}`, instance)
+  }
+
   const secondaryNavigationData = createNavigation(uuid)
   const breadcrumbsData = createBreadcrumbs(uuid)
   const horizonData = instance == 'de' ? buildHorizonData() : undefined
@@ -491,7 +495,7 @@ async function apiRequest(
     kind: 'error',
     errorData: {
       code: 404,
-      message: 'Content type not supported: ' + uuid.__typename,
+      message: `Unknown content type!`,
     },
   }
 }

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -139,6 +139,7 @@ export interface Solution extends Repository {
   trashed: boolean
   currentRevision?: GraphQL.Maybe<Pick<GraphQL.SolutionRevision, 'content'>>
   license: License
+  exercise: { id: number }
 }
 
 // Events are only used in injections, no support for full page view
@@ -549,6 +550,14 @@ export const dataQuery = gql`
 
       ... on Solution {
         ...solution
+        exercise {
+          ... on Exercise {
+            id
+          }
+          ... on GroupedExercise {
+            id
+          }
+        }
       }
 
       ... on Event {


### PR DESCRIPTION
Fixes #569

Similiar to course/coursepage, the frontend just loads to exercise of a solution instead of an bare solution. Better than a 404.