### PR TITLE
Add json-ld for landing and entity-base

### DIFF
--- a/src/components/entity-base.tsx
+++ b/src/components/entity-base.tsx
@@ -5,6 +5,7 @@ import { HSpace } from './content/h-space'
 import { Horizon } from './content/horizon'
 import { Lazy } from './content/lazy'
 import { HeadTags } from './head-tags'
+import { JsonLd } from './json-ld'
 import { Breadcrumbs } from './navigation/breadcrumbs'
 import { MaxWidthDiv } from './navigation/max-width-div'
 import { MetaMenu } from './navigation/meta-menu'
@@ -40,6 +41,9 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
           noindex={'entityData' in page && page.entityData.trashed}
         />
       )}
+      {page.kind === 'single-entity' || page.kind === 'taxonomy' ? (
+        <JsonLd data={page} id={entityId} />
+      ) : null}
       {page.newsletterPopup && <NewsletterPopup />}
       <div className="relative">
         <MaxWidthDiv showNav={!!page.secondaryNavigationData}>

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -1,0 +1,139 @@
+import Head from 'next/head'
+
+import { EntityBaseProps } from './entity-base'
+import { useInstanceData } from '@/contexts/instance-context'
+import { hasOwnPropertyTs } from '@/helper/has-own-property-ts'
+
+interface JsonLdProps {
+  data: EntityBaseProps['page']
+  id: number
+}
+
+// courses are not supported since we redirect them to first course page anyway
+const typeStrings = {
+  Article: 'Article',
+  Applet: 'WebApplication',
+  Course: 'Article',
+  CoursePage: 'Article',
+  Exercise: 'Quiz',
+  ExerciseGroup: 'Quiz',
+  TaxonomyTerm: 'Collection',
+  Video: 'VideoObject',
+}
+
+export function JsonLd({ data, id }: JsonLdProps) {
+  const { lang } = useInstanceData()
+
+  const isEntity = data.kind === 'single-entity'
+  const isTaxonomy = data.kind === 'taxonomy'
+  const entityType = isEntity ? data.entityData.typename : 'TaxonomyTerm'
+
+  if (!hasOwnPropertyTs(typeStrings, entityType)) return null
+  const typeString = typeStrings[entityType]
+
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(getData()) }}
+      ></script>
+    </Head>
+  )
+
+  function getData() {
+    const type = ['LearningResource', typeString]
+    const learningResourceType = typeString
+
+    const version =
+      isEntity && data.entityData.revisionId
+        ? getIRI(data.entityData.revisionId)
+        : undefined
+
+    const license =
+      isEntity && data.entityData.licenseData
+        ? { id: data.entityData.licenseData?.url }
+        : undefined
+
+    const isPartOf =
+      entityType === 'CoursePage' && isEntity
+        ? data.entityData?.courseData?.id
+          ? getIRI(data.entityData.courseData.id)
+          : undefined
+        : data.breadcrumbsData
+            ?.map((node) => (node.id ? getIRI(node.id) : null))
+            .filter(Boolean)
+
+    const taxonomyDataChildren = isTaxonomy
+      ? [
+          ...data.taxonomyData.subterms,
+          ...data.taxonomyData.applets,
+          ...data.taxonomyData.articles,
+          ...data.taxonomyData.courses,
+          ...data.taxonomyData.events,
+          ...data.taxonomyData.exercises,
+          ...data.taxonomyData.videos,
+        ]
+      : undefined
+
+    const hasPart = isTaxonomy
+      ? taxonomyDataChildren?.map((node) => getIRI(node.id))
+      : undefined
+
+    const collectionSize = isTaxonomy ? taxonomyDataChildren?.length : undefined
+
+    const about = data.breadcrumbsData?.[0].id
+      ? [
+          {
+            id: getIRI(data.breadcrumbsData[0].id),
+            prefLabel: {
+              [lang]: data.breadcrumbsData[0].label,
+              '@none': data.breadcrumbsData[0].label,
+            },
+            type: 'Concept',
+          },
+        ]
+      : undefined
+
+    return {
+      '@context': [
+        'https://w3id.org/kim/lrmi-profile/draft/context.jsonld',
+        { '@language': lang },
+      ],
+      id: getIRI(id),
+      type,
+      learningResourceType,
+      name: data.metaData?.title,
+      description: data.metaData?.metaDescription,
+      dateCreated: data.metaData?.dateCreated,
+      dateModified: data.metaData?.dateModified,
+      version,
+      license,
+      isAccessibleForFree: true,
+      isFamilyFriendly: true,
+      publisher: 'https://serlo.org/',
+      inLanguage: lang,
+      audience: [
+        {
+          id: 'http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/student',
+          prefLabel: {
+            en: 'student',
+            de: 'Schüler*in',
+          },
+          type: 'Concept',
+          inScheme: {
+            id: 'http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/',
+          },
+        },
+      ],
+      isPartOf,
+      applicationCategory:
+        entityType === 'Applet' ? 'https://www.geogebra.org/' : undefined,
+      hasPart,
+      collectionSize,
+      about,
+    }
+    function getIRI(id: number) {
+      return `https://serlo.org/${id}`
+    }
+  }
+}

