### PR TITLE
1s revalidation time for 50x status codes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,5 +53,5 @@ module.exports = withBundleAnalyzer({
     localeDetection: false,
   },
   reactStrictMode: true,
-  productionBrowserSourceMaps: true
+  productionBrowserSourceMaps: true,
 })

--- a/src/components/pages/error-page.tsx
+++ b/src/components/pages/error-page.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head'
 import { useState, useEffect } from 'react'
 
 import { PageTitle } from '../content/page-title'
@@ -24,6 +25,9 @@ export function ErrorPage({ code, message }: ErrorData) {
 
   return (
     <>
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
       <PageTitle title={strings.errors.title} headTitle />
       <p className="serlo-p text-2xl" id="error-page-description">
         {strings.errors.defaultMessage}{' '}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -69,11 +69,19 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
 export const getStaticProps: GetStaticProps<SlugProps> = async (context) => {
   const alias = (context.params?.slug as string[]).join('/')
   const pageData = await fetchPageData('/' + context.locale! + '/' + alias)
+
+  const defaultRevalidate = 60 * 15 // 15 min
+
+  const revalidate =
+    pageData.kind === 'error' && pageData.errorData.code >= 500
+      ? 1
+      : defaultRevalidate
+
   return {
     props: {
       pageData: JSON.parse(JSON.stringify(pageData)) as SlugPageData, // remove undefined values
     },
-    revalidate: 60 * 15,
+    revalidate,
   }
 }
 


### PR DESCRIPTION
- closes #1391
- bonus: noindex for our error pages (upsi)


follow up: #1401

