### PR TITLE
noindex meta tags

### DIFF
--- a/src/components/entity-base.tsx
+++ b/src/components/entity-base.tsx
@@ -22,7 +22,13 @@ export function EntityBase({ children, page }: EntityBaseProps) {
       {page.secondaryNavigationData && (
         <MetaMenu data={page.secondaryNavigationData} />
       )}
-      {page.metaData && <HeadTags data={page.metaData} />}
+      {page.metaData && (
+        <HeadTags
+          data={page.metaData}
+          breadcrumbsData={page.breadcrumbsData}
+          noindex={'entityData' in page && page.entityData.trashed}
+        />
+      )}
       {page.newsletterPopup && <NewsletterPopup />}
       <RelativeContainer>
         <MaxWidthDiv showNav={!!page.secondaryNavigationData}>

--- a/src/components/head-tags.tsx
+++ b/src/components/head-tags.tsx
@@ -2,14 +2,16 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 
 import { useInstanceData } from '@/contexts/instance-context'
-import { HeadData } from '@/data-types'
+import { BreadcrumbsData, HeadData } from '@/data-types'
 import { serloDomain } from '@/helper/serlo-domain'
 
 interface HeadTagsProps {
   data: HeadData
+  breadcrumbsData?: BreadcrumbsData
+  noindex?: boolean
 }
 
-export function HeadTags({ data }: HeadTagsProps) {
+export function HeadTags({ data, breadcrumbsData, noindex }: HeadTagsProps) {
   const { title, contentType, metaDescription, metaImage } = data
   const { lang } = useInstanceData()
   const router = useRouter()
@@ -26,6 +28,7 @@ export function HeadTags({ data }: HeadTagsProps) {
       {metaDescription && <meta name="description" content={metaDescription} />}
       <meta property="og:title" content={title} />
       <link rel="canonical" href={canonicalHref} />
+      {renderNoIndexMeta()}
       <meta
         property="og:image"
         content={
@@ -36,4 +39,20 @@ export function HeadTags({ data }: HeadTagsProps) {
       />
     </Head>
   )
+
+  function renderNoIndexMeta() {
+    // hide search, trashed and sandkasten content in instance de
+    const filteredBreadcrumbs = breadcrumbsData?.filter(
+      (entry) => entry.url == '/community/106082/sandkasten'
+    )
+    if (
+      noindex ||
+      (filteredBreadcrumbs && filteredBreadcrumbs.length > 0) ||
+      data.title.startsWith('Sandkasten')
+    ) {
+      return <meta name="robots" content="noindex" />
+    }
+
+    return null
+  }
 }

--- a/src/components/pages/search.tsx
+++ b/src/components/pages/search.tsx
@@ -42,7 +42,10 @@ export function Search() {
 
   return (
     <>
-      <HeadTags data={{ title: `Serlo.org - ${strings.header.search}` }} />
+      <HeadTags
+        data={{ title: `Serlo.org - ${strings.header.search}` }}
+        noindex
+      />
       <MaxWidthDiv>
         <StyledSearchResults>
           <div id="gcs-results"></div>

--- a/src/components/pages/user/profile.tsx
+++ b/src/components/pages/user/profile.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from 'next'
+import Head from 'next/head'
 import styled from 'styled-components'
 
 import { ProfileCommunityBanner } from './profile-community-banner'
@@ -27,6 +28,7 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
 
   return (
     <>
+      {renderNoIndexMeta()}
       <StyledP></StyledP>
       {lang === 'de' && renderCommunityFeatures()}
       {description && (
@@ -83,6 +85,21 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
         }}
       />
     )
+  }
+
+  function renderNoIndexMeta() {
+    if (
+      !userData.activeDonor &&
+      !userData.activeAuthor &&
+      !userData.activeReviewer
+    ) {
+      return (
+        <Head>
+          <meta name="robots" content="noindex" />
+        </Head>
+      )
+    }
+    return null
   }
 }
 


### PR DESCRIPTION
In addition to our [robots.txt](https://github.com/serlo/serlo.org/blob/master/packages/public/server/src/public/robots.txt) is PR adds dynamic noindex tags for 

- search (could be in robots)
- inactive profiles (no donor, author or reviewer)
- content in sandkasten (de only)
- trashed content

(closes #952, #960)