--- a/src/components/landing/rework/landing-json-ld.tsx
+++ b/src/components/landing/rework/landing-json-ld.tsx
@@ -1,0 +1,39 @@
+import Head from 'next/head'
+
+export function LandingJsonLd() {
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(getData()) }}
+      ></script>
+    </Head>
+  )
+
+  function getData() {
+    return {
+      '@context': [
+        'https://w3id.org/kim/lrmi-profile/draft/context.jsonld',
+        { '@language': 'de' },
+      ],
+      id: 'https://serlo.org/',
+      type: ['EducationalOrganization', 'NGO'],
+      name: 'Serlo Education e.V.',
+      url: 'https://de.serlo.org/',
+      description:
+        'Serlo.org bietet einfache Erklärungen, Kurse, Lernvideos, Übungen und Musterlösungen mit denen Schüler*innen und Studierende nach ihrem eigenen Bedarf und in ihrem eigenen Tempo lernen können. Die Lernplattform ist komplett kostenlos und werbefrei.',
+      image:
+        'https://assets.serlo.org/5ce4082185f5d_5df93b32a2e2cb8a0363e2e2ab3ce4f79d444d11.jpg',
+      logo: 'https://de.serlo.org/_assets/img/serlo-logo.svg',
+      address: {
+        type: 'PostalAddress',
+        streetAddress: 'Daiserstraße 15 (RGB)',
+        postalCode: '81371',
+        addressLocality: 'München',
+        addressRegion: 'Bayern',
+        addressCountry: 'Germany',
+      },
+      email: 'de@serlo.org',
+    }
+  }
+}

--- a/src/components/pages/landing-de.tsx
+++ b/src/components/pages/landing-de.tsx
@@ -5,6 +5,7 @@ import { HeadTags } from '../head-tags'
 import { CommunityWall } from '../landing/rework/community-wall'
 import { FooterNew } from '../landing/rework/footer-new'
 import { HeaderNew } from '../landing/rework/header-new'
+import { LandingJsonLd } from '../landing/rework/landing-json-ld'
 import { PartnerListNew } from '../landing/rework/partner-list-new'
 import { WelcomeMessage } from '../landing/rework/welcome-message'
 import { Quickbar } from '../navigation/quickbar'
@@ -108,6 +109,7 @@ export function LandingDE({ data }: LandingDEProps) {
       <Head>
         <link href="_assets/landing-fonts.css" rel="stylesheet" />
       </Head>
+      <LandingJsonLd />
       <HeadTags data={{ title: 'Serlo – Die freie Lernplattform' }} />
       <HeaderNew />
       <main className="text-truegray-700">

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -220,6 +220,7 @@ export type BreadcrumbEntry = BreadcrumbLinkEntry | BreadcrumbEllipsis
 
 export interface BreadcrumbLinkEntry {
   label: string
+  id?: number | null
   url?: string | null
   ellipsis?: boolean
 }
@@ -247,6 +248,8 @@ export interface HeadData {
   contentType?: string
   metaDescription?: string
   metaImage?: string
+  dateCreated?: string
+  dateModified?: string
 }
 
 // The data that fills the horizon (desktop, below content)
@@ -829,12 +832,12 @@ export interface TaxonomyLink {
   title: string
   url: string
   unrevised?: boolean
+  id: number
 }
 
 // Second level has folders and exercises as links
 
 export interface TaxonomySubTerm extends TaxonomyTermBase, TaxonomyLink {
-  id: number
   folders: TaxonomyLink[]
 }
 

--- a/src/edtr-io/editor-response-to-state.ts
+++ b/src/edtr-io/editor-response-to-state.ts
@@ -221,6 +221,7 @@ export function editorResponseToState(uuid: QueryResponse): DeserializeResult {
                   id: page.id,
                   title: page.currentRevision?.title ?? '',
                   content: page.currentRevision?.content ?? '',
+                  date: '', // not used
                 },
               }).initialState.state
             }),

