### PR TITLE
make license notice detailed for non cc licenses

### DIFF
--- a/src/components/content/injection.tsx
+++ b/src/components/content/injection.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect } from 'react'
 
 import { LoadingSpinner } from '../loading/loading-spinner'
-import { StyledP } from '../tags/styled-p'
-import { LicenseNotice } from './license-notice'
 import { useInstanceData } from '@/contexts/instance-context'
-import { LicenseData, SlugPageData, FrontendContentNode } from '@/data-types'
+import { SlugPageData, FrontendContentNode } from '@/data-types'
 import type { RenderNestedFunction } from '@/schema/article-renderer'
 
 export interface InjectionProps {
@@ -21,7 +19,7 @@ export function Injection({ href, renderNested }: InjectionProps) {
 
   const [id, setId] = useState<number | undefined>(undefined)
 
-  const [license, setLicense] = useState<undefined | LicenseData>(undefined)
+  //const [license, setLicense] = useState<undefined | LicenseData>(undefined)
 
   const { lang } = useInstanceData()
 
@@ -71,9 +69,6 @@ export function Injection({ href, renderNested }: InjectionProps) {
     if (pageData.kind === 'single-entity') {
       setId(pageData.entityData.id)
       setValue(pageData.entityData.content)
-      if (pageData.entityData.licenseData) {
-        setLicense(pageData.entityData.licenseData)
-      }
     }
     if (pageData.kind === 'error') {
       if (pageData.errorData.message) {
@@ -91,16 +86,7 @@ export function Injection({ href, renderNested }: InjectionProps) {
     //Show only video without description when injecting
     const renderValue = value[0].type === 'video' ? [value[0]] : value
 
-    return (
-      <>
-        {renderNested(renderValue, `injection${id}`)}
-        {license && !license.default && (
-          <StyledP>
-            <LicenseNotice minimal data={license} type="video" />
-          </StyledP>
-        )}
-      </>
-    )
+    return <>{renderNested(renderValue, `injection${id}`)}</>
   }
   return <LoadingSpinner />
 }

--- a/src/components/content/license-notice.tsx
+++ b/src/components/content/license-notice.tsx
@@ -12,11 +12,12 @@ import { StyledA } from '../tags/styled-a'
 import { Link } from './link'
 import { useInstanceData } from '@/contexts/instance-context'
 import { LicenseData } from '@/data-types'
+import { replacePlaceholders } from '@/helper/replace-placeholders'
 
 interface LicenseNoticeProps {
   data: LicenseData
   minimal?: boolean
-  type?: string
+  type?: 'video' | 'task' | 'exercise-group' | 'solution'
 }
 
 export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
@@ -73,39 +74,44 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
 
   function renderMinimalNotice() {
     const typeString = translateTypeString()
+    const licenseHref = `/license/detail/${data.id}`
     return (
-      <MinimalLink
-        href={`/license/detail/${data.id}`}
-        title={typeString ? typeString + ': ' + data.title : data.title}
-        noExternalIcon
-      >
-        {isCreativeCommons ? (
-          <FontAwesomeIcon icon={faCreativeCommons} />
-        ) : (
-          <span className="fa-layers fa-fw">
+      <>
+        <MinimalLink
+          title={strings.license.nonFree}
+          href={licenseHref}
+          noExternalIcon
+        >
+          {isCreativeCommons ? (
             <FontAwesomeIcon icon={faCreativeCommons} />
-            <FontAwesomeIcon
-              icon={faSlash}
-              flip="horizontal"
-              transform="shrink-6"
-            />
-          </span>
+          ) : (
+            <span className="fa-layers fa-fw">
+              <FontAwesomeIcon icon={faCreativeCommons} />
+              <FontAwesomeIcon
+                icon={faSlash}
+                flip="horizontal"
+                transform="shrink-6"
+              />
+            </span>
+          )}
+        </MinimalLink>
+        {!isCreativeCommons && (
+          <SmallLicenseInfo>
+            {' '}
+            {replacePlaceholders(strings.license.licenseFor, {
+              contenttype: typeString,
+            })}
+            : <Link href={licenseHref}>{data.title}</Link>
+          </SmallLicenseInfo>
         )}
-      </MinimalLink>
+      </>
     )
   }
 
-  function translateTypeString() {
-    switch (type) {
-      case 'video':
-        return strings.entities.video
-      case 'task':
-      case 'exercise-group':
-        return strings.content.task
-      case 'solution':
-        return strings.entities.solution
-    }
-    return type
+  function translateTypeString(): string {
+    if (type == 'task') return strings.content.task
+    if (type == 'exercise-group') return strings.content.task
+    return strings.entities[type || 'content']
   }
 }
 
@@ -124,6 +130,11 @@ const MinimalLink = styled(Link)`
     vertical-align: -0.168em;
     margin-left: 0.009em;
   }
+`
+
+const SmallLicenseInfo = styled.span`
+  font-size: 1rem;
+  vertical-align: text-top;
 `
 
 const StyledSmall = styled.span`

--- a/src/components/content/license-notice.tsx
+++ b/src/components/content/license-notice.tsx
@@ -74,13 +74,17 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
   function renderMinimalNotice() {
     const typeString = translateTypeString()
     const licenseHref = `/license/detail/${data.id}`
+
+    const text = `${typeString}: ${
+      data.shortTitle ? data.shortTitle : strings.license.special
+    }`
+    const title = isCreativeCommons
+      ? data.title
+      : `${data.title} –– ${strings.license.nonFree}`
+
     return (
       <>
-        <MinimalLink
-          title={data.title + ' –– ' + strings.license.nonFree}
-          href={licenseHref}
-          noExternalIcon
-        >
+        <MinimalLink title={title} href={licenseHref} noExternalIcon>
           {data.default ? (
             <FontAwesomeIcon icon={faCreativeCommons} />
           ) : (
@@ -95,7 +99,7 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
                   />
                 )}
               </StyledIcon>
-              {typeString}: {strings.license.special}
+              {text}
             </>
           )}
         </MinimalLink>

--- a/src/components/content/license-notice.tsx
+++ b/src/components/content/license-notice.tsx
@@ -12,7 +12,6 @@ import { StyledA } from '../tags/styled-a'
 import { Link } from './link'
 import { useInstanceData } from '@/contexts/instance-context'
 import { LicenseData } from '@/data-types'
-import { replacePlaceholders } from '@/helper/replace-placeholders'
 
 interface LicenseNoticeProps {
   data: LicenseData
@@ -78,32 +77,28 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
     return (
       <>
         <MinimalLink
-          title={strings.license.nonFree}
+          title={data.title + ' –– ' + strings.license.nonFree}
           href={licenseHref}
           noExternalIcon
         >
-          {isCreativeCommons ? (
+          {data.default ? (
             <FontAwesomeIcon icon={faCreativeCommons} />
           ) : (
-            <span className="fa-layers fa-fw">
-              <FontAwesomeIcon icon={faCreativeCommons} />
-              <FontAwesomeIcon
-                icon={faSlash}
-                flip="horizontal"
-                transform="shrink-6"
-              />
-            </span>
+            <>
+              <StyledIcon className="fa-layers fa-fw">
+                <FontAwesomeIcon icon={faCreativeCommons} />
+                {!isCreativeCommons && (
+                  <FontAwesomeIcon
+                    icon={faSlash}
+                    flip="horizontal"
+                    transform="shrink-6"
+                  />
+                )}
+              </StyledIcon>
+              {typeString}: {strings.license.special}
+            </>
           )}
         </MinimalLink>
-        {!isCreativeCommons && (
-          <SmallLicenseInfo>
-            {' '}
-            {replacePlaceholders(strings.license.licenseFor, {
-              contenttype: typeString,
-            })}
-            : <Link href={licenseHref}>{data.title}</Link>
-          </SmallLicenseInfo>
-        )}
       </>
     )
   }
@@ -117,24 +112,15 @@ export function LicenseNotice({ data, minimal, type }: LicenseNoticeProps) {
 
 const MinimalLink = styled(Link)`
   ${makeTransparentButton}
-  text-align: center;
-  color: ${(props) => props.theme.colors.dark1};
-  background-color: ${(props) => props.theme.colors.lightBackground};
-  font-size: 1.3rem;
-  line-height: 2rem;
-  width: 2rem;
-  height: 2rem;
-  padding: 0;
-
-  > svg {
-    vertical-align: -0.168em;
-    margin-left: 0.009em;
-  }
+  font-weight: normal;
+  font-size: 1rem;
+  height: max-content;
 `
 
-const SmallLicenseInfo = styled.span`
-  font-size: 1rem;
-  vertical-align: text-top;
+const StyledIcon = styled.span`
+  font-size: 1.25rem;
+  vertical-align: sub;
+  margin-right: 3px;
 `
 
 const StyledSmall = styled.span`

--- a/src/components/content/video.tsx
+++ b/src/components/content/video.tsx
@@ -3,8 +3,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styled from 'styled-components'
 
 import { StyledP } from '../tags/styled-p'
+import { LicenseNotice } from './license-notice'
 import { PrivacyWrapper } from './privacy-wrapper'
 import { useInstanceData } from '@/contexts/instance-context'
+import { LicenseData } from '@/data-types'
 import { submitEventWithPath } from '@/helper/submit-event'
 import { ExternalProvider } from '@/helper/use-consent'
 import { NodePath } from '@/schema/article-renderer'
@@ -12,12 +14,13 @@ import { NodePath } from '@/schema/article-renderer'
 export interface VideoProps {
   src: string
   path?: NodePath
+  license?: LicenseData
 }
 
 export function Video(props: VideoProps) {
   const { lang } = useInstanceData()
 
-  const { src, path } = props
+  const { src, path, license } = props
 
   const vimeo = /^(https?:\/\/)?(.*?vimeo\.com\/)(.+)/.exec(src)
   if (vimeo) return renderVimeo(vimeo[3])
@@ -57,29 +60,36 @@ export function Video(props: VideoProps) {
 
   function renderVideo(provider: ExternalProvider, iframeUrl?: string) {
     return (
-      <PrivacyWrapper
-        type="video"
-        provider={provider}
-        embedUrl={iframeUrl}
-        onLoad={() => {
-          submitEventWithPath('loadvideo', path)
-        }}
-      >
-        <VideoWrapper className="video">
-          {provider === ExternalProvider.WikimediaCommons && (
-            <video controls src={src} />
-          )}
-          {(provider === ExternalProvider.YouTube ||
-            ExternalProvider.Vimeo) && (
-            <iframe
-              src={iframeUrl}
-              frameBorder="0"
-              allow="autoplay; encrypted-media; picture-in-picture"
-              allowFullScreen
-            />
-          )}
-        </VideoWrapper>
-      </PrivacyWrapper>
+      <>
+        <PrivacyWrapper
+          type="video"
+          provider={provider}
+          embedUrl={iframeUrl}
+          onLoad={() => {
+            submitEventWithPath('loadvideo', path)
+          }}
+        >
+          <VideoWrapper className="video">
+            {provider === ExternalProvider.WikimediaCommons && (
+              <video controls src={src} />
+            )}
+            {(provider === ExternalProvider.YouTube ||
+              ExternalProvider.Vimeo) && (
+              <iframe
+                src={iframeUrl}
+                frameBorder="0"
+                allow="autoplay; encrypted-media; picture-in-picture"
+                allowFullScreen
+              />
+            )}
+          </VideoWrapper>
+        </PrivacyWrapper>
+        {license && !license.default && (
+          <StyledP>
+            <LicenseNotice minimal data={license} type="video" />
+          </StyledP>
+        )}
+      </>
     )
   }
 }

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -610,6 +610,7 @@ export interface FrontendVideoNode {
   type: 'video'
   src: string
   children?: undefined
+  license?: LicenseData
 }
 
 export interface FrontendCodeNode {
@@ -692,6 +693,7 @@ export interface LicenseData {
   url: string // to to license
   id: number // of the license
   default: boolean
+  shortTitle?: number // show this if not default
 }
 
 // Data for a course page.

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -693,7 +693,7 @@ export interface LicenseData {
   url: string // to to license
   id: number // of the license
   default: boolean
-  shortTitle?: number // show this if not default
+  shortTitle?: string // show this if not default
 }
 
 // Data for a course page.

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -79,8 +79,8 @@ export const instanceData = {
     },
     license: {
       readMore: 'Info',
+      special: 'Different license',
       nonFree: 'Usage of this content might be more restricted than our other content.',
-      licenseFor: 'License for this %contenttype%'
     },
     course: {
       showPages: 'Show course overview',

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -78,7 +78,9 @@ export const instanceData = {
       unrevised: 'Show unrevised revisions'
     },
     license: {
-      readMore: 'Info'
+      readMore: 'Info',
+      nonFree: 'Usage of this content might be more restricted than our other content.',
+      licenseFor: 'License for this %contenttype%'
     },
     course: {
       showPages: 'Show course overview',

--- a/src/fetcher/create-exercises.ts
+++ b/src/fetcher/create-exercises.ts
@@ -1,4 +1,5 @@
 import { convertState } from './convert-state'
+import { createInlineLicense } from './create-inline-license'
 import { Solution, BareExercise, BareExerciseGroup } from './query-types'
 import {
   FrontendExerciseNode,
@@ -61,7 +62,7 @@ export function createExercise(
     task: {
       legacy: taskLegacy,
       edtrState: taskEdtrState,
-      license: uuid.license,
+      license: createInlineLicense(uuid.license),
     },
     solution: createSolutionData(uuid.solution),
     context: {
@@ -105,7 +106,7 @@ function createSolutionData(solution: BareExercise['solution']) {
   return {
     legacy: solutionLegacy,
     edtrState: solutionEdtrState,
-    license: solution?.license,
+    license: solution && createInlineLicense(solution.license),
   }
 }
 
@@ -143,7 +144,7 @@ export function createExerciseGroup(
     type: 'exercise-group',
     content: convertState(uuid.currentRevision?.content),
     positionOnPage: pageIndex,
-    license: uuid.license,
+    license: createInlineLicense(uuid.license),
     children,
     context: {
       id: uuid.id,

--- a/src/fetcher/create-inline-license.tsx
+++ b/src/fetcher/create-inline-license.tsx
@@ -1,0 +1,6 @@
+import { License } from './query-types'
+import { LicenseData } from '@/data-types'
+
+export function createInlineLicense(license: License): LicenseData {
+  return license
+}

--- a/src/fetcher/create-inline-license.tsx
+++ b/src/fetcher/create-inline-license.tsx
@@ -1,6 +1,19 @@
 import { License } from './query-types'
 import { LicenseData } from '@/data-types'
 
+// 4, 5, 6, 7, 10, 16, 19
+
+const shortTitles: { [key: number]: string } = {
+  4: '123mathe.de',
+  5: 'BOS Intranet',
+  6: 'strobl-f.de',
+  7: 'raschweb.de',
+  10: 'Standard-Youtube-Lizenz',
+  19: 'schule-bw.de',
+}
+
 export function createInlineLicense(license: License): LicenseData {
-  return license
+  const output: LicenseData = license
+  output.shortTitle = shortTitles[output.id]
+  return output
 }

--- a/src/fetcher/request-page.ts
+++ b/src/fetcher/request-page.ts
@@ -4,6 +4,7 @@ import { convertState } from './convert-state'
 import { createBreadcrumbs } from './create-breadcrumbs'
 import { createExercise, createExerciseGroup } from './create-exercises'
 import { createHorizon } from './create-horizon'
+import { createInlineLicense } from './create-inline-license'
 import { getMetaImage, getMetaDescription } from './create-meta-data'
 import { createNavigation } from './create-navigation'
 import { buildTaxonomyData } from './create-taxonomy'
@@ -248,6 +249,7 @@ export async function requestPage(
           {
             type: 'video',
             src: uuid.currentRevision?.url!,
+            license: createInlineLicense(uuid.license),
           },
           ...content,
         ],

--- a/src/schema/article-renderer.tsx
+++ b/src/schema/article-renderer.tsx
@@ -357,7 +357,7 @@ function renderElement(props: RenderElementProps): React.ReactNode {
   if (element.type === 'video') {
     return (
       <Lazy>
-        <Video src={element.src} path={path} />
+        <Video src={element.src} path={path} license={element.license} />
       </Lazy>
     )
   }


### PR DESCRIPTION
My draft for #636, #870

- Default license: no notice
- Other Licenses: `[icon] [typename]: Different License` all linked to license page with additional hover info for desktops.
- Icon changes depending on CC or non CC

This way we inform users very clearly that the license for this content (relation with easy to understand typename) is different from the usual. Imho this is enough as a first step. For more info ppl have to click / hover. 

Non-cc license under video: http://localhost:3000/1515
CC-License in exercise injection: http://localhost:3000/1565

![image](https://user-images.githubusercontent.com/1258870/107158475-9324d500-698a-11eb-8570-c5ddc668f2fc.png)
![image](https://user-images.githubusercontent.com/1258870/107158400-f7936480-6989-11eb-9638-0d341f25d418.png)

Did not find a non default solution yet.
 We could change `Aufgabe` to `Aufgabenstellung` to make that relation even more clear. But only if it's @inyono wish :)