### PR TITLE
Refactor pages

### DIFF
--- a/src/components/content/entity.tsx
+++ b/src/components/content/entity.tsx
@@ -78,7 +78,7 @@ export function Entity({ data }: EntityProps) {
     if (!data.title) return null
 
     return (
-      <StyledH1 extraMarginTop itemProp="name">
+      <StyledH1 spaceAbove itemProp="name">
         {data.title}
         {renderEntityIcon()}
       </StyledH1>

--- a/src/components/content/page-title.tsx
+++ b/src/components/content/page-title.tsx
@@ -1,0 +1,22 @@
+import Head from 'next/head'
+import React from 'react'
+
+import { StyledH1 } from '../tags/styled-h1'
+
+type PageTitleProps = React.PropsWithChildren<{
+  headTitle?: boolean
+  title: string
+}>
+
+export function PageTitle({ headTitle, title }: PageTitleProps) {
+  return (
+    <>
+      {headTitle && (
+        <Head>
+          <title>{title}</title>
+        </Head>
+      )}
+      <StyledH1 extraSpaceAbove>{title}</StyledH1>
+    </>
+  )
+}

--- a/src/components/header-footer.tsx
+++ b/src/components/header-footer.tsx
@@ -6,13 +6,12 @@ import { Header } from './navigation/header'
 
 export interface HeaderFooterProps {
   children: React.ReactNode
-  onSearchPage?: boolean
 }
 
-export function HeaderFooter({ children, onSearchPage }: HeaderFooterProps) {
+export function HeaderFooter({ children }: HeaderFooterProps) {
   return (
     <>
-      <Header onSearchPage={onSearchPage} />
+      <Header />
       <MinHeightDiv className="_">{children}</MinHeightDiv>
       <Footer />
     </>

--- a/src/components/navigation/header.tsx
+++ b/src/components/navigation/header.tsx
@@ -11,11 +11,7 @@ import { useAuth } from '@/auth/use-auth'
 import { useInstanceData } from '@/contexts/instance-context'
 import { makeResponsivePadding } from '@/helper/css'
 
-interface HeaderProps {
-  onSearchPage?: boolean
-}
-
-export function Header({ onSearchPage }: HeaderProps) {
+export function Header() {
   const [isOpen, setOpen] = React.useState(false)
   const auth = useAuth()
   const { headerData, strings } = useInstanceData()
@@ -32,7 +28,7 @@ export function Header({ onSearchPage }: HeaderProps) {
         <Menu data={headerData} auth={auth.current} />
         <Logo subline={strings.header.slogan} />
       </PaddedDiv>
-      <SearchInput onSearchPage={onSearchPage} />
+      <SearchInput />
       {isOpen && <MobileMenu data={headerData} auth={auth.current} />}
     </BlueHeader>
   )

--- a/src/components/navigation/search-input.tsx
+++ b/src/components/navigation/search-input.tsx
@@ -15,10 +15,6 @@ import { replacePlaceholders } from '@/helper/replace-placeholders'
 import { ExternalProvider, useConsent } from '@/helper/use-consent'
 import { theme } from '@/theme'
 
-interface SearchInputProps {
-  onSearchPage?: boolean
-}
-
 /*
 This components starts with only a placeholder that looks like a searchbar (basically a button).
 When activated (by click) it loads the Google Custom Search scrips that generate the real input button and alot of markup.
@@ -27,7 +23,7 @@ From this point on it's a styled GSC that loads /search to display the results.
 It's a very hacky, but it's free and works … okay.
 */
 
-export function SearchInput({ onSearchPage }: SearchInputProps) {
+export function SearchInput() {
   const [searchLoaded, setSearchLoaded] = React.useState(false)
   const [searchActive, setSearchActive] = React.useState(false)
   const [consentJustGiven, setConsentJustGiven] = React.useState(false)
@@ -38,6 +34,7 @@ export function SearchInput({ onSearchPage }: SearchInputProps) {
   // const [isSearchPage, setIsSearchPage] = React.useState(false)
   const { lang, strings } = useInstanceData()
   const router = useRouter()
+  const onSearchPage = router.route === '/search'
 
   React.useEffect(() => {
     // note: find a better way to tell search input that it should activate itself

--- a/src/components/page-base-default.tsx
+++ b/src/components/page-base-default.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { HeaderFooter } from './header-footer'
 import { MaxWidthDiv } from './navigation/max-width-div'
 import { RelativeContainer } from './navigation/relative-container'
 
@@ -11,13 +10,11 @@ export type PageBaseDefaultProps = React.PropsWithChildren<{
 export function PageBaseDefault({ children, showNav }: PageBaseDefaultProps) {
   return (
     <>
-      <HeaderFooter>
-        <RelativeContainer>
-          <MaxWidthDiv showNav={showNav}>
-            <main>{children}</main>
-          </MaxWidthDiv>
-        </RelativeContainer>
-      </HeaderFooter>
+      <RelativeContainer>
+        <MaxWidthDiv showNav={showNav}>
+          <main>{children}</main>
+        </MaxWidthDiv>
+      </RelativeContainer>
     </>
   )
 }

--- a/src/components/page-base-default.tsx
+++ b/src/components/page-base-default.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { HeaderFooter } from './header-footer'
+import { MaxWidthDiv } from './navigation/max-width-div'
+import { RelativeContainer } from './navigation/relative-container'
+
+export type PageBaseDefaultProps = React.PropsWithChildren<{
+  showNav?: boolean
+}>
+
+export function PageBaseDefault({ children, showNav }: PageBaseDefaultProps) {
+  return (
+    <>
+      <HeaderFooter>
+        <RelativeContainer>
+          <MaxWidthDiv showNav={showNav}>
+            <main>{children}</main>
+          </MaxWidthDiv>
+        </RelativeContainer>
+      </HeaderFooter>
+    </>
+  )
+}

--- a/src/components/pages/consent-page.tsx
+++ b/src/components/pages/consent-page.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { PageTitle } from '../content/page-title'
 import { StyledA } from '../tags/styled-a'
-import { HSpace } from '@/components/content/h-space'
-import { MaxWidthDiv } from '@/components/navigation/max-width-div'
-import { StyledH1 } from '@/components/tags/styled-h1'
 import { StyledH2 } from '@/components/tags/styled-h2'
 import { StyledP } from '@/components/tags/styled-p'
 import { StyledTable } from '@/components/tags/styled-table'
@@ -25,9 +23,8 @@ export function ConsentPage() {
   ).filter((provider) => checkConsent(provider))
 
   return (
-    <MaxWidthDiv>
-      <HSpace amount={100} />
-      <StyledH1>{strings.consent.title}</StyledH1>
+    <>
+      <PageTitle title={strings.consent.title} headTitle />
 
       <StyledP>
         {replacePlaceholders(strings.consent.intro, {
@@ -43,7 +40,7 @@ export function ConsentPage() {
           {consentedProviders.length > 0 ? renderTable() : renderEmpty()}
         </tbody>
       </StyledTable>
-    </MaxWidthDiv>
+    </>
   )
 
   function renderEmpty() {

--- a/src/components/pages/error-page.tsx
+++ b/src/components/pages/error-page.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { PageTitle } from '../content/page-title'
 import { HSpace } from '@/components/content/h-space'
 import { MaxWidthDiv } from '@/components/navigation/max-width-div'
 import { RelativeContainer } from '@/components/navigation/relative-container'
 import { StyledA } from '@/components/tags/styled-a'
-import { StyledH1 } from '@/components/tags/styled-h1'
 import { StyledP } from '@/components/tags/styled-p'
 import { useInstanceData } from '@/contexts/instance-context'
 import { ErrorData } from '@/data-types'
@@ -43,8 +43,7 @@ export function ErrorPage({ code, message }: ErrorData) {
   return (
     <RelativeContainer>
       <MaxWidthDiv>
-        <HSpace amount={100} />
-        <StyledH1>{strings.errors.title}</StyledH1>
+        <PageTitle title={strings.errors.title} headTitle />
         <_StyledP>
           {strings.errors.defaultMessage}{' '}
           {!isProbablyTemporary && (

--- a/src/components/pages/search.tsx
+++ b/src/components/pages/search.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { HeadTags } from '../head-tags'
+import { MaxWidthDiv } from '../navigation/max-width-div'
 import { SearchResults } from '@/components/navigation/search-results'
 import { useInstanceData } from '@/contexts/instance-context'
 
@@ -42,9 +43,11 @@ export function Search() {
   return (
     <>
       <HeadTags data={{ title: `Serlo.org - ${strings.header.search}` }} />
-      <StyledSearchResults>
-        <div id="gcs-results"></div>
-      </StyledSearchResults>
+      <MaxWidthDiv>
+        <StyledSearchResults>
+          <div id="gcs-results"></div>
+        </StyledSearchResults>
+      </MaxWidthDiv>
     </>
   )
 }

--- a/src/components/pages/user/notifications.tsx
+++ b/src/components/pages/user/notifications.tsx
@@ -9,7 +9,7 @@ import { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
 import { useGraphqlSwrPaginationWithAuth } from '@/api/use-graphql-swr'
 import { useAuth } from '@/auth/use-auth'
 import { Link } from '@/components/content/link'
-import { StyledH1 } from '@/components/tags/styled-h1'
+import { PageTitle } from '@/components/content/page-title'
 import { StyledP } from '@/components/tags/styled-p'
 import { Notification, NotificationEvent } from '@/components/user/notification'
 import { useInstanceData } from '@/contexts/instance-context'
@@ -290,7 +290,7 @@ export const Notifications: NextPage = () => {
     const title = strings.notifications.notifications
     return (
       <>
-        <StyledH1 extraMarginTop>{title}</StyledH1>
+        <PageTitle title={title} headTitle />
         <Wrapper>{children}</Wrapper>
       </>
     )

--- a/src/components/pages/user/notifications.tsx
+++ b/src/components/pages/user/notifications.tsx
@@ -9,8 +9,6 @@ import { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
 import { useGraphqlSwrPaginationWithAuth } from '@/api/use-graphql-swr'
 import { useAuth } from '@/auth/use-auth'
 import { Link } from '@/components/content/link'
-import { MaxWidthDiv } from '@/components/navigation/max-width-div'
-import { RelativeContainer } from '@/components/navigation/relative-container'
 import { StyledH1 } from '@/components/tags/styled-h1'
 import { StyledP } from '@/components/tags/styled-p'
 import { Notification, NotificationEvent } from '@/components/user/notification'
@@ -289,17 +287,12 @@ export const Notifications: NextPage = () => {
   )
 
   function wrapInContainer(children: JSX.Element) {
+    const title = strings.notifications.notifications
     return (
-      <RelativeContainer>
-        <MaxWidthDiv showNav>
-          <main>
-            <StyledH1 extraMarginTop>
-              {strings.notifications.notifications}
-            </StyledH1>
-            <Wrapper>{children}</Wrapper>
-          </main>
-        </MaxWidthDiv>
-      </RelativeContainer>
+      <>
+        <StyledH1 extraMarginTop>{title}</StyledH1>
+        <Wrapper>{children}</Wrapper>
+      </>
     )
   }
 

--- a/src/components/pages/user/profile-redirect-me.tsx
+++ b/src/components/pages/user/profile-redirect-me.tsx
@@ -5,8 +5,6 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { useAuth } from '@/auth/use-auth'
-import { MaxWidthDiv } from '@/components/navigation/max-width-div'
-import { RelativeContainer } from '@/components/navigation/relative-container'
 
 //fallback for legacy routes /user/me and /user/public
 
@@ -22,13 +20,9 @@ export const ProfileRedirectMe: NextPage = () => {
   }, [auth])
 
   return (
-    <RelativeContainer>
-      <MaxWidthDiv>
-        <ColoredIcon>
-          <FontAwesomeIcon icon={faSpinner} spin size="2x" />
-        </ColoredIcon>
-      </MaxWidthDiv>
-    </RelativeContainer>
+    <ColoredIcon>
+      <FontAwesomeIcon icon={faSpinner} spin size="2x" />
+    </ColoredIcon>
   )
 }
 

--- a/src/components/pages/user/profile.tsx
+++ b/src/components/pages/user/profile.tsx
@@ -7,9 +7,9 @@ import { ProfileDonationForm } from './profile-donation-form'
 import { useAuth } from '@/auth/use-auth'
 import { Comments } from '@/components/comments/comments'
 import { HSpace } from '@/components/content/h-space'
+import { PageTitle } from '@/components/content/page-title'
 import { MaxWidthDiv } from '@/components/navigation/max-width-div'
 import { RelativeContainer } from '@/components/navigation/relative-container'
-import { StyledH1 } from '@/components/tags/styled-h1'
 import { StyledH2 } from '@/components/tags/styled-h2'
 import { StyledP } from '@/components/tags/styled-p'
 import { TimeAgo } from '@/components/time-ago'
@@ -33,8 +33,8 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
   return (
     <RelativeContainer>
       <MaxWidthDiv>
-        <HSpace amount={50} />
-        <StyledH1>{username}</StyledH1>
+        <PageTitle title={username} headTitle />
+
         <StyledP></StyledP>
         {lang === 'de' && renderCommunityFeatures()}
         {description && (

--- a/src/components/tags/styled-h1.tsx
+++ b/src/components/tags/styled-h1.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components'
 
 interface StyledH1Props {
-  extraMarginTop?: boolean
+  spaceAbove?: boolean
+  extraSpaceAbove?: boolean
 }
 
 export const StyledH1 = styled.h1<StyledH1Props>`
-  margin-top: ${(props) => (props.extraMarginTop ? '46px' : '15px')};
+  margin-top: ${(props) =>
+    props.spaceAbove ? '46px' : props.extraSpaceAbove ? '80px' : '15px'};
   margin-left: 15px;
   font-size: 2rem;
   padding: 0;

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -80,6 +80,7 @@ export type PageData =
   | RevisionPage
   | TaxonomyPage
   | UserPage
+  | DonationPage
 
 // The landing page is custom built and takes i18n strings
 
@@ -113,6 +114,12 @@ export type LandingSubjectIcon =
   | 'biology'
   | 'sustainability'
   | 'chemistry'
+
+// Error page has some additional data
+
+export interface DonationPage {
+  kind: 'donation'
+}
 
 // Error page has some additional data
 

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -32,7 +32,6 @@ const Revision = dynamic<RevisionProps>(() =>
 
 const PageView: NextPage<InitialProps> = (initialProps) => {
   const page = initialProps.pageData
-  console.log(page.kind)
   if (page === undefined) return <ErrorPage code={404} />
   if (page.kind === 'error') {
     return (

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,8 +6,6 @@ import { RevisionProps } from '@/components/author/revision'
 import { EntityProps } from '@/components/content/entity'
 import { TopicProps } from '@/components/content/topic'
 import { EntityBaseProps } from '@/components/entity-base'
-import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
 import { ProfileProps } from '@/components/pages/user/profile'
 import { InitialProps, ErrorData, PageData } from '@/data-types'
 import { fetchPageData } from '@/fetcher/fetch-page-data'
@@ -34,47 +32,32 @@ const Revision = dynamic<RevisionProps>(() =>
 
 const PageView: NextPage<InitialProps> = (initialProps) => {
   const page = initialProps.pageData
+  console.log(page.kind)
   if (page === undefined) return <ErrorPage code={404} />
+  if (page.kind === 'error') {
+    return (
+      <ErrorPage code={page.errorData.code} message={page.errorData.message} />
+    )
+  }
+  if (page.kind === 'user/profile') {
+    return <Profile userData={page.userData} />
+  }
+  if (page.kind === 'license-detail' || page.kind === 'donation') {
+    return null // have own pages…
+  }
 
-  // all other kinds are using basic layout
-  // render it together to avoid remounting
-  return (
-    <FrontendClientBase>
-      <HeaderFooter>
-        {(() => {
-          if (page.kind === 'user/profile') {
-            return <Profile userData={page.userData} />
-          }
-          if (page.kind === 'error') {
-            return (
-              <ErrorPage
-                code={page.errorData.code}
-                message={page.errorData.message}
-              />
-            )
-          }
-          return (
-            <EntityBase page={page}>
-              {(() => {
-                if (page.kind === 'license-detail') {
-                  return 'are you a wizard?' //license has a own page
-                }
-                if (page.kind === 'single-entity') {
-                  return <Entity data={page.entityData} />
-                }
-                if (page.kind === 'revision') {
-                  return <Revision data={page.revisionData} />
-                } else {
-                  /* taxonomy */
-                  return <Topic data={page.taxonomyData} />
-                }
-              })()}
-            </EntityBase>
-          )
-        })()}
-      </HeaderFooter>
-    </FrontendClientBase>
-  )
+  const entity =
+    page.kind === 'single-entity' ? (
+      <Entity data={page.entityData} />
+    ) : page.kind === 'revision' ? (
+      <Revision data={page.revisionData} />
+    ) : page.kind === 'taxonomy' ? (
+      <Topic data={page.taxonomyData} />
+    ) : (
+      'are you a wizard?'
+    )
+
+  return <EntityBase page={page}>{entity}</EntityBase>
 }
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getStaticProps: GetStaticProps = async (context) => {

--- a/src/pages/___explore.tsx
+++ b/src/pages/___explore.tsx
@@ -1,15 +1,7 @@
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
 import { Explore } from '@/components/pages/explore'
 
 export default function Page() {
-  return (
-    <FrontendClientBase>
-      <HeaderFooter>
-        <Explore />
-      </HeaderFooter>
-    </FrontendClientBase>
-  )
+  return <Explore />
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { config } from '@fortawesome/fontawesome-svg-core'
 // eslint-disable-next-line import/no-unassigned-import
 import '@fortawesome/fontawesome-svg-core/styles.css'
-import { AppProps } from 'next/app'
+import { NextComponentType, NextPageContext } from 'next'
 import Router from 'next/router'
 import NProgress from 'nprogress'
 import React from 'react'
@@ -10,7 +10,10 @@ import { ThemeProvider } from 'styled-components'
 import '@/assets-webkit/fonts/karmilla.css'
 import '@/assets-webkit/fonts/katex/katex.css'
 
+import { FrontendClientBase } from '@/components/frontend-client-base'
+import { HeaderFooter } from '@/components/header-footer'
 import { NProgressStyles } from '@/components/navigation/n-progress-styles'
+import { InitialProps } from '@/data-types'
 import { FontFix } from '@/helper/css'
 import { theme } from '@/theme'
 
@@ -54,14 +57,28 @@ Router.events.on('routeChangeStart', () => {
 Router.events.on('routeChangeComplete', () => NProgress.done())
 Router.events.on('routeChangeError', () => NProgress.done())
 
-// eslint-disable-next-line import/no-default-export
-export default function App({ Component, pageProps }: AppProps) {
+interface CustomAppProps {
+  Component: NextComponentType<NextPageContext, any, InitialProps>
+  pageProps: InitialProps
+}
+
+export default function App({ Component, pageProps }: CustomAppProps) {
+  const noHeaderFooter = pageProps.pageData?.kind === 'donation'
+
   return (
     <React.StrictMode>
       <ThemeProvider theme={theme}>
         <FontFix />
         <NProgressStyles />
-        <Component {...pageProps} />
+        <FrontendClientBase>
+          {noHeaderFooter ? (
+            <Component {...pageProps} />
+          ) : (
+            <HeaderFooter>
+              <Component {...pageProps} />
+            </HeaderFooter>
+          )}
+        </FrontendClientBase>
       </ThemeProvider>
     </React.StrictMode>
   )

--- a/src/pages/consent.tsx
+++ b/src/pages/consent.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
 import { PageBaseDefault } from '@/components/page-base-default'
 import { ConsentPage } from '@/components/pages/consent-page'
 
 export default function Page() {
   return (
-    <FrontendClientBase>
-      <PageBaseDefault>
-        <ConsentPage />
-      </PageBaseDefault>
-    </FrontendClientBase>
+    <PageBaseDefault>
+      <ConsentPage />
+    </PageBaseDefault>
   )
 }

--- a/src/pages/consent.tsx
+++ b/src/pages/consent.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
 
 import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
-import { RelativeContainer } from '@/components/navigation/relative-container'
+import { PageBaseDefault } from '@/components/page-base-default'
 import { ConsentPage } from '@/components/pages/consent-page'
 
 export default function Page() {
   return (
     <FrontendClientBase>
-      <RelativeContainer>
-        <HeaderFooter>
-          <ConsentPage />
-        </HeaderFooter>
-      </RelativeContainer>
+      <PageBaseDefault>
+        <ConsentPage />
+      </PageBaseDefault>
     </FrontendClientBase>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,8 +2,6 @@ import { GetStaticProps, NextPage } from 'next'
 import { useRouter } from 'next/router'
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
 import { LandingDE } from '@/components/pages/landing-de'
 import { LandingInternational } from '@/components/pages/landing-international'
 import { LandingPage } from '@/data-types'
@@ -11,17 +9,9 @@ import { getLandingData } from '@/helper/feature-i18n'
 
 const Page: NextPage<{ pageData: LandingPage }> = ({ pageData }) => {
   const { locale } = useRouter()
-  return (
-    <FrontendClientBase>
-      <HeaderFooter>
-        {locale == 'de' ? (
-          <LandingDE data={pageData.landingData} />
-        ) : (
-          <LandingInternational data={pageData.landingData} />
-        )}
-      </HeaderFooter>
-    </FrontendClientBase>
-  )
+
+  if (locale == 'de') return <LandingDE data={pageData.landingData} />
+  return <LandingInternational data={pageData.landingData} />
 }
 
 export default Page

--- a/src/pages/license/detail/[id].tsx
+++ b/src/pages/license/detail/[id].tsx
@@ -2,8 +2,6 @@ import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 import React from 'react'
 
 import { EntityBase } from '@/components/entity-base'
-import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
 import { ErrorPage } from '@/components/pages/error-page'
 import { LicenseDetail } from '@/components/pages/license-detail'
 import { InitialProps, LicenseDetailPage } from '@/data-types'
@@ -15,13 +13,9 @@ const PageView: NextPage<InitialProps> = (initialProps) => {
   if (page === undefined) return <ErrorPage code={404} />
 
   return (
-    <FrontendClientBase>
-      <HeaderFooter>
-        <EntityBase page={page}>
-          <LicenseDetail {...page.licenseData} />
-        </EntityBase>
-      </HeaderFooter>
-    </FrontendClientBase>
+    <EntityBase page={page}>
+      <LicenseDetail {...page.licenseData} />
+    </EntityBase>
   )
 }
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,15 +1,7 @@
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
 import { Search } from '@/components/pages/search'
 
 export default function Page() {
-  return (
-    <FrontendClientBase>
-      <HeaderFooter onSearchPage>
-        <Search />
-      </HeaderFooter>
-    </FrontendClientBase>
-  )
+  return <Search />
 }

--- a/src/pages/spenden.tsx
+++ b/src/pages/spenden.tsx
@@ -1,12 +1,19 @@
+import { GetStaticProps } from 'next'
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
 import { Donations } from '@/components/pages/donations'
 
 export default function Page() {
-  return (
-    <FrontendClientBase>
-      <Donations />
-    </FrontendClientBase>
-  )
+  return <Donations />
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {
+      pageData: {
+        kind: 'donation',
+      },
+    },
+  }
 }

--- a/src/pages/user/me.tsx
+++ b/src/pages/user/me.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
 import { PageBaseDefault } from '@/components/page-base-default'
 import { ProfileRedirectMe } from '@/components/pages/user/profile-redirect-me'
 
 export default function Page() {
   return (
-    <FrontendClientBase>
-      <PageBaseDefault>
-        <ProfileRedirectMe />
-      </PageBaseDefault>
-    </FrontendClientBase>
+    <PageBaseDefault>
+      <ProfileRedirectMe />
+    </PageBaseDefault>
   )
 }

--- a/src/pages/user/me.tsx
+++ b/src/pages/user/me.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
 import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
+import { PageBaseDefault } from '@/components/page-base-default'
 import { ProfileRedirectMe } from '@/components/pages/user/profile-redirect-me'
 
 export default function Page() {
   return (
     <FrontendClientBase>
-      <HeaderFooter>
+      <PageBaseDefault>
         <ProfileRedirectMe />
-      </HeaderFooter>
+      </PageBaseDefault>
     </FrontendClientBase>
   )
 }

--- a/src/pages/user/notifications.tsx
+++ b/src/pages/user/notifications.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
 import { FrontendClientBase } from '@/components/frontend-client-base'
-import { HeaderFooter } from '@/components/header-footer'
+import { PageBaseDefault } from '@/components/page-base-default'
 import { Notifications } from '@/components/pages/user/notifications'
 
 export default function Page() {
   return (
     <FrontendClientBase>
-      <HeaderFooter>
+      <PageBaseDefault>
         <Notifications />
-      </HeaderFooter>
+      </PageBaseDefault>
     </FrontendClientBase>
   )
 }

--- a/src/pages/user/notifications.tsx
+++ b/src/pages/user/notifications.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 
-import { FrontendClientBase } from '@/components/frontend-client-base'
 import { PageBaseDefault } from '@/components/page-base-default'
 import { Notifications } from '@/components/pages/user/notifications'
 
 export default function Page() {
   return (
-    <FrontendClientBase>
-      <PageBaseDefault>
-        <Notifications />
-      </PageBaseDefault>
-    </FrontendClientBase>
+    <PageBaseDefault>
+      <Notifications />
+    </PageBaseDefault>
   )
 }


### PR DESCRIPTION
Most important change:  Moved `FrontendClientBase` and `HeaderFooter` to `_app`. 
This way we can always access i18n strings and have less renders again.

@Entkenntnis any objections? This way it should not screw with packets, right?


This is how a simple page looks now, I like ^^
``` tsx
import React from 'react'

import { Search } from '@/components/pages/search'

export default function Page() {
  return <Search />
}

```