### PR TITLE
Set notification to read manually, cache revalidation

### DIFF
--- a/src/components/pages/user/notifications.tsx
+++ b/src/components/pages/user/notifications.tsx
@@ -1,5 +1,7 @@
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { PageInfo } from '@serlo/api'
-import { useEffect } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import { useAuthentication } from '@/auth/use-authentication'
@@ -7,8 +9,8 @@ import { LoadingSpinner } from '@/components/loading/loading-spinner'
 import { Notification, NotificationEvent } from '@/components/user/notification'
 import { useInstanceData } from '@/contexts/instance-context'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
-import { makeMargin, makePrimaryButton } from '@/helper/css'
-// import { useSetNotificationStateMutation } from '@/helper/mutations'
+import { makeLightButton, makeMargin, makePrimaryButton } from '@/helper/css'
+import { useSetNotificationStateMutation } from '@/helper/mutations'
 
 interface NotificationData {
   id: number
@@ -23,22 +25,16 @@ interface NotificationProps {
   }
   loadMore: () => void
   isLoading: boolean
-  // isUnread?: boolean
 }
 
 export const Notifications = ({
   data,
   loadMore,
   isLoading,
-}: // isUnread,
-NotificationProps) => {
+}: NotificationProps) => {
   const auth = useAuthentication()
-  // const setToRead = useSetNotificationStateMutation()
-
-  useEffect(() => {
-    //if (isUnread) setAllToRead()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth, data])
+  const setNotificationToRead = useSetNotificationStateMutation()
+  const [hidden, setHidden] = useState<number[]>([])
 
   const { strings } = useInstanceData()
   const loggedInData = useLoggedInData()
@@ -50,40 +46,52 @@ NotificationProps) => {
       {renderNotifications(data.nodes)}
       {isLoading && <LoadingSpinner text={strings.loading.isLoading} />}
       {data?.pageInfo.hasNextPage && !isLoading ? (
-        <Button
-          onClick={() => {
-            loadMore()
-          }}
-        >
-          {loggedInStrings.loadMore}
-        </Button>
+        <ButtonWrap>
+          <Button onClick={() => loadMore()}>{loggedInStrings.loadMore}</Button>
+          <LightButton onClick={() => setAllToRead()}>
+            <FontAwesomeIcon icon={faCheck} /> {loggedInStrings.setAllToRead}
+          </LightButton>
+        </ButtonWrap>
       ) : null}
     </>
   )
 
   function renderNotifications(nodes: NotificationData[]) {
-    return nodes.map((node) => (
-      <Notification
-        key={node.id}
-        eventId={node.id}
-        event={node.event}
-        unread={node.unread}
-        loggedInStrings={loggedInStrings}
-      />
-    ))
+    return nodes.map((node) => {
+      if (hidden.includes(node.id)) return null
+      return (
+        <Notification
+          key={node.id}
+          eventId={node.id}
+          event={node.event}
+          unread={node.unread}
+          loggedInStrings={loggedInStrings}
+          setToRead={setToRead}
+        />
+      )
+    })
   }
 
-  // function setAllToRead() {
-  //   if (auth.current === null) return
+  function setToRead(id: number) {
+    void setNotificationToRead({
+      id: [id],
+      unread: false,
+    })
+    // hide immediately
+    setHidden([...hidden, id])
+  }
 
-  //   const unreadIds = data?.nodes.flatMap((node) =>
-  //     node.unread ? [node.id] : []
-  //   )
-  //   void setToRead({
-  //     id: unreadIds,
-  //     unread: false,
-  //   })
-  // }
+  function setAllToRead() {
+    if (auth.current === null) return
+
+    const unreadIds = data?.nodes.flatMap((node) =>
+      node.unread ? [node.id] : []
+    )
+    void setNotificationToRead({
+      id: unreadIds,
+      unread: false,
+    })
+  }
 }
 
 const Button = styled.button`
@@ -91,4 +99,16 @@ const Button = styled.button`
   ${makeMargin}
   margin-top: 20px;
   margin-bottom: 50px;
+`
+
+const LightButton = styled.button`
+  ${makeLightButton}
+  ${makeMargin}
+  margin-top: 20px;
+  margin-bottom: 50px;
+`
+
+const ButtonWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
 `

--- a/src/components/pages/user/notifications.tsx
+++ b/src/components/pages/user/notifications.tsx
@@ -8,7 +8,7 @@ import { Notification, NotificationEvent } from '@/components/user/notification'
 import { useInstanceData } from '@/contexts/instance-context'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
 import { makeMargin, makePrimaryButton } from '@/helper/css'
-import { useSetNotificationStateMutation } from '@/helper/mutations'
+// import { useSetNotificationStateMutation } from '@/helper/mutations'
 
 interface NotificationData {
   id: number
@@ -23,20 +23,20 @@ interface NotificationProps {
   }
   loadMore: () => void
   isLoading: boolean
-  isUnread?: boolean
+  // isUnread?: boolean
 }
 
 export const Notifications = ({
   data,
   loadMore,
   isLoading,
-  isUnread,
-}: NotificationProps) => {
+}: // isUnread,
+NotificationProps) => {
   const auth = useAuthentication()
-  const setToRead = useSetNotificationStateMutation()
+  // const setToRead = useSetNotificationStateMutation()
 
   useEffect(() => {
-    if (isUnread) setAllToRead()
+    //if (isUnread) setAllToRead()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth, data])
 
@@ -65,6 +65,7 @@ export const Notifications = ({
     return nodes.map((node) => (
       <Notification
         key={node.id}
+        eventId={node.id}
         event={node.event}
         unread={node.unread}
         loggedInStrings={loggedInStrings}
@@ -72,17 +73,17 @@ export const Notifications = ({
     ))
   }
 
-  function setAllToRead() {
-    if (auth.current === null) return
+  // function setAllToRead() {
+  //   if (auth.current === null) return
 
-    const unreadIds = data?.nodes.flatMap((node) =>
-      node.unread ? [node.id] : []
-    )
-    void setToRead({
-      id: unreadIds,
-      unread: false,
-    })
-  }
+  //   const unreadIds = data?.nodes.flatMap((node) =>
+  //     node.unread ? [node.id] : []
+  //   )
+  //   void setToRead({
+  //     id: unreadIds,
+  //     unread: false,
+  //   })
+  // }
 }
 
 const Button = styled.button`

--- a/src/components/user/notification.tsx
+++ b/src/components/user/notification.tsx
@@ -1,4 +1,4 @@
-import { faVolumeMute } from '@fortawesome/free-solid-svg-icons'
+import { faBellSlash, faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   CheckoutRevisionNotificationEvent,
@@ -30,6 +30,7 @@ import { TimeAgo } from '@/components/time-ago'
 import { useInstanceData } from '@/contexts/instance-context'
 import { LoggedInData } from '@/data-types'
 import { getEntityStringByTypename } from '@/helper/feature-i18n'
+import { useSetNotificationStateMutation } from '@/helper/mutations'
 
 export type NotificationEvent =
   | CheckoutRevisionNotificationEvent
@@ -51,24 +52,52 @@ export type NotificationEvent =
 
 export function Notification({
   event,
+  eventId,
   unread,
   loggedInStrings,
 }: {
-  unread: boolean
   event: NotificationEvent
+  eventId: number
+  unread: boolean
   loggedInStrings: LoggedInData['strings']['notifications']
 }) {
   const eventDate = new Date(event.date)
   const { strings } = useInstanceData()
+  const setToRead = useSetNotificationStateMutation()
 
   return (
     <Item>
       <StyledTimeAgo datetime={eventDate} dateAsTitle />
       <Title unread={unread}>{renderText()}</Title>
       {renderExtraContent()}
-      {renderMuteButton()}
+      <ButtonWrapper>
+        {renderMuteButton()}
+        {unread && renderReadButton()}
+      </ButtonWrapper>
     </Item>
   )
+
+  function renderReadButton() {
+    return (
+      <Tippy
+        duration={[300, 250]}
+        animation="fade"
+        placement="bottom"
+        content={<Tooltip>{loggedInStrings.setToRead}</Tooltip>}
+      >
+        <StyledButton
+          onClick={() => {
+            void setToRead({
+              id: [eventId],
+              unread: false,
+            })
+          }}
+        >
+          <FontAwesomeIcon icon={faCheck} />
+        </StyledButton>
+      </Tippy>
+    )
+  }
 
   function renderMuteButton() {
     return (
@@ -78,9 +107,9 @@ export function Notification({
         placement="bottom"
         content={<Tooltip>{loggedInStrings.hide}</Tooltip>}
       >
-        <MuteButton href={`/unsubscribe/${event.objectId.toString()}`}>
-          <FontAwesomeIcon icon={faVolumeMute} />
-        </MuteButton>
+        <StyledButton href={`/unsubscribe/${event.objectId.toString()}`}>
+          <FontAwesomeIcon icon={faBellSlash} />
+        </StyledButton>
       </Tippy>
     )
   }
@@ -120,6 +149,7 @@ export function Notification({
         )
 
       case 'CreateCommentNotificationEvent':
+        console.log(event)
         return parseString(loggedInStrings.createComment, {
           thread: renderThread(event.thread.id),
           comment: (
@@ -281,14 +311,19 @@ const StyledTimeAgo = styled(TimeAgo)`
   color: ${(props) => props.theme.colors.gray};
 `
 
-const MuteButton = styled.a`
-  position: absolute;
-  opacity: 0;
+const ButtonWrapper = styled.div`
   display: flex;
-  justify-content: center;
+  position: absolute;
   right: 20px;
   top: 30px;
+`
+
+const StyledButton = styled.a`
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
   padding: 10px;
+  margin-left: 10px;
   border-radius: 2rem;
   transition: all 0.2s ease-in;
   color: ${(props) => props.theme.colors.brand};
@@ -318,7 +353,7 @@ const Item = styled.div`
     background: ${(props) => props.theme.colors.bluewhite};
   }
 
-  &:hover ${MuteButton} {
+  &:hover ${StyledButton} {
     opacity: 1;
   }
 `

--- a/src/components/user/notification.tsx
+++ b/src/components/user/notification.tsx
@@ -22,7 +22,7 @@ import {
 } from '@serlo/api'
 import Tippy from '@tippyjs/react'
 import * as R from 'ramda'
-import { useState, Fragment } from 'react'
+import { Fragment } from 'react'
 import styled, { css } from 'styled-components'
 
 import { UserLink } from './user-link'
@@ -30,7 +30,6 @@ import { TimeAgo } from '@/components/time-ago'
 import { useInstanceData } from '@/contexts/instance-context'
 import { LoggedInData } from '@/data-types'
 import { getEntityStringByTypename } from '@/helper/feature-i18n'
-import { useSetNotificationStateMutation } from '@/helper/mutations'
 
 export type NotificationEvent =
   | CheckoutRevisionNotificationEvent
@@ -55,27 +54,16 @@ export function Notification({
   eventId,
   unread,
   loggedInStrings,
+  setToRead,
 }: {
   event: NotificationEvent
   eventId: number
   unread: boolean
   loggedInStrings: LoggedInData['strings']['notifications']
+  setToRead: (id: number) => void
 }) {
   const eventDate = new Date(event.date)
   const { strings } = useInstanceData()
-  const setToRead = useSetNotificationStateMutation()
-  const [hidden, setHidden] = useState<number[]>([])
-
-  function _setToRead(id: number) {
-    void setToRead({
-      id: [id],
-      unread: false,
-    })
-    // hide immediately
-    setHidden([...hidden, id])
-  }
-
-  if (hidden.includes(eventId)) return null
 
   return (
     <Item>
@@ -97,7 +85,7 @@ export function Notification({
         placement="bottom"
         content={<Tooltip>{loggedInStrings.setToRead}</Tooltip>}
       >
-        <StyledButton onClick={() => _setToRead(eventId)}>
+        <StyledButton onClick={() => setToRead(eventId)}>
           <FontAwesomeIcon icon={faCheck} />
         </StyledButton>
       </Tippy>

--- a/src/components/user/notification.tsx
+++ b/src/components/user/notification.tsx
@@ -22,7 +22,7 @@ import {
 } from '@serlo/api'
 import Tippy from '@tippyjs/react'
 import * as R from 'ramda'
-import { Fragment } from 'react'
+import { useState, Fragment } from 'react'
 import styled, { css } from 'styled-components'
 
 import { UserLink } from './user-link'
@@ -64,6 +64,18 @@ export function Notification({
   const eventDate = new Date(event.date)
   const { strings } = useInstanceData()
   const setToRead = useSetNotificationStateMutation()
+  const [hidden, setHidden] = useState<number[]>([])
+
+  function _setToRead(id: number) {
+    void setToRead({
+      id: [id],
+      unread: false,
+    })
+    // hide immediately
+    setHidden([...hidden, id])
+  }
+
+  if (hidden.includes(eventId)) return null
 
   return (
     <Item>
@@ -85,14 +97,7 @@ export function Notification({
         placement="bottom"
         content={<Tooltip>{loggedInStrings.setToRead}</Tooltip>}
       >
-        <StyledButton
-          onClick={() => {
-            void setToRead({
-              id: [eventId],
-              unread: false,
-            })
-          }}
-        >
+        <StyledButton onClick={() => _setToRead(eventId)}>
           <FontAwesomeIcon icon={faCheck} />
         </StyledButton>
       </Tippy>
@@ -149,7 +154,6 @@ export function Notification({
         )
 
       case 'CreateCommentNotificationEvent':
-        console.log(event)
         return parseString(loggedInStrings.createComment, {
           thread: renderThread(event.thread.id),
           comment: (

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -283,6 +283,7 @@ export const loggedInData = {
     notifications: {
       loadMore: "Load more",
       hide: "Hide notifications for this content.",
+      setToRead: "Set notification to read.",
       setThreadStateArchived: "%actor% archived %thread%.",
       setThreadStateUnarchived: "%actor% restored %thread%.",
       createComment: "%actor% commented in %thread%: %comment%.",

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -284,6 +284,7 @@ export const loggedInData = {
       loadMore: "Load more",
       hide: "Hide notifications for this content.",
       setToRead: "Set notification to read.",
+      setAllToRead: "Set all visible to read",
       setThreadStateArchived: "%actor% archived %thread%.",
       setThreadStateUnarchived: "%actor% restored %thread%.",
       createComment: "%actor% commented in %thread%: %comment%.",

--- a/src/helper/mutations.ts
+++ b/src/helper/mutations.ts
@@ -14,7 +14,7 @@ import {
 import { GraphQLError } from 'graphql'
 import { ClientError, gql, GraphQLClient } from 'graphql-request'
 import NProgress from 'nprogress'
-import { mutate } from 'swr'
+import { mutate, cache } from 'swr'
 
 import { csrReload } from './csr-reload'
 import { showToastNotice } from './show-toast-notice'
@@ -76,9 +76,24 @@ export function useSetNotificationStateMutation() {
   ) {
     const success = await mutationFetch(auth, mutation, input)
 
+    // TODO: Maybe implement global cache key management
+
     if (success) {
-      console.log('...')
-    } // TODO: mutate mutation count
+      const keys = cache
+        .keys()
+        .filter(
+          (key) =>
+            key.startsWith('arg@') &&
+            key.indexOf('query notifications($first') > 0 &&
+            key.indexOf('"unread":true') > 0
+        )
+
+      keys.forEach((key) => {
+        // console.log(key)
+        // console.log(cache.get(key))
+        void mutate(key)
+      })
+    }
     return success
   }
   return async (input: NotificationSetStateInput) =>

--- a/src/helper/mutations.ts
+++ b/src/helper/mutations.ts
@@ -79,14 +79,13 @@ export function useSetNotificationStateMutation() {
     // TODO: Maybe implement global cache key management, but this works okay
 
     if (success) {
-      const keys = cache
-        .keys()
-        .filter(
-          (key) =>
-            key.startsWith('arg@') &&
+      const keys = cache.keys().filter(
+        (key) =>
+          (key.startsWith('arg@') &&
             key.indexOf('query notifications($first') > 0 &&
-            key.indexOf('"unread":true') > 0
-        )
+            key.indexOf('"unread":true') > 0) ||
+          key.indexOf('notifications(unread: true)') > 0 // update count
+      )
 
       keys.forEach((key) => {
         void mutate(key)

--- a/src/helper/mutations.ts
+++ b/src/helper/mutations.ts
@@ -76,7 +76,7 @@ export function useSetNotificationStateMutation() {
   ) {
     const success = await mutationFetch(auth, mutation, input)
 
-    // TODO: Maybe implement global cache key management
+    // TODO: Maybe implement global cache key management, but this works okay
 
     if (success) {
       const keys = cache
@@ -89,8 +89,6 @@ export function useSetNotificationStateMutation() {
         )
 
       keys.forEach((key) => {
-        // console.log(key)
-        // console.log(cache.get(key))
         void mutate(key)
       })
     }

--- a/src/pages/user/notifications.tsx
+++ b/src/pages/user/notifications.tsx
@@ -67,7 +67,7 @@ function Content() {
             data={data!}
             isLoading={loading}
             loadMore={loadMore}
-            isUnread
+            // isUnread
           />
         </Guard>
       ) : (
@@ -101,10 +101,10 @@ export function useNotificationFetch(unread?: boolean, noKey?: boolean) {
     event: NotificationEvent
     unread: boolean
   }>({
-    query,
-    variables: {
-      first: 10,
-      unread,
+    query: notificationsQuery,
+    variables: { first: 10, unread },
+    config: {
+      refreshInterval: 10 * 1000, // seconds
     },
     getConnection(data) {
       return data.notifications
@@ -113,7 +113,12 @@ export function useNotificationFetch(unread?: boolean, noKey?: boolean) {
   })
 }
 
-const query = gql`
+export const notificationsVariables = {
+  first: 10,
+  unread: undefined,
+}
+
+export const notificationsQuery = gql`
   query notifications($first: Int!, $unread: Boolean, $after: String) {
     notifications(first: $first, unread: $unread, after: $after) {
       pageInfo {


### PR DESCRIPTION
~basically done, but atm. revalidation (or redraw) after setting notification to `read` only works on the first "page" (10 entries).~

This changes the logic of notifications in the frontend so that users can (and have to) set them to read manually.
@kulla and @inyono preferred this behaviour and also it's a lot more stable that the automatic approach.

Also we now revalidate the local swr cache immediately after the mutation.
I opted for a very optimistic UI, since a failure (single notification is still marked unread after refresh) is not a real problem here. Seems pretty fast this way ⚡ (no delay).
The button to set all visible notifications to read and the notification count are not optimistic but rely on the (slightly delayed) revalidation.


(preview not possible in PR because of auth)