### PR TITLE
try reloading on error

### DIFF
--- a/src/components/comments/comment.tsx
+++ b/src/components/comments/comment.tsx
@@ -39,7 +39,7 @@ export function Comment({
   // Step 2: Replace urls in remaining strings
   const r2 = replaceWithJSX(
     r1,
-    /(https?:\/\/(?:www\.)?(?:[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b)(?:[-a-zA-Z0-9()@:%_+~#?&//=]*))/g,
+    /(https?:\/\/(?:www\.)?(?:[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9]{1,6}\b)(?:[-a-zA-Z0-9@:%_+~#?&//=]*))/g,
     (str, i) => (
       <Link
         key={`link-${i}`}

--- a/src/components/content/link.tsx
+++ b/src/components/content/link.tsx
@@ -43,13 +43,14 @@ export function isLegacyLink(_href: string) {
     legacyLinks.includes(_href) ||
     _href.startsWith('/auth/') ||
     _href.startsWith('/api/auth') ||
+    _href.startsWith('/discussions') ||
     _href.startsWith('/entity') ||
+    _href.startsWith('/math/wiki/') ||
     _href.startsWith('/page') ||
     _href.startsWith('/taxonomy') ||
-    _href.startsWith('/discussions') ||
-    _href.startsWith('/subscription/update') ||
     _href.startsWith('/unsubscribe') ||
     _href.startsWith('/user/profile/') ||
+    _href.startsWith('/subscription/update') ||
     _href.includes('.serlo.org') //e.g. community.serlo.org or different language
   )
 }

--- a/src/components/pages/error-page.tsx
+++ b/src/components/pages/error-page.tsx
@@ -25,7 +25,7 @@ export function ErrorPage({ code, message }: ErrorData) {
   return (
     <>
       <PageTitle title={strings.errors.title} headTitle />
-      <p className="serlo-p text-2xl">
+      <p className="serlo-p text-2xl" id="error-page-description">
         {strings.errors.defaultMessage}{' '}
         {!isProbablyTemporary && (
           <>

--- a/src/components/user/event.tsx
+++ b/src/components/user/event.tsx
@@ -113,7 +113,7 @@ export function Event({
         return parseString(strings.events.createComment, {
           thread: renderThread(event.thread),
           comment: (
-            <Link href={`/${event.comment.id}`}>
+            <Link href={`/${event.comment.id}`} noCSR>
               {strings.entities.comment}
             </Link>
           ),
@@ -262,7 +262,11 @@ export function Event({
 
   function renderThread(thread: Thread) {
     const id = thread.comments?.nodes[0]?.id
-    return <Link href={`/${id}`}>{strings.entities.thread}</Link>
+    return (
+      <Link href={`/${id}`} noCSR>
+        {strings.entities.thread}
+      </Link>
+    )
   }
 
   function hasObject(


### PR DESCRIPTION
we discussed this a while ago.
experiment to refresh page withour client-side-redirect when encountering an error.
this allows the cf-worker to route it to legacy and should trigger an sentry error so those cases are more visible.


Also: remove parentesis from comment link regex. they are quite uncommon and can result in errors for cases like `here it is (https://…)`.