### PR TITLE
use window width to conditionally load mobile menu

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,5 +53,5 @@ module.exports = withBundleAnalyzer({
     localeDetection: false,
   },
   reactStrictMode: true,
-  productionBrowserSourceMaps: true
+  productionBrowserSourceMaps: true,
 })

--- a/src/components/landing/rework/header-new.tsx
+++ b/src/components/landing/rework/header-new.tsx
@@ -9,6 +9,8 @@ import { MenuNew } from './menu-new'
 import { useAuthentication } from '@/auth/use-authentication'
 import { Quickbar } from '@/components/navigation/quickbar'
 import { useInstanceData } from '@/contexts/instance-context'
+import { useWindowWidth } from '@/helper/use-window-width'
+import { theme } from '@/theme'
 
 export function HeaderNew() {
   const [isOpen, setOpen] = useState(false)
@@ -20,9 +22,14 @@ export function HeaderNew() {
     setOpen(false)
   })
 
+  const windowWidth = useWindowWidth()
+  const isMobile = windowWidth < theme.breakpointsInt.sm
+
   return (
     <header className="text-truegray-700">
-      <MobileMenuButtonNew onClick={() => setOpen(!isOpen)} open={isOpen} />
+      {isMobile ? (
+        <MobileMenuButtonNew onClick={() => setOpen(!isOpen)} open={isOpen} />
+      ) : null}
       <div className="flex justify-between pt-3 pb-6 px-side lg:px-side-lg">
         <div>
           <Link href="/" path={['logo']}>
@@ -47,9 +54,11 @@ export function HeaderNew() {
           <Quickbar />
         </div>
 
-        <MenuNew data={headerData} auth={auth.current} />
+        {isMobile ? null : <MenuNew data={headerData} auth={auth.current} />}
       </div>
-      {isOpen && <MobileMenu data={headerData} auth={auth.current} />}
+      {isOpen && isMobile ? (
+        <MobileMenu data={headerData} auth={auth.current} />
+      ) : null}
     </header>
   )
 }

--- a/src/components/landing/rework/menu-new.tsx
+++ b/src/components/landing/rework/menu-new.tsx
@@ -13,6 +13,7 @@ import { useLoggedInComponents } from '@/contexts/logged-in-components'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
 import { HeaderData, HeaderLink } from '@/data-types'
 import { getAuthData, shouldUseNewAuth } from '@/helper/feature-auth'