--- a/src/edtr-io/revision-response-to-response.ts
+++ b/src/edtr-io/revision-response-to-response.ts
@@ -21,6 +21,7 @@ export function revisionResponseToResponse(
   const metaDescription = hasOwnPropertyTs(uuid, 'metaDescription')
     ? uuid.metaDescription
     : ''
+  const date = '' // just to make type happy, not used
 
   const taxonomyTerms = hasOwnPropertyTs(uuid.repository, 'taxonomyTerms')
     ? uuid.repository.taxonomyTerms
@@ -37,6 +38,7 @@ export function revisionResponseToResponse(
         content,
         metaTitle,
         metaDescription,
+        date,
       },
       ...repositoryFields,
       taxonomyTerms,
@@ -48,12 +50,14 @@ export function revisionResponseToResponse(
     uuid.__typename
     return {
       __typename: 'Article',
+      date,
       currentRevision: {
         id: uuid.id,
         title,
         content,
         metaTitle,
         metaDescription,
+        date,
       },
       taxonomyTerms,
       ...repositoryFields,
@@ -83,6 +87,7 @@ export function revisionResponseToResponse(
         id: uuid.id,
         title,
         content,
+        date,
       },
       ...repositoryFields,
       revisions: uuid.repository.revisions,
@@ -110,6 +115,7 @@ export function revisionResponseToResponse(
       currentRevision: {
         id: uuid.id,
         content,
+        date,
       },
       taxonomyTerms,
       ...repositoryFields,
@@ -125,6 +131,7 @@ export function revisionResponseToResponse(
         id: uuid.id,
         content,
         cohesive: uuid.cohesive,
+        date,
       },
       exercises: uuid.repository.exercises,
       taxonomyTerms,
@@ -140,6 +147,7 @@ export function revisionResponseToResponse(
       currentRevision: {
         id: uuid.id,
         content,
+        date,
       },
       exerciseGroup: uuid.repository.exerciseGroup,
       ...repositoryFields,
@@ -183,6 +191,7 @@ export function revisionResponseToResponse(
         url: uuid.url,
         title,
         content,
+        date,
       },
       taxonomyTerms,
       ...repositoryFields,

--- a/src/fetcher/create-taxonomy.ts
+++ b/src/fetcher/create-taxonomy.ts
@@ -70,6 +70,7 @@ function collectType(
       if (title) {
         result.push({
           title,
+          id: child.id,
           url: getAlias(child),
           unrevised: !child.currentRevision,
         })
@@ -95,6 +96,7 @@ function collectTopicFolders(
     )
       result.push({
         title: child.name,
+        id: child.id,
         url: getAlias(child),
       })
   })
@@ -140,7 +142,7 @@ function collectSubfolders(children: TaxonomyTermChildrenLevel2[]) {
       child.type !== 'topicFolder' &&
       child.type !== 'curriculumTopicFolder'
     )
-      result.push({ title: child.name, url: getAlias(child) })
+      result.push({ title: child.name, url: getAlias(child), id: child.id })
   })
   return result
 }

--- a/src/fetcher/query-fragments.ts
+++ b/src/fetcher/query-fragments.ts
@@ -7,6 +7,7 @@ export const sharedRevisionFragments = gql`
     content
     metaTitle
     metaDescription
+    date
   }
 
   fragment pageRevision on PageRevision {
@@ -29,18 +30,21 @@ export const sharedRevisionFragments = gql`
     url
     metaTitle
     metaDescription
+    date
   }
 
   fragment coursePageRevision on CoursePageRevision {
     id
     content
     title
+    date
   }
 
   fragment exerciseGroupRevision on ExerciseGroupRevision {
     id
     content
     cohesive
+    date
   }
 
   fragment eventRevision on EventRevision {
@@ -255,8 +259,10 @@ export const sharedExerciseFragments = gql`
     alias
     instance
     trashed
+    date
     currentRevision {
       content
+      date
     }
     solution {
       ...solution

--- a/src/fetcher/query-types.ts
+++ b/src/fetcher/query-types.ts
@@ -46,9 +46,10 @@ export interface Article extends EntityWithTaxonomyTerms {
   currentRevision?: GraphQL.Maybe<
     Pick<
       GraphQL.ArticleRevision,
-      'title' | 'content' | 'metaTitle' | 'metaDescription' | 'id'
+      'title' | 'content' | 'metaTitle' | 'metaDescription' | 'id' | 'date'
     >
   >
+  date: string
   revisions: {
     totalCount: number
     nodes: {
@@ -60,7 +61,7 @@ export interface Article extends EntityWithTaxonomyTerms {
 export interface Video extends EntityWithTaxonomyTerms {
   __typename: 'Video'
   currentRevision?: GraphQL.Maybe<
-    Pick<GraphQL.VideoRevision, 'title' | 'url' | 'content' | 'id'>
+    Pick<GraphQL.VideoRevision, 'title' | 'url' | 'content' | 'id' | 'date'>
   >
   revisions: {
     totalCount: number
@@ -75,7 +76,13 @@ export interface Applet extends EntityWithTaxonomyTerms {
   currentRevision?: GraphQL.Maybe<
     Pick<
       GraphQL.AppletRevision,
-      'title' | 'content' | 'url' | 'metaTitle' | 'metaDescription' | 'id'
+      | 'title'
+      | 'content'
+      | 'url'
+      | 'metaTitle'
+      | 'metaDescription'
+      | 'id'
+      | 'date'
     >
   >
   revisions: {
@@ -89,7 +96,7 @@ export interface Applet extends EntityWithTaxonomyTerms {
 export interface CoursePage extends Entity {
   __typename: 'CoursePage'
   currentRevision?: GraphQL.Maybe<
-    Pick<GraphQL.CoursePageRevision, 'content' | 'title' | 'id'>
+    Pick<GraphQL.CoursePageRevision, 'content' | 'title' | 'id' | 'date'>
   >
   revisions: {
     totalCount: number
@@ -124,7 +131,7 @@ export interface CoursePage extends Entity {
 export interface BareExercise extends Entity {
   trashed: boolean
   currentRevision?: GraphQL.Maybe<
-    Pick<GraphQL.AbstractExerciseRevision, 'content' | 'id'>
+    Pick<GraphQL.AbstractExerciseRevision, 'content' | 'id' | 'date'>
   >
   revisions?: {
     totalCount: number
@@ -157,7 +164,7 @@ export interface GroupedExercise extends BareExercise {
 export interface BareExerciseGroup extends Entity {
   __typename: 'ExerciseGroup'
   currentRevision?: GraphQL.Maybe<
-    Pick<GraphQL.ExerciseGroupRevision, 'content' | 'id' | 'cohesive'>
+    Pick<GraphQL.ExerciseGroupRevision, 'content' | 'id' | 'cohesive' | 'date'>
   >
   revisions?: {
     totalCount: number

--- a/src/fetcher/query.ts
+++ b/src/fetcher/query.ts
@@ -35,6 +35,7 @@ export const dataQuery = gql`
       }
 
       ... on Article {
+        date
         currentRevision {
           ...articleRevision
         }
@@ -63,6 +64,7 @@ export const dataQuery = gql`
       }
 
       ... on Applet {
+        date
         currentRevision {
           ...appletRevision
         }
@@ -75,6 +77,7 @@ export const dataQuery = gql`
       }
 
       ... on CoursePage {
+        date
         currentRevision {
           ...coursePageRevision
         }
@@ -122,6 +125,7 @@ export const dataQuery = gql`
       }
 
       ... on ExerciseGroup {
+        date
         currentRevision {
           ...exerciseGroupRevision
         }
@@ -238,6 +242,7 @@ export const dataQuery = gql`
       nodes {
         label
         url
+        id
       }
     }
   }
