### PR TITLE
Query always by alias

### DIFF
--- a/__tests__/fetcher/fetch-page-data.ts
+++ b/__tests__/fetcher/fetch-page-data.ts
@@ -430,7 +430,10 @@ describe('check all supported typenames with stored api-data', () => {
           variables: { id?: number; alias?: { path: string; instance: 'de' } }
         }
 
-        if (body.variables.id === 51979) {
+        if (
+          body.variables.alias?.path === '/51979' &&
+          body.variables.alias?.instance === 'de'
+        ) {
           return res(
             ctx.json({
               data: {

--- a/src/fetcher/request-page.ts
+++ b/src/fetcher/request-page.ts
@@ -19,23 +19,9 @@ export async function requestPage(
   alias: string,
   instance: Instance
 ): Promise<SlugPageData> {
-  const isId = /^\/[\d]+$/.test(alias) //e.g. /1565
-  const variables = isId
-    ? {
-        id: parseInt(alias.substring(1), 10),
-      }
-    : {
-        alias: {
-          instance,
-          path: alias,
-        },
-      }
-
-  const { uuid } = await request<{ uuid: QueryResponse }>(
-    endpoint,
-    dataQuery,
-    variables
-  )
+  const { uuid } = await request<{ uuid: QueryResponse }>(endpoint, dataQuery, {
+    alias: { instance, path: alias },
+  })
 
   // Can be deleted if CFWorker redirects those for us
   if (


### PR DESCRIPTION
API supports querys of the form `/:id` and thus there is no need to have
different ways to query for a resource.