### PR TITLE
hide table, activate serloTable

### DIFF
--- a/src/components/user/profile-experimental.tsx
+++ b/src/components/user/profile-experimental.tsx
@@ -6,11 +6,6 @@ import { hasOwnPropertyTs } from '@/helper/has-own-property-ts'
 import { isProduction } from '@/helper/is-production'
 
 export const features = {
-  tablePlugin: {
-    cookieName: 'useTablePlugin',
-    isActive: false,
-    activeInDev: true,
-  },
   legacyDesign: {
     cookieName: 'useFrontend',
     isActive: false,
@@ -77,15 +72,7 @@ export function ProfileExperimental() {
       <h2 className="serlo-h2" id="experiments">
         🧪 Experimente
       </h2>
-      {features.tablePlugin && (
-        <div>
-          <h3 className="serlo-h3 mb-3">
-            {renderFeatureButton('tablePlugin')} Editor: New Table Plugin 📋
-          </h3>
-          <p className="serlo-p">Das neue Table Plugin zum testen.</p>
-        </div>
-      )}
-      <hr className="mx-side mb-4 -mt-2" />
+      {/* <hr className="mx-side mb-4 -mt-2" /> */}
       {features.legacyDesign && (
         <div>
           <h3 className="serlo-h3 mb-3">

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -559,7 +559,7 @@ export const loggedInData = {
         spoiler: 'Spoiler',
         spoilerDesc: 'A collapsible box.',
         serloTable: 'Table',
-        serloTableDesc: '(new plugin in testing) Create tables',
+        serloTableDesc: 'Create pretty tables',
         table: 'Table',
         tableDesc: 'Create tables using Markdown.',
         video: 'Video',

--- a/src/edtr-io/get-plugin-registry.tsx
+++ b/src/edtr-io/get-plugin-registry.tsx
@@ -17,7 +17,6 @@ import {
 import { faSquare } from '@fortawesome/free-regular-svg-icons/faSquare'
 import { faGripLinesVertical, faUsers } from '@fortawesome/free-solid-svg-icons'
 
-import { shouldUseFeature } from '@/components/user/profile-experimental'
 import { LoggedInData, UuidType } from '@/data-types'
 
 export function getPluginRegistry(
@@ -105,12 +104,6 @@ export function getPluginRegistry(
       icon: createIcon(faCaretSquareDown),
     },
     {
-      name: 'table',
-      title: editorStrings.edtrIo.table,
-      description: editorStrings.edtrIo.tableDesc,
-      icon: createIcon(faTable),
-    },
-    {
       name: 'serloTable',
       title: editorStrings.edtrIo.serloTable,
       description: editorStrings.edtrIo.serloTableDesc,
@@ -158,12 +151,5 @@ export function getPluginRegistry(
     (plugin) => !['blockquote', 'important'].includes(plugin.name)
   )
 
-  // Testing new table plugin
-  const showNewTable = shouldUseFeature('tablePlugin')
-
-  const tableFiltered = showNewTable
-    ? boxFiltered.filter((plugin) => plugin.name !== 'table')
-    : boxFiltered.filter((plugin) => plugin.name !== 'serloTable')
-
-  return tableFiltered
+  return boxFiltered
 }

--- a/src/edtr-io/plugins/box/index.tsx
+++ b/src/edtr-io/plugins/box/index.tsx
@@ -18,7 +18,6 @@ export function createBoxState(
     'image',
     'equations',
     'multimedia',
-    'table',
     'serloTable',
     'highlight',
   ])

--- a/src/edtr-io/plugins/page-layout/index.ts
+++ b/src/edtr-io/plugins/page-layout/index.ts
@@ -26,7 +26,6 @@ export function createPageLayoutState(
     'injection',
     'multimedia',
     'spoiler',
-    'table',
     'serloTable',
     'video',
   ])


### PR DESCRIPTION
use new `serloTable` plugin by default.

### backlog
- old one should still be supported until we have the mutations done. 
- also there is a bit of a problem with unconverted content. I don't think it's worth the effort to update the converter code to create the state for `serloTable` directly.