### PR TITLE
equations: Use border-left for transform step

### DIFF
--- a/src/components/content/equations.tsx
+++ b/src/components/content/equations.tsx
@@ -1,5 +1,4 @@
 import { shade } from 'polished'
-import { Fragment } from 'react'
 
 import { FrontendContentNode, Sign } from '@/data-types'
 import { RenderNestedFunction } from '@/schema/article-renderer'
@@ -54,8 +53,12 @@ export function Equations({ steps, renderNested }: EquationProps) {
           <td className="text-left formula">
             {step.right ? renderStepFormula('right') : null}
           </td>
-          <td className="pl-1 formula">
-            {step.transform ? <>|{renderStepFormula('transform')}</> : null}
+          <td className="formula">
+            {step.transform ? (
+              <span className="border-l border-black pl-1">
+                {renderStepFormula('transform')}
+              </span>
+            ) : null}
           </td>
         </tr>
         {hasExplanation ? (

--- a/src/components/content/equations.tsx
+++ b/src/components/content/equations.tsx
@@ -1,4 +1,5 @@
 import { shade } from 'polished'
+import { Fragment } from 'react'
 
 import { FrontendContentNode, Sign } from '@/data-types'
 import { RenderNestedFunction } from '@/schema/article-renderer'
@@ -34,7 +35,7 @@ export function Equations({ steps, renderNested }: EquationProps) {
     })
 
     return (
-      <>
+      <Fragment key={i}>
         <style jsx>{`
           .formula {
             @apply align-baseline text-lg;
@@ -70,7 +71,7 @@ export function Equations({ steps, renderNested }: EquationProps) {
             </td>
           </tr>
         ) : null}
-      </>
+      </Fragment>
     )
 
     function renderStepFormula(key: 'transform' | 'left' | 'right') {


### PR DESCRIPTION
Result: 
![2021-09-10-133152_404x301_scrot](https://user-images.githubusercontent.com/1327215/132847121-6f8ef6a1-9ee5-411a-a95f-7f19c9f01dd4.png)

See at `/mathe/220515/220515`