### PR TITLE
use endpoints to save/create pages and taxonomy terms

### DIFF
--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -13,8 +13,10 @@ import { useAddPageRevision } from '@/helper/mutations/use-add-page-revision-mut
 import {
   AddPageRevisionMutationData,
   SetEntityMutationData,
+  TaxonomyCreateOrUpdateMutationData,
 } from '@/helper/mutations/use-set-entity-mutation/types'
 import { useSetEntityMutation } from '@/helper/mutations/use-set-entity-mutation/use-set-entity-mutation'
+import { useTaxonomyCreateOrUpdateMutation } from '@/helper/mutations/use-taxonomy-create-or-update-mutation'
 
 export function AddRevision({
   initialState,
@@ -32,6 +34,7 @@ export function AddRevision({
 
   const setEntityMutation = useSetEntityMutation()
   const addPageRevision = useAddPageRevision()
+  const taxonomyCreateOrUpdateMutation = useTaxonomyCreateOrUpdateMutation()
 
   const [cookieReady, setCookieReady] = useState(false)
 
@@ -62,8 +65,8 @@ export function AddRevision({
     'ExerciseGroup',
     'GroupedExercise',
     'Page',
+    'TaxonomyTerm',
   ]
-  // 'Taxonomy'
   // 'User'
 
   return (
@@ -85,7 +88,10 @@ export function AddRevision({
           }}
           needsReview={needsReview}
           onSave={async (
-            data: SetEntityMutationData | AddPageRevisionMutationData
+            data:
+              | SetEntityMutationData
+              | AddPageRevisionMutationData
+              | TaxonomyCreateOrUpdateMutationData
           ) => {
             if (
               shouldUseFeature('addRevisionMutation') &&
@@ -109,6 +115,10 @@ export function AddRevision({
                 type === 'Page'
                   ? //@ts-expect-error resolve when old code is removed
                     await addPageRevision(dataWithType)
+                  : type === 'TaxonomyTerm'
+                  ? await taxonomyCreateOrUpdateMutation(
+                      dataWithType as TaxonomyCreateOrUpdateMutationData
+                    )
                   : await setEntityMutation(
                       //@ts-expect-error resolve when old code is removed
                       dataWithType,

--- a/src/helper/mutations/helper.ts
+++ b/src/helper/mutations/helper.ts
@@ -7,6 +7,8 @@ import {
   RejectRevisionInput,
   SetEntityResponse,
   SubscriptionSetInput,
+  TaxonomyTermCreateInput,
+  TaxonomyTermSetNameAndDescriptionInput,
   ThreadCreateCommentInput,
   ThreadCreateThreadInput,
   ThreadMutation,
@@ -45,6 +47,8 @@ type MutationInput =
   | UserSetDescriptionInput
   | SetEntityInputTypes
   | PageAddRevisionInput
+  | TaxonomyTermCreateInput
+  | TaxonomyTermSetNameAndDescriptionInput
 
 type MutationResponse =
   | ThreadMutation

--- a/src/helper/mutations/helper.ts
+++ b/src/helper/mutations/helper.ts
@@ -3,6 +3,7 @@ import {
   EntityMutation,
   NotificationMutation,
   NotificationSetStateInput,
+  PageAddRevisionInput,
   RejectRevisionInput,
   SetEntityResponse,
   SubscriptionSetInput,
@@ -43,6 +44,7 @@ type MutationInput =
   | UserDeleteBotsInput
   | UserSetDescriptionInput
   | SetEntityInputTypes
+  | PageAddRevisionInput
 
 type MutationResponse =
   | ThreadMutation

--- a/src/helper/mutations/use-add-page-revision-mutation.ts
+++ b/src/helper/mutations/use-add-page-revision-mutation.ts
@@ -34,8 +34,7 @@ export function useAddPageRevision() {
 
       if (success) {
         showToastNotice(loggedInData.strings.mutations.success.save, 'success')
-        // window.location.href = `/entity/repository/history/${data.id}`
-        // TODO: fix redirect
+        window.location.href = `/${data.id}`
         return true
       }
       return false

--- a/src/helper/mutations/use-add-page-revision-mutation.ts
+++ b/src/helper/mutations/use-add-page-revision-mutation.ts
@@ -34,7 +34,8 @@ export function useAddPageRevision() {
 
       if (success) {
         showToastNotice(loggedInData.strings.mutations.success.save, 'success')
-        window.location.href = `/entity/repository/history/${data.id}`
+        // window.location.href = `/entity/repository/history/${data.id}`
+        // TODO: fix redirect
         return true
       }
       return false

--- a/src/helper/mutations/use-add-page-revision-mutation.ts
+++ b/src/helper/mutations/use-add-page-revision-mutation.ts
@@ -1,0 +1,57 @@
+import { gql } from 'graphql-request'
+
+import { showToastNotice } from '../show-toast-notice'
+import { mutationFetch } from './helper'
+import { AddPageRevisionMutationData } from './use-set-entity-mutation/types'
+import { getRequiredString } from './use-set-entity-mutation/use-set-entity-mutation'
+import { useAuthentication } from '@/auth/use-authentication'
+import { useLoggedInData } from '@/contexts/logged-in-data-context'
+
+export function useAddPageRevision() {
+  const auth = useAuthentication()
+  const loggedInData = useLoggedInData()
+
+  return async (data: AddPageRevisionMutationData) => {
+    if (!auth || !loggedInData) {
+      showToastNotice('Please make sure you are logged in!', 'warning')
+      return false
+    }
+    if (!data.__typename || data.__typename !== 'Page') return false
+
+    try {
+      const input = {
+        content: getRequiredString(loggedInData, 'content', data.content),
+        pageId: data.id,
+        title: getRequiredString(loggedInData, 'title', data.title),
+      }
+
+      const success = await mutationFetch(
+        auth,
+        addPageRevisionMutation,
+        input,
+        loggedInData?.strings.mutations.errors
+      )
+
+      if (success) {
+        showToastNotice(loggedInData.strings.mutations.success.save, 'success')
+        window.location.href = `/entity/repository/history/${data.id}`
+        return true
+      }
+      return false
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log('probably missing value?')
+      return false
+    }
+  }
+}
+
+const addPageRevisionMutation = gql`
+  mutation addPageRevision($input: PageAddRevisionInput!) {
+    page {
+      addRevision(input: $input) {
+        success
+      }
+    }
+  }
+`

--- a/src/helper/mutations/use-set-entity-mutation/types.ts
+++ b/src/helper/mutations/use-set-entity-mutation/types.ts
@@ -19,6 +19,7 @@ import {
   CourseSerializedState,
   EventSerializedState,
   PageSerializedState,
+  TaxonomySerializedState,
   TextExerciseGroupSerializedState,
   TextExerciseSerializedState,
   TextSolutionSerializedState,
@@ -68,6 +69,13 @@ export type SupportedTypesSerializedState =
 export type SetEntityMutationData = SupportedTypesSerializedState & OnSaveData
 export type AddPageRevisionMutationData = PageSerializedState & {
   __typename?: 'Page'
+}
+export type TaxonomyCreateOrUpdateMutationData = Pick<
+  TaxonomySerializedState,
+  'id' | 'term' | 'description'
+> & {
+  __typename?: 'TaxonomyTerm'
+  parent?: number
 }
 
 export interface SetEntityMutationRunnerData {

--- a/src/helper/mutations/use-set-entity-mutation/types.ts
+++ b/src/helper/mutations/use-set-entity-mutation/types.ts
@@ -18,6 +18,7 @@ import {
   CoursePageSerializedState,
   CourseSerializedState,
   EventSerializedState,
+  PageSerializedState,
   TextExerciseGroupSerializedState,
   TextExerciseSerializedState,
   TextSolutionSerializedState,
@@ -65,6 +66,9 @@ export type SupportedTypesSerializedState =
   | TextGroupedExerciseSerilizedState
 
 export type SetEntityMutationData = SupportedTypesSerializedState & OnSaveData
+export type AddPageRevisionMutationData = PageSerializedState & {
+  __typename?: 'Page'
+}
 
 export interface SetEntityMutationRunnerData {
   auth: RefObject<AuthenticationPayload>

--- a/src/helper/mutations/use-set-entity-mutation/use-set-entity-mutation.ts
+++ b/src/helper/mutations/use-set-entity-mutation/use-set-entity-mutation.ts
@@ -217,7 +217,7 @@ const loopNestedChildren = async ({
   }
 }
 
-function getRequiredString(
+export function getRequiredString(
   loggedInData: LoggedInData,
   name: string,
   value?: string

--- a/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
+++ b/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
@@ -30,16 +30,11 @@ export function useTaxonomyCreateOrUpdateMutation() {
         ),
       }
 
-      //only for create
+      // reafactor as soon as we don't rely on legacy any more…
+      // only for create
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [_a, _b, c_, _d, typeNumberString, parentIdString] =
         window.location.pathname.split('/') // taxonomy/term/create/4/1390
-
-      // console.log('parent')
-      // console.log(parseInt(parentIdString))
-
-      // console.log('getTaxonomyType')
-      // console.log(getTaxonomyType(typeNumberString))
 
       const success = data.id
         ? await mutationFetch(
@@ -61,7 +56,7 @@ export function useTaxonomyCreateOrUpdateMutation() {
 
       if (success) {
         showToastNotice(loggedInData.strings.mutations.success.save, 'success')
-        //window.location.href = `/${data.id}` // TODO: if id is undef
+        window.location.href = `/${data.id ?? parentIdString}`
         return true
       }
       return false

--- a/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
+++ b/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
@@ -1,5 +1,6 @@
 import { TaxonomyTypeCreateOptions } from '@serlo/api'
 import { gql } from 'graphql-request'
+import { useRouter } from 'next/router'
 
 import { showToastNotice } from '../show-toast-notice'
 import { mutationFetch } from './helper'
@@ -11,6 +12,7 @@ import { useLoggedInData } from '@/contexts/logged-in-data-context'
 export function useTaxonomyCreateOrUpdateMutation() {
   const auth = useAuthentication()
   const loggedInData = useLoggedInData()
+  const router = useRouter()
 
   return async (data: TaxonomyCreateOrUpdateMutationData) => {
     if (!auth || !loggedInData) {
@@ -32,9 +34,8 @@ export function useTaxonomyCreateOrUpdateMutation() {
 
       // reafactor as soon as we don't rely on legacy any more…
       // only for create
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_a, _b, c_, _d, typeNumberString, parentIdString] =
-        window.location.pathname.split('/') // taxonomy/term/create/4/1390
+      const [, , , , typeNumberString, parentIdString] =
+        router.asPath.split('/') // taxonomy/term/create/4/1390
 
       const success = data.id
         ? await mutationFetch(

--- a/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
+++ b/src/helper/mutations/use-taxonomy-create-or-update-mutation.ts
@@ -1,0 +1,111 @@
+import { TaxonomyTypeCreateOptions } from '@serlo/api'
+import { gql } from 'graphql-request'
+
+import { showToastNotice } from '../show-toast-notice'
+import { mutationFetch } from './helper'
+import { TaxonomyCreateOrUpdateMutationData } from './use-set-entity-mutation/types'
+import { getRequiredString } from './use-set-entity-mutation/use-set-entity-mutation'
+import { useAuthentication } from '@/auth/use-authentication'
+import { useLoggedInData } from '@/contexts/logged-in-data-context'
+
+export function useTaxonomyCreateOrUpdateMutation() {
+  const auth = useAuthentication()
+  const loggedInData = useLoggedInData()
+
+  return async (data: TaxonomyCreateOrUpdateMutationData) => {
+    if (!auth || !loggedInData) {
+      showToastNotice('Please make sure you are logged in!', 'warning')
+      return false
+    }
+    if (!data.__typename || data.__typename !== 'TaxonomyTerm') return false
+
+    try {
+      const input = {
+        id: data.id,
+        name: getRequiredString(loggedInData, 'name', data.term.name),
+        description: getRequiredString(
+          loggedInData,
+          'description',
+          data.description
+        ),
+      }
+
+      //only for create
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_a, _b, c_, _d, typeNumberString, parentIdString] =
+        window.location.pathname.split('/') // taxonomy/term/create/4/1390
+
+      // console.log('parent')
+      // console.log(parseInt(parentIdString))
+
+      // console.log('getTaxonomyType')
+      // console.log(getTaxonomyType(typeNumberString))
+
+      const success = data.id
+        ? await mutationFetch(
+            auth,
+            taxonomySetMutation,
+            input,
+            loggedInData?.strings.mutations.errors
+          )
+        : await mutationFetch(
+            auth,
+            taxonomyCreateMutation,
+            {
+              ...input,
+              parentId: parseInt(parentIdString),
+              taxonomyType: getTaxonomyType(typeNumberString),
+            },
+            loggedInData?.strings.mutations.errors
+          )
+
+      if (success) {
+        showToastNotice(loggedInData.strings.mutations.success.save, 'success')
+        //window.location.href = `/${data.id}` // TODO: if id is undef
+        return true
+      }
+      return false
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log('probably missing value?')
+      return false
+    }
+  }
+}
+
+function getTaxonomyType(idString?: string) {
+  if (!idString || !parseInt(idString))
+    throw 'invalid url -> unknown taxonomy type'
+
+  const id = parseInt(idString)
+
+  const topicIds = [4, 16, 33, 42, 48, 53]
+  const topicFolderIds = [9, 19, 36, 45, 51, 56]
+
+  if (topicIds.includes(id)) return TaxonomyTypeCreateOptions.Topic
+  if (topicFolderIds.includes(id)) return TaxonomyTypeCreateOptions.TopicFolder
+
+  throw 'unknown taxonomy type'
+}
+
+const taxonomySetMutation = gql`
+  mutation taxonomyTermSetNameAndDescription(
+    $input: TaxonomyTermSetNameAndDescriptionInput!
+  ) {
+    taxonomyTerm {
+      setNameAndDescription(input: $input) {
+        success
+      }
+    }
+  }
+`
+
+const taxonomyCreateMutation = gql`
+  mutation taxonomyCreate($input: TaxonomyTermCreateInput!) {
+    taxonomyTerm {
+      create(input: $input) {
+        success
+      }
+    }
+  }
+`

--- a/src/pages/taxonomy/term/create/[parent_id]/[id].tsx
+++ b/src/pages/taxonomy/term/create/[parent_id]/[id].tsx
@@ -19,7 +19,7 @@ export default renderedPageNoHooks<TaxonomyTermCreateProps>(({ parent }) => {
         <MaxWidthDiv>
           <main>
             <AddRevision
-              type="taxonomy" /* type is mostly irrelevant? */
+              type="TaxonomyTerm"
               needsReview={false}
               id={parent}
               initialState={{


### PR DESCRIPTION
- `page: addRevision`
- `taxonomyTerm: create / setNameAndDescription`
- this code is really loking forward to being refactored when we don't need the legacy compability any more :)