### PR TITLE
user: Hide edit buttons for newly registered user

### DIFF
--- a/src/components/pages/user/profile.tsx
+++ b/src/components/pages/user/profile.tsx
@@ -46,6 +46,17 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
   const [showMotivationModal, setShowMotivationModal] = useState(false)
   const [isOwnProfile, setIsOwnProfile] = useState(false)
 
+  const registerDate = new Date(date)
+  const legacyDate = new Date('2021-11-14')
+  const isUserWithoutActivities =
+    !userData.isActiveDonor &&
+    activityByType.edits + activityByType.reviews === 0 &&
+    registerDate > legacyDate
+  const hourInMilliseconds = 60 * 60 * 1000
+  const isNewlyRegisteredUser =
+    isUserWithoutActivities &&
+    new Date().getTime() - new Date(date).getTime() < 1 * hourInMilliseconds
+
   useEffect(() => {
     setIsOwnProfile(auth.current?.username === username)
   }, [auth, username])
@@ -78,7 +89,9 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
             style={{ gridArea: 'motivation' }}
           >
             {motivation && <>&quot;{motivation}&quot;</>}
-            {isOwnProfile && renderEditMotivationLink()}
+            {isOwnProfile &&
+              !isNewlyRegisteredUser &&
+              renderEditMotivationLink()}
           </div>
           <ProfileChatButton
             userId={id}
@@ -116,7 +129,7 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
           alt={`Profile image of ${username}`}
           className="block rounded-full w-full h-full"
         />
-        {isOwnProfile && (
+        {isOwnProfile && !isNewlyRegisteredUser && (
           <a
             onClick={() => setShowImageModal(true)}
             className={clsx(
@@ -133,18 +146,12 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
 
   function renderDescription() {
     if (!description) return null
-    const registerDate = new Date(date)
-    const legacyDate = new Date('2021-11-14')
-    const hideDescription =
-      !userData.isActiveDonor &&
-      activityByType.edits + activityByType.reviews === 0 &&
-      registerDate > legacyDate
 
-    if (!isOwnProfile && hideDescription) return null
+    if (!isOwnProfile && isUserWithoutActivities) return null
     return (
       <section>
         <h2 className="serlo-h2">{strings.profiles.aboutMe}</h2>
-        {hideDescription && isOwnProfile ? (
+        {isUserWithoutActivities && isOwnProfile ? (
           <StaticInfoPanel icon={faInfoCircle}>
             {strings.profiles.lockedDescriptionTitle}
             <br />


### PR DESCRIPTION
Most newly registered users who want to edit their profile are currently
spam accounts. This PR hides edit buttons for profile picture and
motivation text for the first hour after registration. This might help
that most spam accounts change the description which we can easily
detect and which does not effect other authors (most people will not see
these texts currently)