### PR TITLE
Update menu-data.ts

### DIFF
--- a/src/data/es/menu-data.ts
+++ b/src/data/es/menu-data.ts
@@ -5,7 +5,7 @@ export const landingSubjectsData: LandingSubjectsData = {
   subjects: [
     { url: '/169578', title: 'Aprender matemáticas', icon: 'math' },
     {
-      url: '/community/193306/estudios-en-diásporas-africanas-para-la-escuela',
+      url: '/229701/estudios-en-diásporas-africanas-para-la-escuela',
       title: 'Diásporas Africanas',
       icon: 'geography',
     },


### PR DESCRIPTION
The icon on the homepage 'geography' links now to the Landing page Estudios en Diásporas Africanas para la Escuela (/229701/estudios-en-diásporas-africanas-para-la-escuela) and not the Sandbox (/community/193306/estudios-en-diásporas-africanas-para-la-escuela).