### PR TITLE
report to sentry when fetching comments without id

### DIFF
--- a/src/helper/use-comment-data.ts
+++ b/src/helper/use-comment-data.ts
@@ -2,6 +2,7 @@ import { ThreadAware } from '@serlo/api'
 import { gql, GraphQLClient } from 'graphql-request'
 import useSWR from 'swr'
 
+import { triggerSentry } from './trigger-sentry'
 import { endpoint } from '@/api/endpoint'
 
 const query = gql`
@@ -36,6 +37,7 @@ const query = gql`
   }
 `
 export function useCommentData(id: number) {
+  if (!id) triggerSentry({ message: 'trying to fetch comments without id' })
   const client = new GraphQLClient(endpoint)
   const fetcher = () => client.request(query, { id })
   const resp = useSWR<{ uuid: ThreadAware }, object>(


### PR DESCRIPTION
Tbh I have no Idea how #1390 can happen… if `!id` it should be a type error.
Maybe this helps to find out what's happening.