+import { triggerSentry } from '@/helper/trigger-sentry'
 
 // Only show some icons on full menu
 const menuIconMapping = {
@@ -36,7 +37,14 @@ export function MenuNew(props: MenuProps) {
     null
   )
   useEffect(() => {
-    void import('@tippyjs/react').then((value) => setTippy(value))
+    void import('@tippyjs/react').then(
+      (value) => setTippy(value),
+      (reason) => {
+        // eslint-disable-next-line no-console
+        console.log(reason)
+        triggerSentry({ message: 'tippy chunk load problem: ' })
+      }
+    )
   }, [])
 
   if (!Tippy) {

--- a/src/components/landing/rework/menu-new.tsx
+++ b/src/components/landing/rework/menu-new.tsx
@@ -84,7 +84,7 @@ function MenuInner({
   }
   const newData = [data[1], data[4]]
   return (
-    <nav className="min-h-[50px] hidden sm:block mt-6">
+    <nav className="min-h-[50px] mt-6">
       {Tippy && (
         <Tippy.default
           singleton={source}

--- a/src/components/navigation/header.tsx
+++ b/src/components/navigation/header.tsx
@@ -8,6 +8,8 @@ import { MobileMenuButton } from './mobile-menu-button'
 import { SearchInput } from './search-input'
 import { useAuthentication } from '@/auth/use-authentication'
 import { useInstanceData } from '@/contexts/instance-context'
+import { useWindowWidth } from '@/helper/use-window-width'
+import { theme } from '@/theme'
 
 export function Header() {
   const [isOpen, setOpen] = useState(false)
@@ -19,15 +21,22 @@ export function Header() {
     setOpen(false)
   })
 
+  const windowWidth = useWindowWidth()
+  const isMobile = windowWidth < theme.breakpointsInt.sm
+
   return (
     <header className="bg-brand-100">
-      <MobileMenuButton onClick={() => setOpen(!isOpen)} open={isOpen} />
+      {isMobile ? (
+        <MobileMenuButton onClick={() => setOpen(!isOpen)} open={isOpen} />
+      ) : null}
       <div className="pt-3 pb-6 px-side lg:px-side-lg">
-        <Menu data={headerData} auth={auth.current} />
+        {isMobile ? null : <Menu data={headerData} auth={auth.current} />}
         <Logo subline={strings.header.slogan} />
       </div>
       <SearchInput />
-      {isOpen && <MobileMenu data={headerData} auth={auth.current} />}
+      {isOpen && isMobile ? (
+        <MobileMenu data={headerData} auth={auth.current} />
+      ) : null}
     </header>
   )
 }

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -13,6 +13,7 @@ import { useLoggedInComponents } from '@/contexts/logged-in-components'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
 import { HeaderData, HeaderLink } from '@/data-types'
 import { getAuthData, shouldUseNewAuth } from '@/helper/feature-auth'
+import { triggerSentry } from '@/helper/trigger-sentry'
 
 // Only show some icons on full menu
 const menuIconMapping = {
@@ -36,8 +37,16 @@ export function Menu(props: MenuProps) {
     null
   )
   useEffect(() => {
-    void import('@tippyjs/react').then((value) => setTippy(value))
+    void import('@tippyjs/react').then(
+      (value) => setTippy(value),
+      (reason) => {
+        // eslint-disable-next-line no-console
+        console.log(reason)
+        triggerSentry({ message: 'tippy chunk load problem: ' })
+      }
+    )
   }, [])
+
   if (!Tippy) {
     return <MenuWithoutTippy {...props} />
   }

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -83,7 +83,7 @@ function MenuInner({
   }
 
   return (
-    <nav className="min-h-[50px] hidden sm:block">
+    <nav className="min-h-[50px]">
       {Tippy && (
         <Tippy.default
           singleton={source}

--- a/src/components/navigation/mobile-menu-button-new.tsx
+++ b/src/components/navigation/mobile-menu-button-new.tsx
@@ -12,7 +12,7 @@ export function MobileMenuButtonNew(props: MobileMenuButtonProps) {
   return (
     <button
       className={clsx(
-        'sm:hidden absolute top-7 right-4',
+        'absolute top-7 right-4',
         'border border-truegray-700 rounded-full w-12 h-12',
         'text-truegray-700 outline-none cursor-pointer'
       )}

--- a/src/components/navigation/mobile-menu-button.tsx
+++ b/src/components/navigation/mobile-menu-button.tsx
@@ -14,7 +14,7 @@ export function MobileMenuButton(props: MobileMenuButtonProps) {
       onClick={onClick}
       aria-label="Menu"
       className={clsx(
-        'sm:hidden absolute top-4 right-4',
+        'absolute top-4 right-4',
         'rounded-full bg-brand-150 text-brand w-12 h-12',
         'outline-none'
       )}

--- a/src/helper/use-window-width.ts
+++ b/src/helper/use-window-width.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export function useWindowWidth() {
+  const [width, setWidth] = useState(
+    typeof window === 'undefined' ? 1200 : window.innerWidth
+  )
+  function changeWidth() {
+    setWidth(window.innerWidth)
+  }
+  useEffect(() => {
+    window.addEventListener('resize', changeWidth)
+    return () => {
+      window.removeEventListener('resize', changeWidth)
+    }
+  }, [])
+  return width
+}


### PR DESCRIPTION
- this way we don't load tippy on mobile on first load. -> might also help with #1405
- also: report failed tippy chunk load to sentry directly