### PR TITLE
Deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,13 +36,11 @@ module.exports = withBundleAnalyzer({
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
   async rewrites() {
-    return {
-      fallback: [
-        {
-          source: '/api/pdf/:path*',
-          destination: `https://pdf.serlo.org/api/:path*`,
-        },
-      ],
-    }
+    return [
+      {
+        source: '/api/pdf/:path*',
+        destination: 'https://pdf.serlo.org/api/:path*',
+      },
+    ]
   },
 })

--- a/next.config.js
+++ b/next.config.js
@@ -35,4 +35,14 @@ module.exports = withBundleAnalyzer({
   },
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
+  async rewrites() {
+    return {
+      fallback: [
+        {
+          source: '/api/pdf/:path*',
+          destination: `https://pdf.serlo.org/api/:path*`,
+        },
+      ],
+    }
+  },
 })

--- a/src/components/comments/comment-form.tsx
+++ b/src/components/comments/comment-form.tsx
@@ -52,6 +52,8 @@ export function CommentForm({
     isMac ? '⌘' : strings.keys.ctrl
   }↵`
 
+  const formId = `comment-form${threadId ?? ''}`
+
   return (
     <div
       className={clsx(
@@ -60,9 +62,13 @@ export function CommentForm({
         'transition-colors duration-200 ease-in py-1'
       )}
     >
+      <label htmlFor={formId} className="sr-only">
+        {placeholder}
+      </label>
       <TextareaAutosize
         value={commentValue}
         ref={textareaRef}
+        id={formId}
         onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
           setCommentValue(event.target.value)
         }}

--- a/src/components/content/lazy.tsx
+++ b/src/components/content/lazy.tsx
@@ -12,9 +12,9 @@ export interface LazyProps {
 
 export function Lazy(props: LazyProps) {
   if (isPrintMode) {
+    if (props.noPrint) return null
     return <>{props.children}</>
   }
-  if (props.noPrint) return null
 
   return (
     <>

--- a/src/components/content/multimedia.tsx
+++ b/src/components/content/multimedia.tsx
@@ -44,7 +44,8 @@ export function Multimedia({
       >
         {renderNested(media, 'media')}
       </div>
-      <div>{renderNested(children, 'children')}</div>
+      {/* 1px margin fixes mistery bug in firefox */}
+      <div className="ml-[1px]">{renderNested(children, 'children')}</div>
       {renderLightbox()}
       <div className="clear-both" />
     </div>

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -78,7 +78,11 @@ export function PrivacyWrapper({
     return (
       <Placeholder>
         <PreviewImageWrapper>
-          <PreviewImage src={previewImageUrl} faded={isTwingle} />
+          <PreviewImage
+            src={previewImageUrl}
+            faded={isTwingle}
+            alt={`${strings.content.previewImage} ${provider}`}
+          />
         </PreviewImageWrapper>
         {!checkConsent(provider) && (
           <InfoBar>

--- a/src/components/content/video.tsx
+++ b/src/components/content/video.tsx
@@ -16,10 +16,8 @@ export interface VideoProps {
   license?: LicenseData
 }
 
-export function Video(props: VideoProps) {
+export function Video({ src, path, license }: VideoProps) {
   const { lang } = useInstanceData()
-
-  const { src, path, license } = props
 
   const vimeo = /^(https?:\/\/)?(.*?vimeo\.com\/)(.+)/.exec(src)
   if (vimeo) return renderVimeo(vimeo[3])

--- a/src/components/entity-base.tsx
+++ b/src/components/entity-base.tsx
@@ -24,7 +24,9 @@ const CommentArea = dynamic<CommentAreaProps>(() =>
 
 export function EntityBase({ children, page, entityId }: EntityBaseProps) {
   const noComments =
-    page.kind === 'single-entity' && page.entityData.typename === 'Page'
+    page.kind === 'single-entity' &&
+    (page.entityData.typename === 'Page' ||
+      page.entityData.typename === 'GroupedExercise')
 
   return (
     <>

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -194,6 +194,7 @@ function MenuInner({
             className="group"
           >
             {renderIcon()} {!hasIcon && link.title}
+            <span className="sr-only">{strings.pageTitles.notifications}</span>
           </StyledLink>
         )}
       </Li>

--- a/src/components/toast-notice.tsx
+++ b/src/components/toast-notice.tsx
@@ -13,6 +13,10 @@ export function ToastNotice() {
   const showTime = 4000
 
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(document.referrer)
+
+    // welcome, bye
     if (window.location.hash === '#auth') {
       setTimeout(removeHash, 3000)
       showToastNotice(
@@ -58,6 +62,12 @@ export function ToastNotice() {
         window.location.hash = '#flush-legacy'
         window.location.reload()
       }, 1000)
+    }
+
+    if (document.referrer.includes('/taxonomy/term/organize/')) {
+      setTimeout(() => {
+        window.location.reload()
+      }, 500)
     }
 
     if (window.location.hash == '#flush-legacy') {

--- a/src/components/toast-notice.tsx
+++ b/src/components/toast-notice.tsx
@@ -67,7 +67,7 @@ export function ToastNotice() {
     if (document.referrer.includes('/taxonomy/term/organize/')) {
       setTimeout(() => {
         window.location.reload()
-      }, 500)
+      }, 200)
     }
 
     if (window.location.hash == '#flush-legacy') {

--- a/src/components/toast-notice.tsx
+++ b/src/components/toast-notice.tsx
@@ -13,9 +13,6 @@ export function ToastNotice() {
   const showTime = 4000
 
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(document.referrer)
-
     // welcome, bye
     if (window.location.hash === '#auth') {
       setTimeout(removeHash, 3000)

--- a/src/components/user-tools/share-modal.tsx
+++ b/src/components/user-tools/share-modal.tsx
@@ -115,9 +115,7 @@ export function ShareModal({ isOpen, onClose, showPdf }: ShareModalProps) {
       onClick: () => {
         showToastNotice('🐒 ' + strings.loading.oneMomentPlease)
       },
-      href: `https://pdf.serlo.org/api/${id}${
-        noSolutions ? '?noSolutions' : ''
-      }`,
+      href: `/api/pdf/${id}${noSolutions ? '?noSolutions' : ''}`,
     }
   }
 

--- a/src/components/user/user-link.tsx
+++ b/src/components/user/user-link.tsx
@@ -32,7 +32,12 @@ export function UserLink({
         className={className}
         path={path ?? []}
       >
-        {withIcon && <UserImage src={getAvatarUrl(user.username)} />}
+        {withIcon && (
+          <UserImage
+            src={getAvatarUrl(user.username)}
+            alt={`User-Avatar: ${user.username}`}
+          />
+        )}
         {user.username}
         {!noBadges && renderBadges()}
       </Link>

--- a/src/data/de/index.ts
+++ b/src/data/de/index.ts
@@ -109,7 +109,7 @@ export const instanceData = {
       unrevisedNotice: "Dieser Inhalt hat noch keine akzeptierte Bearbeitung. Über die %link% kannst du dir die Entwürfe anzeigen lassen.",
       strategy: "Lösungsstrategie",
       picture: "Bild",
-      previewImage: 'Preview Image'
+      previewImage: "Vorschaubild"
     },
     consent: {
       title: "Einwilligungen für externe Inhalte",

--- a/src/data/de/index.ts
+++ b/src/data/de/index.ts
@@ -108,7 +108,8 @@ export const instanceData = {
       trashedNotice: "Dieser Inhalt wurde zum Löschen markiert.",
       unrevisedNotice: "Dieser Inhalt hat noch keine akzeptierte Bearbeitung. Über die %link% kannst du dir die Entwürfe anzeigen lassen.",
       strategy: "Lösungsstrategie",
-      picture: "Bild"
+      picture: "Bild",
+      previewImage: 'Preview Image'
     },
     consent: {
       title: "Einwilligungen für externe Inhalte",

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -109,6 +109,7 @@ export const instanceData = {
       unrevisedNotice: 'This content has no accepted revision yet. Please use the %link% to preview.',
       strategy: 'Solution Strategy',
       picture: 'Picture',
+      previewImage: 'Preview Image',
     },
     consent: {
       title: 'Consent for external Content',

--- a/src/data/es/index.ts
+++ b/src/data/es/index.ts
@@ -108,7 +108,8 @@ export const instanceData = {
       trashedNotice: "Este contenido está marcado para su eliminación.",
       unrevisedNotice: 'This content has no accepted revision yet. Please use the %link% to preview.',
       strategy: "Estrategia de solución",
-      picture: "Imagen"
+      picture: "Imagen",
+      previewImage: 'Preview Image'
     },
     consent: {
       title: "Consentimiento para contenido externo",

--- a/src/data/fr/index.ts
+++ b/src/data/fr/index.ts
@@ -108,7 +108,8 @@ export const instanceData = {
       trashedNotice: "Ce contenu est marqué pour être supprimé.",
       unrevisedNotice: 'This content has no accepted revision yet. Please use the %link% to preview.',
       strategy: "Stratégie de solution",
-      picture: 'Picture'
+      picture: 'Picture',
+      previewImage: 'Preview Image'
     },
     consent: {
       title: "Consentement pour le contenu externe",

--- a/src/data/hi/index.ts
+++ b/src/data/hi/index.ts
@@ -108,7 +108,8 @@ export const instanceData = {
       trashedNotice: "यह सामग्री हटाने के लिए चिह्नित है",
       unrevisedNotice: 'This content has no accepted revision yet. Please use the %link% to preview.',
       strategy: 'Solution Strategy',
-      picture: 'Picture'
+      picture: 'Picture',
+      previewImage: 'Preview Image'
     },
     consent: {
       title: "बाहरी सामग्री के लिए सहमति",

--- a/src/data/ta/index.ts
+++ b/src/data/ta/index.ts
@@ -108,7 +108,8 @@ export const instanceData = {
       trashedNotice: "இந்த உள்ளடக்கம் குப்பையாக குறிக்கப்பட்டுள்ளது.",
       unrevisedNotice: 'This content has no accepted revision yet. Please use the %link% to preview.',
       strategy: 'Solution Strategy',
-      picture: 'Picture'
+      picture: 'Picture',
+      previewImage: 'Preview Image'
     },
     consent: {
       title: 'Consent for external Content',


### PR DESCRIPTION
- fix: pdf downloads get triggered and use correct filename now
- fix: taxonomy changes now show immediately 
- change: no comment area for single view of `GroupedExercise`
- fix: hidden videos bug
- fix: weird layout quirk in multimedia comp for firefox ([example](https://de.serlo.org/lerntipps/186900/lernen-mit-eselsbr%C3%BCcken))
- fix: some a11y improvements. Thanks to https://khan.github.io/tota11y/