### PR TITLE
add rel tags to profile links to discourage spam

### DIFF
--- a/src/components/comments/comment.tsx
+++ b/src/components/comments/comment.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import dynamic from 'next/dynamic'
 import * as React from 'react'
 
+import { Link } from '../content/link'
 import { MathSpanProps } from '../content/math-span'
 import { MetaBar } from './meta-bar'
 import { replaceWithJSX } from '@/helper/replace-with-jsx'
@@ -40,15 +41,14 @@ export function Comment({
     r1,
     /(https?:\/\/(?:www\.)?(?:[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b)(?:[-a-zA-Z0-9()@:%_+~#?&//=]*))/g,
     (str, i) => (
-      <a
+      <Link
         key={`link-${i}`}
         href={str}
-        rel="ugc nofollow noreferrer"
-        target="_blank"
         className="serlo-link break-all"
+        unreviewed
       >
         {str}
-      </a>
+      </Link>
     )
   )
 

--- a/src/components/content/link.tsx
+++ b/src/components/content/link.tsx
@@ -16,6 +16,7 @@ export interface LinkProps {
   title?: string
   noCSR?: boolean
   path?: NodePath
+  unreviewed?: boolean // e.g. user profiles or comments
 }
 
 //TODO: Should come from cloudflare worker https://github.com/serlo/frontend/issues/328
@@ -61,6 +62,7 @@ export function Link({
   title,
   noCSR,
   path,
+  unreviewed,
 }: LinkProps) {
   const { lang } = useInstanceData()
   const entityId = React.useContext(EntityIdContext)
@@ -166,11 +168,14 @@ export function Link({
       : undefined
 
     return (
+      // eslint-disable-next-line react/jsx-no-target-blank
       <a
         href={_href}
         className={clsx(className, 'serlo-link')}
         title={title}
         onClick={clickHandler}
+        rel={unreviewed && isExternal ? 'ugc nofollow noreferrer' : undefined}
+        target={unreviewed && isExternal ? '_blank' : undefined}
       >
         {children}
         {isExternal && !noExternalIcon && <ExternalLink />}

--- a/src/schema/article-renderer.tsx
+++ b/src/schema/article-renderer.tsx
@@ -171,8 +171,10 @@ function renderElement(props: RenderElementProps): React.ReactNode {
   const { element, children, path } = props
 
   if (element.type === 'a') {
+    const isOnProfile =
+      path && typeof path[0] === 'string' && path[0].startsWith('profile')
     return (
-      <Link href={element.href} path={path}>
+      <Link href={element.href} path={path} unreviewed={isOnProfile}>
         {children}
       </Link>
     )


### PR DESCRIPTION
Sorry, I thought we have this for profiles already, but it was only on comments. 
This should in theory discourage spammers since there is no more SEO advantage to be gained. (But since they also use the chat now… idk 😩)

@kulla or @Entkenntnis could one of you review this? 
Unfortunately we can't really test it in staging since the descriptions are missing. 