### PR TITLE
Feature: Activate Revision History and Revision View

### DIFF
--- a/src/components/content/link.tsx
+++ b/src/components/content/link.tsx
@@ -33,8 +33,8 @@ const legacyLinks = [
 export function isLegacyLink(_href: string) {
   // compat: this is a special frontend route or force frontend use
   if (_href == '/user/notifications') return false
-  // if (_href.startsWith('/entity/repository/history')) return true //disabled for zwischenrelease
-  // if (_href.startsWith('/entity/repository/compare')) return true //disabled for zwischenrelease
+  if (_href.startsWith('/entity/repository/history')) return true
+  if (_href.startsWith('/entity/repository/compare')) return true
 
   return (
     legacyLinks.indexOf(_href) > -1 ||

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -136,6 +136,7 @@ export const instanceData = {
     },
     revisions: {
       toOverview: "Back to overview",
+      toContent: "Back to content",
       changes: "Changes",
       title: "Title",
       content: "Content",

--- a/src/fetcher/revision/query.ts
+++ b/src/fetcher/revision/query.ts
@@ -36,6 +36,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...pageRevision
             }
           }
@@ -46,6 +47,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...appletRevision
             }
           }
@@ -56,6 +58,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...courseRevision
             }
           }
@@ -66,6 +69,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...coursePageRevision
             }
           }
@@ -76,6 +80,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...eventRevision
             }
           }
@@ -86,6 +91,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               content
             }
           }
@@ -100,6 +106,7 @@ export const revisionQuery = gql`
               title
             }
             currentRevision {
+              id
               content
             }
           }
@@ -114,6 +121,7 @@ export const revisionQuery = gql`
               title
             }
             currentRevision {
+              id
               ...exerciseGroupRevision
             }
           }
@@ -124,6 +132,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               content
             }
           }
@@ -134,6 +143,7 @@ export const revisionQuery = gql`
           repository {
             id
             currentRevision {
+              id
               ...videoRevision
             }
           }

--- a/src/pages/entity/repository/history/[id].tsx
+++ b/src/pages/entity/repository/history/[id].tsx
@@ -19,6 +19,7 @@ export default renderedPageNoHooks<HistoryRevisionProps>((props) => (
 
 function Content({ id }: HistoryRevisionProps) {
   const response = useFetch(id)
+  const { strings } = useInstanceData()
   if (response.data?.uuid.solutionRevisions) {
     response.data.uuid.revisions = response.data.uuid.solutionRevisions
   }
@@ -27,7 +28,9 @@ function Content({ id }: HistoryRevisionProps) {
       <Breadcrumbs
         data={[
           {
-            label: response.data?.uuid.currentRevision?.title ?? '',
+            label:
+              response.data?.uuid.currentRevision?.title ??
+              strings.revisions.toContent,
             url: response.data?.uuid.alias ?? undefined,
           },
         ]}


### PR DESCRIPTION
Now that the mutations are live (thank you @kulla and @inyono for the super fast implementation) [Revision History](https://frontend-git-feature-revisions-serlo.vercel.app/entity/repository/history/1565) and [Revision Preview](https://frontend-git-feature-revisions-serlo.vercel.app/entity/repository/compare/1565/162707) are ready for testing imo.

@Entkenntnis what do you think?

Notes:
- I checked some different content types, but not very thoroughly. 
- The Revision View always compares to the currently accepted revision now.