@@ -269,8 +274,10 @@ export const dataQuery = gql`
     ... on Video {
       alias
       id
+      date
       currentRevision {
         title
+        date
       }
       revisions(first: 1, unrevised: true) {
         nodes {

--- a/src/fetcher/request-page.ts
+++ b/src/fetcher/request-page.ts
@@ -286,6 +286,8 @@ export async function requestPage(
         metaDescription: uuid.currentRevision?.metaDescription
           ? uuid.currentRevision?.metaDescription
           : getMetaDescription(content),
+        dateCreated: uuid.date,
+        dateModified: uuid.currentRevision?.date,
       },
       horizonData,
       cacheKey,

--- a/src/fetcher/revision/request.ts
+++ b/src/fetcher/revision/request.ts
@@ -54,7 +54,11 @@ export async function requestRevision(
           createExercise({
             ...uuid,
             license: uuid.repository.license,
-            currentRevision: { content: uuid.content, id: uuid.id },
+            currentRevision: {
+              content: uuid.content,
+              id: uuid.id,
+              date: uuid.date,
+            },
           }),
         ]
       : null


### PR DESCRIPTION
closes #1420, #1421

easiest way to test locally or in preview branch is a browser extention. 
e.g. https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj

should support landing page and `Article Applet CoursePage Exercise ExerciseGroup TaxonomyTerm Video`

currently this is inline script in the head which could cause blocking. Since this is just a bit of json it should render quickly, but still I'd prefer to find a different solution in the future.
E.g. bottom of `<body>` or use something [like this](https://www.phpied.com/asynchronous-inline-scripts-via-data-urls/).