### PR TITLE
Author menus: also show unrevised instead of edit

### DIFF
--- a/__fixtures__/api_mockdata.ts
+++ b/__fixtures__/api_mockdata.ts
@@ -1944,6 +1944,9 @@ export const exerciseGroupUuidMock = {
     content:
       '{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"Finde die passenden Gleichungen zu den Funktionsgraphen:"}]}]}]}',
   },
+  revisions: {
+    totalCount: 1,
+  },
   exercises: [
     {
       id: 53209,

--- a/src/components/content/entity.tsx
+++ b/src/components/content/entity.tsx
@@ -119,7 +119,7 @@ export function Entity({ data }: EntityProps) {
         aboveContent={setting?.aboveContent}
         id={data.id}
         hideEdit={!data.inviteToEdit}
-        unrevisedRevision={data.unrevisedRevisions}
+        unrevisedRevisions={data.unrevisedRevisions}
         data={{
           type: data.typename,
           id: data.id,

--- a/src/components/content/entity.tsx
+++ b/src/components/content/entity.tsx
@@ -126,6 +126,8 @@ export function Entity({ data }: EntityProps) {
           revisionId: data.revisionId,
           courseId: data.courseData?.id,
           trashed: data.trashed,
+          unrevisedRevisions: data.unrevisedRevisions,
+          unrevisedCourseRevisions: data.unrevisedCourseRevisions,
         }}
       />
     )

--- a/src/components/content/exercises/exercise-group.tsx
+++ b/src/components/content/exercises/exercise-group.tsx
@@ -26,8 +26,9 @@ export function ExerciseGroup({
     setLoaded(true)
   }, [])
   const auth = useAuthentication()
-  const lic = useLoggedInComponents()
-  const Comp = lic?.ExerciseAuthorTools
+  const loggedInComponents = useLoggedInComponents()
+  const ExerciseAuthorTools = loggedInComponents?.ExerciseAuthorTools
+
   return (
     <div className="pt-1">
       <div className="pt-2 mb-3">
@@ -40,8 +41,8 @@ export function ExerciseGroup({
         <div className="flex mb-0.5">
           <div className="flex-grow">{groupIntro}</div>
           <div>{license}</div>
-          {loaded && auth.current && Comp && (
-            <Comp data={{ type: '_ExerciseGroupInline', id }} />
+          {loaded && auth.current && ExerciseAuthorTools && (
+            <ExerciseAuthorTools data={{ type: '_ExerciseGroupInline', id }} />
           )}
         </div>
       </div>

--- a/src/components/content/exercises/exercise-group.tsx
+++ b/src/components/content/exercises/exercise-group.tsx
@@ -11,6 +11,7 @@ export interface ExerciseGroupProps {
   positionOnPage?: number
   id: number
   href?: string
+  unrevisedRevisions?: number
 }
 
 export function ExerciseGroup({
@@ -20,6 +21,7 @@ export function ExerciseGroup({
   positionOnPage,
   id,
   href,
+  unrevisedRevisions,
 }: ExerciseGroupProps) {
   const [loaded, setLoaded] = React.useState(false)
   React.useEffect(() => {
@@ -42,7 +44,13 @@ export function ExerciseGroup({
           <div className="flex-grow">{groupIntro}</div>
           <div>{license}</div>
           {loaded && auth.current && ExerciseAuthorTools && (
-            <ExerciseAuthorTools data={{ type: '_ExerciseGroupInline', id }} />
+            <ExerciseAuthorTools
+              data={{
+                type: '_ExerciseGroupInline',
+                id,
+                unrevisedRevisions,
+              }}
+            />
           )}
         </div>
       </div>

--- a/src/components/content/exercises/exercise.tsx
+++ b/src/components/content/exercises/exercise.tsx
@@ -78,6 +78,7 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
           id: node.context.solutionId!,
           parentId: node.context.id,
           grouped: node.grouped,
+          unrevisedRevisions: node.unrevisedRevisions,
         }}
       />
     )
@@ -169,7 +170,6 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
 
   function renderToolsButton() {
     if (isRevisionView) return null
-
     const ExerciseAuthorTools = loggedInComponents?.ExerciseAuthorTools
     return (
       <>
@@ -179,6 +179,7 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
               type: '_ExerciseInline',
               id: node.context.id,
               grouped: node.grouped,
+              unrevisedRevisions: node.unrevisedRevisions,
             }}
           />
         )}

--- a/src/components/content/exercises/exercise.tsx
+++ b/src/components/content/exercises/exercise.tsx
@@ -35,7 +35,7 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
     setLoaded(true)
   }, [])
 
-  const lic = useLoggedInComponents()
+  const loggedInComponents = useLoggedInComponents()
   const isRevisionView =
     path && typeof path[0] === 'string' && path[0].startsWith('revision')
 
@@ -70,9 +70,9 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
     const license = node.solution.license && !node.solution.license.default && (
       <LicenseNotice minimal data={node.solution.license} type="solution" />
     )
-    const Comp = lic?.ExerciseAuthorTools
-    const authorTools = Comp && loaded && auth.current && (
-      <Comp
+    const ExerciseAuthorTools = loggedInComponents?.ExerciseAuthorTools
+    const authorTools = ExerciseAuthorTools && loaded && auth.current && (
+      <ExerciseAuthorTools
         data={{
           type: '_SolutionInline',
           id: node.context.solutionId!,
@@ -170,11 +170,11 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
   function renderToolsButton() {
     if (isRevisionView) return null
 
-    const Comp = lic?.ExerciseAuthorTools
+    const ExerciseAuthorTools = loggedInComponents?.ExerciseAuthorTools
     return (
       <>
-        {loaded && auth.current && Comp && (
-          <Comp
+        {loaded && auth.current && ExerciseAuthorTools && (
+          <ExerciseAuthorTools
             data={{
               type: '_ExerciseInline',
               id: node.context.id,

--- a/src/components/landing/rework/menu-new.tsx
+++ b/src/components/landing/rework/menu-new.tsx
@@ -79,7 +79,7 @@ function MenuInner({
 
   useEffect(() => setMounted(true), [])
 
-  const lic = useLoggedInComponents()
+  const loggedInComponents = useLoggedInComponents()
 
   function onSubMenuInnerClick() {
     if (tippyRoot && tippyRoot !== undefined) tippyRoot.hide()
@@ -204,7 +204,7 @@ function MenuInner({
       if (!hasIcon) return null
 
       if (link.icon === 'notifications') {
-        const Comp = lic?.UnreadNotificationsCount
+        const Comp = loggedInComponents?.UnreadNotificationsCount
         if (Comp) return <Comp icon={menuIconMapping[link.icon]} />
       }
 

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -78,7 +78,7 @@ function MenuInner({
 
   useEffect(() => setMounted(true), [])
 
-  const lic = useLoggedInComponents()
+  const loggedInComponents = useLoggedInComponents()
 
   function onSubMenuInnerClick() {
     if (tippyRoot && tippyRoot !== undefined) tippyRoot.hide()
@@ -203,7 +203,7 @@ function MenuInner({
       if (!hasIcon) return null
 
       if (link.icon === 'notifications') {
-        const Comp = lic?.UnreadNotificationsCount
+        const Comp = loggedInComponents?.UnreadNotificationsCount
         if (Comp) return <Comp icon={menuIconMapping[link.icon]} />
       }
 

--- a/src/components/user-tools/author-tools-hover-menu.tsx
+++ b/src/components/user-tools/author-tools-hover-menu.tsx
@@ -18,6 +18,7 @@ export interface AuthorToolsData {
   trashed?: boolean
   checkoutRejectButtons?: JSX.Element
   unrevisedRevisions?: number
+  unrevisedCourseRevisions?: number
 }
 
 export interface AuthorToolsHoverMenuProps {
@@ -89,16 +90,21 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
   }
 
   function renderCoursePage() {
+    const hasCourseRevisions =
+      data.unrevisedCourseRevisions && data.unrevisedCourseRevisions > 0
+
     return (
       <ul className="serlo-sub-list-hover">
         <Tippy
           {...tippyDefaultProps}
           content={
             <ul className="serlo-sub-list-hover">
+              {/* Author tools for this course page */}
               <AuthorTools
                 entityId={data.id}
                 data={data}
                 tools={[
+                  hasUnrevised ? Tool.UnrevisedEdit : Tool.Edit,
                   Tool.Abo,
                   Tool.History,
                   Tool.MoveCoursePage,
@@ -121,10 +127,11 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
           {...tippyDefaultProps}
           content={
             <ul className="serlo-sub-list-hover">
+              {/* Author tools for course */}
               <AuthorTools
                 data={data}
                 tools={[
-                  Tool.Edit,
+                  hasCourseRevisions ? Tool.UnrevisedEdit : Tool.Edit,
                   Tool.History,
                   Tool.Abo,
                   Tool.AddCoursePage,

--- a/src/components/user-tools/author-tools-hover-menu.tsx
+++ b/src/components/user-tools/author-tools-hover-menu.tsx
@@ -17,6 +17,7 @@ export interface AuthorToolsData {
   grouped?: boolean
   trashed?: boolean
   checkoutRejectButtons?: JSX.Element
+  unrevisedRevisions?: number
 }
 
 export interface AuthorToolsHoverMenuProps {
@@ -37,6 +38,8 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
 
   if (!loggedInData) return null
   const loggedInStrings = loggedInData.strings
+  const hasUnrevised =
+    data.unrevisedRevisions !== undefined && data.unrevisedRevisions > 0
 
   if (data.type == 'CoursePage') {
     return renderCoursePage()
@@ -122,8 +125,8 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
                 data={data}
                 tools={[
                   Tool.Edit,
-                  Tool.Abo,
                   Tool.History,
+                  Tool.Abo,
                   Tool.AddCoursePage,
                   Tool.Sort,
                   Tool.Curriculum,
@@ -166,7 +169,9 @@ export function AuthorToolsHoverMenu({ data }: AuthorToolsHoverMenuProps) {
         <AuthorTools
           entityId={data.id}
           data={data}
-          tools={[Tool.Edit, Tool.History]}
+          tools={
+            hasUnrevised ? [Tool.UnrevisedEdit] : [Tool.Edit, Tool.History]
+          }
         />
 
         {data.type == '_ExerciseGroupInline' && (

--- a/src/components/user-tools/author-tools.tsx
+++ b/src/components/user-tools/author-tools.tsx
@@ -29,6 +29,7 @@ export enum Tool {
   CopyItems = 'copyItems',
   Curriculum = 'curriculum',
   Edit = 'edit',
+  UnrevisedEdit = 'unrevisedEdit',
   History = 'history',
   Log = 'log',
   MoveCoursePage = 'moveCoursePage',
@@ -104,6 +105,10 @@ export function AuthorTools({ tools, entityId, data }: AuthorToolsProps) {
     },
     edit: {
       url: `/entity/repository/add-revision/${entityId}`,
+      canDo: canDo(Uuid.create('EntityRevision')),
+    },
+    unrevisedEdit: {
+      url: `/entity/repository/history/${entityId}`,
       canDo: canDo(Uuid.create('EntityRevision')),
     },
     curriculum: {

--- a/src/components/user-tools/user-tools.tsx
+++ b/src/components/user-tools/user-tools.tsx
@@ -27,7 +27,7 @@ interface UserToolsProps {
   hideEdit?: boolean
   hideEditProfile?: boolean
   data: AuthorToolsData
-  unrevisedRevision?: number
+  unrevisedRevisions?: number
   aboveContent?: boolean
 }
 
@@ -40,24 +40,24 @@ export function UserTools({
   onShare,
   hideEdit,
   data,
-  unrevisedRevision,
+  unrevisedRevisions,
   aboveContent,
   hideEditProfile,
 }: UserToolsProps) {
   const { strings, lang } = useInstanceData()
   const auth = useAuthentication()
   const loggedInData = useLoggedInData()
-  const lic = useLoggedInComponents()
+  const loggedInComponents = useLoggedInComponents()
   const canDo = useCanDo()
 
   // note: we hide the ui on ssr and fade it in on the client
   const [firstPass, setFirstPass] = useState(true)
 
   useEffect(() => {
-    if (firstPass && (!auth.current || (auth.current && lic))) {
+    if (firstPass && (!auth.current || (auth.current && loggedInComponents))) {
       setFirstPass(false)
     }
-  }, [auth, lic, firstPass])
+  }, [auth, loggedInComponents, firstPass])
 
   // note: this component is added twice, once without aboveContent and once with it
   // (responsive variants)
@@ -139,17 +139,12 @@ export function UserTools({
   }
 
   function renderEdit() {
-    const showHistory = unrevisedRevision !== undefined && unrevisedRevision > 0
-
-    if (showHistory) {
-      return renderUnrevised()
-    }
+    const hasUnrevised =
+      unrevisedRevisions !== undefined && unrevisedRevisions > 0
+    if (hasUnrevised) return renderUnrevised()
 
     const editHref = getEditHref()
-
-    if (!editHref) {
-      return null
-    }
+    if (!editHref) return null
 
     return (
       <Link href={editHref} className={buttonClassName()}>
@@ -184,7 +179,7 @@ export function UserTools({
         className={buttonClassName()}
       >
         {renderInner(
-          `${strings.edit.unrevised} (${unrevisedRevision || ''})`,
+          `${strings.edit.unrevised} (${unrevisedRevisions || ''})`,
           faClock
         )}
       </Link>
@@ -228,7 +223,7 @@ export function UserTools({
   }
 
   function renderExtraTools() {
-    if (!lic || !loggedInData) return null // safeguard
+    if (!loggedInComponents || !loggedInData) return null // safeguard
     const supportedTypes = [
       'Page',
       'Article',
@@ -243,12 +238,12 @@ export function UserTools({
     ]
     if (supportedTypes.indexOf(data.type) === -1) return null
 
-    const Comp = lic.AuthorToolsHoverMenu
+    const AuthorToolsHoverMenu = loggedInComponents?.AuthorToolsHoverMenu
 
     return (
       <LazyTippy
         interactive
-        content={<Comp data={data} />}
+        content={<AuthorToolsHoverMenu data={data} />}
         placement={aboveContent ? 'bottom' : 'left-end'}
         delay={[0, 300]}
         trigger="click mouseenter focus"

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -554,6 +554,7 @@ export interface FrontendExerciseNode {
   }
   children?: undefined
   href?: string
+  unrevisedRevisions?: number
 }
 
 export interface FrontendSolutionNode {
@@ -565,6 +566,7 @@ export interface FrontendSolutionNode {
   }
   href?: string
   children?: undefined
+  unrevisedRevisions?: number
 }
 
 export interface TaskEdtrState {
@@ -622,6 +624,7 @@ export interface FrontendExerciseGroupNode {
     id: number
   }
   href?: string
+  unrevisedRevisions?: number
 }
 
 export interface FrontendVideoNode {

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -285,6 +285,7 @@ export interface EntityData {
   licenseData?: LicenseData
   courseData?: CourseData
   unrevisedRevisions?: number
+  unrevisedCourseRevisions?: number
 }
 
 export interface RevisionPage extends EntityPageBase {

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -363,6 +363,7 @@ export const loggedInData = {
       restoreContent: 'Restore from trash',
       sort: 'Sort children',
       edit: 'Edit',
+      unrevisedEdit: 'Show unrevised revisions',
       organize: 'Organize',
       moveToGroupedTextExercise: 'Move content to other grouped-text-exercise',
       moveToTextExercise: 'Move content to other text-exercise',

--- a/src/fetcher/create-exercises.ts
+++ b/src/fetcher/create-exercises.ts
@@ -49,7 +49,6 @@ export function createExercise(
       taskLegacy = convertState(content)
     }
   }
-
   return {
     type: 'exercise',
     grouped: false,
@@ -65,6 +64,7 @@ export function createExercise(
       solutionId: uuid.solution?.id,
     },
     href: uuid.alias ? uuid.alias : undefined,
+    unrevisedRevisions: uuid.revisions?.totalCount,
   }
 }
 
@@ -115,6 +115,7 @@ export function createSolution(uuid: Solution): FrontendSolutionNode {
       id: uuid.id,
     },
     href: uuid.alias ? uuid.alias : undefined,
+    unrevisedRevisions: uuid.unrevisedRevisions,
   }
 }
 
@@ -147,5 +148,6 @@ export function createExerciseGroup(
       id: uuid.id,
     },
     href: uuid.alias ? uuid.alias : undefined,
+    unrevisedRevisions: uuid.revisions.totalCount,
   }
 }

--- a/src/fetcher/query-types.ts
+++ b/src/fetcher/query-types.ts
@@ -143,6 +143,7 @@ export interface Solution extends Repository {
   currentRevision?: GraphQL.Maybe<Pick<GraphQL.SolutionRevision, 'content'>>
   license: License
   exercise: { id: number }
+  unrevisedRevisions?: number
 }
 
 // Events are only used in injections, no support for full page view

--- a/src/fetcher/query-types.ts
+++ b/src/fetcher/query-types.ts
@@ -90,6 +90,9 @@ export interface CoursePage extends Entity {
       id: number
       currentRevision: Pick<GraphQL.CoursePageRevision, 'title' | 'trashed'>
     }[]
+    revisions: {
+      totalCount: number
+    }
     taxonomyTerms: { nodes: TaxonomyTerms }
   }
 }

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -82,6 +82,9 @@ export const dataQuery = gql`
             }
           }
           ...taxonomyTerms
+          revisions(unrevised: true) {
+            totalCount
+          }
         }
       }
 

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -111,6 +111,9 @@ export const dataQuery = gql`
         }
         exercises {
           ...exercise
+          revisions(unrevised: true) {
+            totalCount
+          }
         }
       }
 

--- a/src/fetcher/request-page.ts
+++ b/src/fetcher/request-page.ts
@@ -381,6 +381,7 @@ export async function requestPage(
           previousPageUrl: pages[currentPageIndex - 2]?.url,
         },
         unrevisedRevisions: uuid.revisions?.totalCount,
+        unrevisedCourseRevisions: uuid.course.revisions?.totalCount,
       },
       metaData: {
         title,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -12,7 +12,6 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
   if (pageData === undefined) return <ErrorPage code={404} />
-
   //fallback, should be handled by CFWorker
   if (pageData.kind === 'redirect') {
     if (typeof window !== 'undefined') {

--- a/src/schema/article-renderer.tsx
+++ b/src/schema/article-renderer.tsx
@@ -394,6 +394,7 @@ function renderElement({
         positionOnPage={element.positionOnPage}
         id={element.context.id}
         href={element.href}
+        unrevisedRevisions={element.unrevisedRevisions}
       >
         {children}
       </ExerciseGroup>


### PR DESCRIPTION
For submenus (courses and exercises/exgroups/solutions) editing on top of existing unrevised revision could happen easily.

@Entkenntnis I hope you don't mind, I renamed `lic` to `loggedInComponents` across the project, to make it easier to understand for newcomers (and me). Also I renamed Comp to the Components Name when it was not right below the definition.