### PR TITLE
add support for slate inline code

### DIFF
--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -386,6 +386,7 @@ export interface FrontendTextNode {
   color?: FrontendTextColor
   em?: boolean
   strong?: boolean
+  code?: boolean
   children?: undefined
 }
 

--- a/src/schema/article-renderer.tsx
+++ b/src/schema/article-renderer.tsx
@@ -142,6 +142,7 @@ interface RenderLeafProps {
     color?: 'blue' | 'green' | 'orange'
     em?: boolean
     strong?: boolean
+    code?: boolean
   }
   key: number
   children: React.ReactNode
@@ -149,13 +150,31 @@ interface RenderLeafProps {
 
 export function renderLeaf({ leaf, key, children }: RenderLeafProps) {
   const styles: CSS.Properties = {}
+
+  if (leaf.code) {
+    return (
+      <code
+        key={key}
+        className="bg-brand-100 text-brand p-1 rounded-sm text-base"
+      >
+        {children}
+      </code>
+    )
+  }
+
   if (leaf.color) styles.color = articleColors[leaf.color]
   if (leaf.em) styles.fontStyle = 'italic'
   if (leaf.strong) styles.fontWeight = 'bold'
 
   if (Object.keys(styles).length === 0) return children
 
-  const LeafTag = leaf.strong ? 'b' : leaf.em ? 'i' : 'span'
+  const LeafTag = leaf.code
+    ? 'code'
+    : leaf.strong
+    ? 'b'
+    : leaf.em
+    ? 'i'
+    : 'span'
   const outputStyles = !(Object.keys(styles).length === 1 && LeafTag !== 'span')
 
   return (

--- a/src/schema/convert-edtr-io-state.tsx
+++ b/src/schema/convert-edtr-io-state.tsx
@@ -338,6 +338,7 @@ function convertText(node: SlateTextElement) {
       em: node.em,
       strong: node.strong,
       color: colors[node.color as number],
+      code: node.code,
     },
   ]
 }


### PR DESCRIPTION
@Entkenntnis  do you remember why we did not support this before or did I overlook something? 😅 

### example
https://frontend-git-text-code-serlo.vercel.app/221693