### PR TITLE
Markup links in comments and make sure they line-break

### DIFF
--- a/src/components/comments/comment.tsx
+++ b/src/components/comments/comment.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 
 import { StyledP } from '../tags/styled-p'
 import { MetaBar } from './meta-bar'
+import { htmlEscapeString } from '@/helper/html-escape'
 
 interface CommentProps {
   isParent?: boolean
@@ -12,10 +13,20 @@ interface CommentProps {
 
 export function Comment({ data, isParent }: CommentProps) {
   const { author, createdAt, content } = data
+
+  const urlFinder = /https?:\/\/(www\.)?([-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b)([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
+
+  //could content end up here unescaped?
+  const escapedContent = htmlEscapeString(content)
+
+  const contentWithLinks = escapedContent.replace(urlFinder, (match) => {
+    return `<a href="${match}" rel="ugc nofollow">${match}</a>`
+  })
+
   return (
     <Wrapper isParent={isParent}>
       <MetaBar user={author} timestamp={createdAt} isParent={isParent} />
-      <StyledP>{content}</StyledP>
+      <StyledP dangerouslySetInnerHTML={{ __html: contentWithLinks }}></StyledP>
     </Wrapper>
   )
 }
@@ -34,6 +45,13 @@ const Wrapper = styled.div<{ isParent?: boolean }>`
   > p {
     margin-bottom: 0;
     white-space: pre-line;
+    overflow-wrap: break-word;
+    word-break: break-all;
+    hyphens: auto;
     padding-left: 8px;
+
+    > a {
+      color: ${(props) => props.theme.colors.brand};
+    }
   }
 `

--- a/src/fetcher/prettify-links.tsx
+++ b/src/fetcher/prettify-links.tsx
@@ -102,8 +102,6 @@ export async function prettifyLinks(pageData: PageData) {
           }
         }>(endpoint, idsQuery([...new Set(ids)]))
 
-  //console.log('prettylinks', prettyLinks)
-
   callbacks.forEach((x) => {
     if (prettyLinks === undefined) return
 

--- a/src/helper/html-escape.ts
+++ b/src/helper/html-escape.ts
@@ -11,6 +11,6 @@ const ESCAPE_LOOKUP: { [match: string]: string } = {
 
 const ESCAPE_REGEX = /[&><\u2028\u2029]/g
 
-export function htmlEscapeJsonString(str: string): string {
+export function htmlEscapeString(str: string): string {
   return str.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match])
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,7 +8,7 @@ import Document, {
 import { ServerStyleSheet } from 'styled-components'
 
 import { getInstanceDataByLang } from '@/helper/feature-i18n'
-import { htmlEscapeJsonString } from '@/helper/html-escape'
+import { htmlEscapeString } from '@/helper/html-escape'
 
 const bodyStyles = {
   margin: 0,
@@ -117,7 +117,7 @@ export default class MyDocument extends Document {
               type="application/json"
               id="__FRONTEND_CLIENT_INSTANCE_DATA__"
               dangerouslySetInnerHTML={{
-                __html: htmlEscapeJsonString(JSON.stringify(langData)),
+                __html: htmlEscapeString(JSON.stringify(langData)),
               }}
             />
           )}


### PR DESCRIPTION
closes #770

Not sure about the need to escape.
Chose not to use `<Link/>` to keep it simple. 
(downside: serlo links will be treated like external links, but's still better than link-stings? 😄)