### PR TITLE
hotfix: revert change because it breaks legacy saving

### DIFF
--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -93,6 +93,8 @@ export function AddRevision({
               | AddPageRevisionMutationData
               | TaxonomyCreateOrUpdateMutationData
           ) => {
+            console.log(data)
+
             if (
               shouldUseFeature('addRevisionMutation') &&
               supportedTypes.includes(type)

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -93,8 +93,6 @@ export function AddRevision({
               | AddPageRevisionMutationData
               | TaxonomyCreateOrUpdateMutationData
           ) => {
-            console.log(data)
-
             if (
               shouldUseFeature('addRevisionMutation') &&
               supportedTypes.includes(type)

--- a/src/edtr-io/editor-response-to-state.ts
+++ b/src/edtr-io/editor-response-to-state.ts
@@ -231,6 +231,7 @@ export function editorResponseToState(uuid: MainUuidType): DeserializeResult {
           license: license!, // there could be cases where this is not correct
           revision,
           changes: '',
+          icon: 'explanation',
           title: uuid.currentRevision?.title || '',
           content: serializeEditorState(
             toEdtr(convertEditorState(uuid.currentRevision?.content || ''))

--- a/src/edtr-io/plugins/types/course-page.tsx
+++ b/src/edtr-io/plugins/types/course-page.tsx
@@ -10,6 +10,7 @@ export const coursePageTypeState = entityType(
   {
     ...entity,
     title: string(''),
+    icon: string('explanation'),
     content: editorContent(),
   },
   {}
@@ -32,7 +33,13 @@ function CoursePageTypeEditor(
     { skipControls: boolean }
   >
 ) {
-  const { title, content } = props.state
+  const { title, content, icon } = props.state
+
+  React.useEffect(() => {
+    if (!['explanation', 'play', 'question'].includes(icon.value)) {
+      icon.set('explanation')
+    }
+  }, [icon])
 
   const loggedInData = useLoggedInData()
   if (!loggedInData) return null


### PR DESCRIPTION
course pages can not be saved atm. via the legacy infrastructure. 

@Entkenntnis do you mind if I deploy this or could you?