### PR TITLE
Comments: add invitation to log in or start thread

### DIFF
--- a/src/components/comments/comment-area.tsx
+++ b/src/components/comments/comment-area.tsx
@@ -55,8 +55,10 @@ export function CommentArea({ id: entityId, noForms }: CommentAreaProps) {
   return (
     <div ref={container}>
       <Guard data={commentData} error={error}>
-        {renderStartThreadForm()}
-        {renderContent()}
+        <>
+          {renderStartThreadForm()}
+          {renderContent()}
+        </>
       </Guard>
     </div>
   )

--- a/src/components/comments/comment-area.tsx
+++ b/src/components/comments/comment-area.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import { Lazy } from '../content/lazy'
 import { Guard } from '../guard'
+import { PleaseLogIn } from '../user/please-log-in'
 import { CommentArchive } from './comment-archive'
 import { CommentForm } from './comment-form'
 import { Thread } from './thread'
@@ -54,6 +55,7 @@ export function CommentArea({ id: entityId, noForms }: CommentAreaProps) {
   return (
     <div ref={container}>
       <Guard data={commentData} error={error}>
+        {renderStartThreadForm()}
         {renderContent()}
       </Guard>
     </div>
@@ -65,18 +67,6 @@ export function CommentArea({ id: entityId, noForms }: CommentAreaProps) {
 
     return (
       <>
-        {!noForms && auth.current && (
-          <>
-            <CustomH2 id="comments">
-              <StyledIcon icon={faQuestionCircle} /> {strings.comments.question}
-            </CustomH2>
-            <CommentForm
-              placeholder={strings.comments.placeholder}
-              onSend={onSend}
-            />
-          </>
-        )}
-
         {commentCount > 0 && (
           <>
             <CustomH2>
@@ -92,6 +82,25 @@ export function CommentArea({ id: entityId, noForms }: CommentAreaProps) {
               {renderArchive()}
             </Lazy>
           </>
+        )}
+      </>
+    )
+  }
+
+  function renderStartThreadForm() {
+    if (noForms) return null
+    return (
+      <>
+        <CustomH2 id="comments">
+          <StyledIcon icon={faQuestionCircle} /> {strings.comments.question}
+        </CustomH2>
+        {auth.current === null ? (
+          <PleaseLogIn />
+        ) : (
+          <CommentForm
+            placeholder={strings.comments.placeholder}
+            onSend={onSend}
+          />
         )}
       </>
     )


### PR DESCRIPTION
- Always shows either form to start a new thread or the invitation to log in to do so.
- Uses `<PleaseLogIn>` component that uses a generic "log in to use this function" that we could make more specific in the future.

closes #845