### PR TITLE
Move instance data out of initial props

### DIFF
--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -16,8 +16,8 @@ import { instanceData, instanceLandingData, loggedInData } from '@/data/en'
 // If your data is static across all pages and languages, don't add it here, but add it directly to the component.
 
 export interface InitialProps {
-  instanceData?: InstanceData
   pageData: PageData
+  lang: Instance | string
 }
 
 // Instance data consists of the language, translation strings, header menu and footer menu.

--- a/src/fetcher/get-initial-props.ts
+++ b/src/fetcher/get-initial-props.ts
@@ -1,11 +1,7 @@
 import { NextPageContext } from 'next'
 
-import { InitialProps, PageData, InstanceData } from '@/data-types'
-import {
-  parseLanguageSubfolder,
-  getInstanceDataByLang,
-  getLandingData,
-} from '@/helper/feature-i18n'
+import { InitialProps, PageData } from '@/data-types'
+import { parseLanguageSubfolder, getLandingData } from '@/helper/feature-i18n'
 import { frontendOrigin } from '@/helper/frontent-origin'
 
 export const fetcherAdditionalData = {
@@ -30,13 +26,6 @@ export async function getInitialProps(
       ? fetcherAdditionalData.instance
       : instance_path
 
-  let instanceData: InstanceData | undefined = undefined
-
-  if (typeof window === 'undefined') {
-    // only load instanceData serverside
-    instanceData = getInstanceDataByLang(instance)
-  }
-
   const rawAlias = alias.substring(1).replace('user/public', 'user/me')
 
   if (
@@ -48,27 +37,27 @@ export async function getInitialProps(
       pageData: {
         kind: rawAlias,
       },
-      instanceData,
+      lang: instance,
     }
   }
 
   if (alias === '/spenden' && instance == 'de') {
     return {
-      instanceData,
       pageData: {
         kind: 'donation',
       },
+      lang: instance,
     }
   }
 
   if (typeof window === 'undefined') {
     if (alias === '/') {
       return {
-        instanceData,
         pageData: {
           kind: 'landing',
           landingData: getLandingData(instance),
         },
+        lang: instance,
       }
     }
 
@@ -103,8 +92,8 @@ export async function getInitialProps(
     }
 
     return {
-      instanceData,
       pageData: fetchedData,
+      lang: instance,
     }
   } else {
     //client
@@ -114,6 +103,7 @@ export async function getInitialProps(
       if (fromCache) {
         return {
           pageData: JSON.parse(fromCache) as PageData,
+          lang: instance,
         }
       }
     } catch (e) {
@@ -139,6 +129,7 @@ export async function getInitialProps(
     }*/
     return {
       pageData: fetchedData,
+      lang: instance,
     }
   }
 }

--- a/src/helper/html-escape.ts
+++ b/src/helper/html-escape.ts
@@ -1,0 +1,16 @@
+// This utility is based on https://github.com/zertosh/htmlescape
+// License: https://github.com/zertosh/htmlescape/blob/0527ca7156a524d256101bb310a9f970f63078ad/LICENSE
+
+const ESCAPE_LOOKUP: { [match: string]: string } = {
+  '&': '\\u0026',
+  '>': '\\u003e',
+  '<': '\\u003c',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+}
+
+const ESCAPE_REGEX = /[&><\u2028\u2029]/g
+
+export function htmlEscapeJsonString(str: string): string {
+  return str.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match])
+}

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -116,14 +116,14 @@ const PageView: NextPage<InitialProps> = (initialProps) => {
     sessionStorage.setItem('currentPathname', window.location.pathname)
   })
 
-  fetcherAdditionalData.instance = initialProps.lang
+  fetcherAdditionalData.instance = instanceData.lang
 
   const auth = useAuth()
   const [loggedInData, setLoggedInData] = React.useState<LoggedInData | null>(
     getCachedLoggedInData()
   )
 
-  React.useEffect(fetchLoggedInData, [auth, loggedInData, initialProps.lang])
+  React.useEffect(fetchLoggedInData, [auth, instanceData.lang, loggedInData])
 
   const toastNotice = notify.createShowQueue()
 
@@ -170,11 +170,11 @@ const PageView: NextPage<InitialProps> = (initialProps) => {
     if (auth.current && !loggedInData) {
       void (async () => {
         const res = await fetch(
-          frontendOrigin + '/api/locale/' + initialProps.lang
+          frontendOrigin + '/api/locale/' + instanceData.lang
         )
         const json = (await res.json()) as LoggedInData
         sessionStorage.setItem(
-          `___loggedInData_${initialProps.lang}`,
+          `___loggedInData_${instanceData.lang}`,
           JSON.stringify(json)
         )
         setLoggedInData(json)

--- a/src/pages/___graphql.tsx
+++ b/src/pages/___graphql.tsx
@@ -1730,7 +1730,7 @@ const GraphiQL = dynamic<GraphiQLProps>(() => import('graphiql'), {
 })
 const GraphQL: NextPage = () => {
   const auth = useAuth()
-  console.log('GraphQL auth', auth.current)
+  //console.log('GraphQL auth', auth.current)
 
   return (
     <>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -7,6 +7,9 @@ import Document, {
 } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
+import { getInstanceDataByLang } from '@/helper/feature-i18n'
+import { htmlEscapeJsonString } from '@/helper/html-escape'
+
 const bodyStyles = {
   margin: 0,
   fontFamily: 'Karmilla, sans-serif',
@@ -40,6 +43,8 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const props = this.props.__NEXT_DATA__.props.pageProps
+    const langData = props.lang ? getInstanceDataByLang(props.lang) : undefined
     return (
       <Html
         lang={
@@ -98,6 +103,15 @@ export default class MyDocument extends Document {
         </Head>
         <body style={bodyStyles}>
           <Main />
+          {langData && (
+            <script
+              type="application/json"
+              id="__FRONTEND_CLIENT_INSTANCE_DATA__"
+              dangerouslySetInnerHTML={{
+                __html: htmlEscapeJsonString(JSON.stringify(langData)),
+              }}
+            />
+          )}
           <NextScript />
           <script async defer src="https://sa.serlo.org/latest.js" />
           <noscript>


### PR DESCRIPTION
Finally found a good way to load translation data into the client. The trick was to think out of the box, e.g. out of react.

The instance data is not anymore part of the page props. Instead, the data is added to the html output in `_document.tsx`. This way, its only loaded on full page load, and not while csr.

@elbotho This is the second step of the refactorings. Can you take a look it?