### PR TITLE
validate css classnames

### DIFF
--- a/scripts/tailwind-status.js
+++ b/scripts/tailwind-status.js
@@ -47,16 +47,93 @@ files.forEach((file) => {
   }
 })
 
+// process classnames -> check availability and variants
+
+const classes = {}
+
+const variants = {}
+
+classNameMatches.forEach(({ classNames }) => {
+  classNames.forEach((cn) =>
+    cn.c.split(' ').forEach((c) => {
+      if (c) {
+        classes[c] = true
+        while (c.includes(':')) {
+          const index = c.indexOf(':')
+          const variant = c.substr(0, index)
+          variants[variant] = true
+          c = c.substr(index + 1)
+        }
+      }
+    })
+  )
+})
+
+const classList = Object.keys(classes)
+classList.sort()
+
+const variantList = Object.keys(variants)
+variantList.sort()
+
+if (fs.existsSync('./.next/BUILD_ID')) {
+  console.log(
+    '\nClass name validation. Please make sure the build is up-to-date'
+  )
+  const files = fs
+    .readdirSync('./.next/static/css')
+    .filter((entry) => entry.endsWith('.css'))
+
+  const css = fs.readFileSync(`./.next/static/css/${files[0]}`, 'utf8')
+
+  const invalidClasses = []
+
+  const unknownClasses = classList.filter((c) => {
+    const cFiltered = c.replace(/[^a-z-0-9\/\.\:]/g, '')
+    if (c !== cFiltered) {
+      invalidClasses.push(c)
+      return false
+    } else {
+      const escaped = cFiltered
+        .replace(/\./g, '\\\\\\.')
+        .replace(/\//g, '\\\\\\/')
+        .replace(/\:/g, '\\\\\\:')
+      const regexStr = `\\.${escaped}(?![a-z-0-9\\\\])`
+      if (new RegExp(regexStr, 'g').test(css)) {
+        return false
+      } else {
+        //console.log(regexStr)
+        return true
+      }
+    }
+  })
+
+  if (invalidClasses.length > 0) {
+    console.log('\nInvalid class names:', invalidClasses.join(', '))
+  }
+
+  if (unknownClasses.length > 0) {
+    console.log(
+      '\nClass names not found in style sheet:\n ',
+      unknownClasses.join('\n  ')
+    )
+  }
+} else {
+  console.log('\nNo build found, skipping class name validation\n')
+  console.log('\nClasses in use:\n', classList.join(', '))
+}
+
+console.log('\nVariants in use:', variantList.join(', '))
+
 // output
 
-console.log('\nExtracted class names:\n')
+/*console.log('\nExtracted class names:\n')
 classNameMatches.forEach(({ file, classNames }) => {
   console.log(`  ${file.substr(6)}`)
   classNames.forEach((cn) => {
     console.log(`    ${cn.clsx ? '=' : '-'}`, [cn.c])
   })
   console.log()
-})
+})*/
 
 console.log(
   '\n' + filesWithStyledComponents.length + ' files using styled-components:\n'


### PR DESCRIPTION
Make `yarn tailwind:status` more useful, add validation of classNames:

![grafik](https://user-images.githubusercontent.com/13507950/120631399-2026f900-c468-11eb-88a8-59d1305b3081.png)

Maybe adding this as github workflow one day.