### PR TITLE
Update menu-data.ts

### DIFF
--- a/src/data/en/menu-data.ts
+++ b/src/data/en/menu-data.ts
@@ -12,7 +12,8 @@ export const headerData: InstanceData['headerData'] = [
     title: 'Subjects',
     icon: 'subject',
     children: [
-      { url: '/112089', title: 'Applied Sustainability' },
+      { url: '/63179', title: 'Applied Sustainability' },
+      { url: '/23591', title: 'Mathematics' },
       { url: '/106103', title: 'Subjects under construction' },
     ],
   },


### PR DESCRIPTION
Im Dropdown-Menü der Fächer ist jetzt Mathematik und Nachhaltigkeit mit der Fachseite verlinkt. Vorher war Nachhaltigkeit mit dem Sandbox verlinkt.