### PR TITLE
kratos: refactor auth provider

### DIFF
--- a/src/api/graphql-fetch.ts
+++ b/src/api/graphql-fetch.ts
@@ -1,5 +1,4 @@
 import { GraphQLClient, RequestDocument } from 'graphql-request'
-import { RefObject } from 'react'
 
 import { endpoint } from '@/api/endpoint'
 import { AuthenticationPayload } from '@/auth/auth-provider'
@@ -23,11 +22,9 @@ export function createGraphqlFetch() {
   }
 }
 
-export function createAuthAwareGraphqlFetch(
-  auth: RefObject<AuthenticationPayload>
-) {
+export function createAuthAwareGraphqlFetch(auth: AuthenticationPayload) {
   return async function graphqlFetch(args: string) {
-    if (auth.current === null) throw new Error('unauthorized')
+    if (auth === null) throw new Error('unauthorized')
 
     // proxy calls from localhost to make sure we can send the cookies
     if (window.location.hostname == 'localhost') {

--- a/src/auth/auth-provider.tsx
+++ b/src/auth/auth-provider.tsx
@@ -29,6 +29,20 @@ export function AuthProvider({
     })
   }
 
+  useEffect(() => {
+    // inspired by useSWR
+    const refreshWhenVisible = () => {
+      if (document.visibilityState) refreshAuth()
+    }
+    document.addEventListener('visibilitychange', refreshWhenVisible) //on tab focus change
+    window.addEventListener('online', refreshAuth) //on reconnect
+
+    return () => {
+      document.addEventListener('visibilitychange', refreshWhenVisible)
+      window.removeEventListener('online', refreshAuth)
+    }
+  })
+
   const authorizationPayload = useAuthorizationPayload(
     authenticationPayload,
     unauthenticatedAuthorizationPayload

--- a/src/auth/auth-provider.tsx
+++ b/src/auth/auth-provider.tsx
@@ -5,7 +5,7 @@ import { AuthSessionCookie } from './auth-session-cookie'
 import type { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
 
 export interface AuthContextValue {
-  authenticationPayload: { current: AuthenticationPayload }
+  authenticationPayload: AuthenticationPayload
   authorizationPayload: AuthorizationPayload | null
   refreshAuth: () => void
 }
@@ -19,18 +19,17 @@ export function AuthProvider({
   children: ReactNode
   unauthenticatedAuthorizationPayload?: AuthorizationPayload
 }) {
-  const [authenticationPayload, setAuthenticationPayload] = useState({
-    current: getAuthPayloadFromLocalCookie(AuthSessionCookie.get()),
-  })
+  const [authenticationPayload, setAuthenticationPayload] = useState(
+    getAuthPayloadFromLocalCookie(AuthSessionCookie.get())
+  )
 
   function refreshAuth() {
-    setAuthenticationPayload({
-      current: getAuthPayloadFromLocalCookie(AuthSessionCookie.get()),
-    })
+    setAuthenticationPayload(
+      getAuthPayloadFromLocalCookie(AuthSessionCookie.get())
+    )
   }
 
   useEffect(() => {
-    // inspired by useSWR
     const refreshWhenVisible = () => {
       if (document.visibilityState) refreshAuth()
     }
@@ -86,13 +85,13 @@ export function getAuthPayloadFromLocalCookie(
 }
 
 function useAuthorizationPayload(
-  authenticationPayload: { current: AuthenticationPayload },
+  authenticationPayload: AuthenticationPayload,
   unauthenticatedAuthorizationPayload?: AuthorizationPayload
 ) {
-  async function fetchAuthorizationPayload(authenticationPayload: {
-    current: AuthenticationPayload
-  }): Promise<AuthorizationPayload> {
-    if (authenticationPayload.current === null) {
+  async function fetchAuthorizationPayload(
+    authenticationPayload: AuthenticationPayload
+  ): Promise<AuthorizationPayload> {
+    if (authenticationPayload === null) {
       return unauthenticatedAuthorizationPayload ?? {}
     }
 
@@ -127,7 +126,7 @@ function useAuthorizationPayload(
       }
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authenticationPayload, authenticationPayload.current?.id])
+  }, [authenticationPayload, authenticationPayload?.id])
 
   return authorizationPayload
 }

--- a/src/auth/fetch-auth-session.ts
+++ b/src/auth/fetch-auth-session.ts
@@ -3,10 +3,10 @@ import type { Session } from '@ory/client'
 import { AuthSessionCookie } from './auth-session-cookie'
 import { kratos } from '@/auth/kratos'
 
-// TODO: when auth consumers update without refresh
-// we could run this on route changes and maybe browser tab change / refocus as well?
-
-export async function fetchAndPersistAuthSession(session?: Session | null) {
+export async function fetchAndPersistAuthSession(
+  refreshAuth: () => void,
+  session?: Session | null
+) {
   if (session !== undefined) {
     if (session === null) AuthSessionCookie.remove()
     else AuthSessionCookie.set(session)
@@ -22,5 +22,6 @@ export async function fetchAndPersistAuthSession(session?: Session | null) {
         AuthSessionCookie.remove()
       })
   }
+  refreshAuth()
   return session ?? null
 }

--- a/src/auth/fetch-auth-session.ts
+++ b/src/auth/fetch-auth-session.ts
@@ -4,7 +4,7 @@ import { AuthSessionCookie } from './auth-session-cookie'
 import { kratos } from '@/auth/kratos'
 
 export async function fetchAndPersistAuthSession(
-  refreshAuth: () => void,
+  refreshAuth?: () => void,
   session?: Session | null
 ) {
   if (session !== undefined) {
@@ -22,6 +22,6 @@ export async function fetchAndPersistAuthSession(
         AuthSessionCookie.remove()
       })
   }
-  refreshAuth()
+  if (refreshAuth) refreshAuth()
   return session ?? null
 }

--- a/src/auth/fetch-auth-session.ts
+++ b/src/auth/fetch-auth-session.ts
@@ -4,24 +4,26 @@ import { AuthSessionCookie } from './auth-session-cookie'
 import { kratos } from '@/auth/kratos'
 
 export async function fetchAndPersistAuthSession(
-  refreshAuth?: () => void,
+  refreshAuth?: (session: Session | null) => void,
   session?: Session | null
 ) {
   if (session !== undefined) {
     if (session === null) AuthSessionCookie.remove()
     else AuthSessionCookie.set(session)
+    if (refreshAuth) refreshAuth(session)
   } else {
     await kratos
       .toSession()
       .then(({ data }) => {
         AuthSessionCookie.set(data)
+        if (refreshAuth) refreshAuth(data)
         return data
       })
       .catch(() => {
         // user probably not logged in
         AuthSessionCookie.remove()
+        if (refreshAuth) refreshAuth(null)
       })
   }
-  if (refreshAuth) refreshAuth()
   return session ?? null
 }

--- a/src/auth/use-logout.ts
+++ b/src/auth/use-logout.ts
@@ -37,21 +37,11 @@ export function useLogout() {
               )
             }
             showToastNotice(strings.notices.bye)
-
-            setTimeout(() => {
-              // TODO: make sure router.push() also rerenders authed components (e.g. header)
-              void router.push(originalPreviousPath ?? '/')
-              // window.location.href = originalPreviousPath ?? '/'
-            }, 1000)
-
+            setTimeout(() => router.push(originalPreviousPath ?? '/'), 1000)
             return
           })
-          .catch((error: unknown) => {
-            return Promise.reject(error)
-          })
+          .catch((error: unknown) => Promise.reject(error))
       })
-      .catch((error: unknown) => {
-        return Promise.reject(error)
-      })
+      .catch((error: unknown) => Promise.reject(error))
   }
 }

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -97,7 +97,6 @@ export function Node(props: NodeProps) {
             >
               <span className="flex justify-between content-end">
                 {fieldName}
-                {attributes.type === 'password' ? renderShowHide() : null}
               </span>
               <input
                 className="text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full"
@@ -111,6 +110,7 @@ export function Node(props: NodeProps) {
                 }}
               />
             </label>
+            {attributes.type === 'password' ? renderShowHide() : null}
             {messages}
           </div>
         )
@@ -125,17 +125,19 @@ export function Node(props: NodeProps) {
 
   function renderShowHide() {
     return (
-      <button
-        type="button" // keep this, otherwise enter does not submit form any more
-        onClick={(e) => {
-          e.preventDefault()
-          setShowPassword(!showPassword)
-        }}
-        className="serlo-button-blue-transparent text-base py-0 mr-1.5 mb-0.5 align-super"
-      >
-        <FaIcon icon={showPassword ? faEyeSlash : faEye} />{' '}
-        {showPassword ? 'hide' : 'show'}
-      </button>
+      <div className="text-right mb-20">
+        <button
+          type="button" // keep this, otherwise enter does not submit form any more
+          onClick={(e) => {
+            e.preventDefault()
+            setShowPassword(!showPassword)
+          }}
+          className="serlo-button-blue-transparent text-base py-0 mr-1.5 relative block -mt-24 ml-auto"
+        >
+          <FaIcon icon={showPassword ? faEyeSlash : faEye} />{' '}
+          {showPassword ? 'hide' : 'show'}
+        </button>
+      </div>
     )
   }
 }

--- a/src/components/comments/comment-area-all-threads.tsx
+++ b/src/components/comments/comment-area-all-threads.tsx
@@ -32,7 +32,7 @@ export function CommentAreaAllThreads() {
             instance: lang,
           })}
         </StaticInfoPanel>
-        {auth.current === null ? (
+        {auth === null ? (
           <StaticInfoPanel icon={faWarning} type="warning">
             <PleaseLogIn noWrapper />
           </StaticInfoPanel>

--- a/src/components/comments/comment-area.tsx
+++ b/src/components/comments/comment-area.tsx
@@ -68,7 +68,7 @@ export function CommentArea({
   }
 
   function renderContent() {
-    if (!auth.current && commentCount == 0) return null
+    if (!auth && commentCount == 0) return null
 
     return (
       <>
@@ -98,7 +98,7 @@ export function CommentArea({
       <>
         {renderHeading(faQuestionCircle, ` ${strings.comments.question}`)}
         {
-          auth.current === null ? (
+          auth === null ? (
             <PleaseLogIn />
           ) : canDo(AuthThread.createThread) ? (
             <CommentForm
@@ -127,8 +127,7 @@ export function CommentArea({
   }
 
   function renderReplyForm(threadId: string) {
-    if (!auth.current || noForms || !canDo(AuthThread.createComment))
-      return null
+    if (!auth || noForms || !canDo(AuthThread.createComment)) return null
     return (
       <CommentForm
         placeholder={strings.comments.placeholderReply}
@@ -168,7 +167,7 @@ export function CommentArea({
   }
 
   async function onSend(content: string, reply?: boolean, threadId?: string) {
-    if (auth.current === null) return false
+    if (auth === null) return false
 
     if (reply) {
       if (threadId === undefined) return false

--- a/src/components/content/exercises/exercise-group.tsx
+++ b/src/components/content/exercises/exercise-group.tsx
@@ -49,7 +49,7 @@ export function ExerciseGroup({
         <div className="flex mb-0.5">
           <div className="grow">{groupIntro}</div>
           <div>{license}</div>
-          {loaded && auth.current && (
+          {loaded && auth && (
             <AuthorToolsExercises
               data={{
                 type: ExerciseInlineType.ExerciseGroup,

--- a/src/components/content/exercises/exercise.tsx
+++ b/src/components/content/exercises/exercise.tsx
@@ -105,7 +105,7 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
       !node.solution.license.isDefault && (
         <LicenseNotice minimal data={node.solution.license} type="solution" />
       )
-    const authorTools = loaded && auth.current && (
+    const authorTools = loaded && auth && (
       <AuthorToolsExercises
         data={{
           type: ExerciseInlineType.Solution,
@@ -213,7 +213,7 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
     if (isRevisionView) return null
     return (
       <>
-        {loaded && auth.current && (
+        {loaded && auth && (
           <AuthorToolsExercises
             data={{
               type: ExerciseInlineType.Exercise,

--- a/src/components/frontend-client-base.tsx
+++ b/src/components/frontend-client-base.tsx
@@ -94,10 +94,13 @@ export function FrontendClientBase({
     getCachedLoggedInData()
   )
 
+  const isLoggedIn = AuthSessionCookie.get() !== undefined
+
   useEffect(fetchLoggedInData, [
     instanceData.lang,
     loggedInData,
     loadLoggedInData,
+    isLoggedIn,
   ])
 
   // dev

--- a/src/components/guard.tsx
+++ b/src/components/guard.tsx
@@ -22,7 +22,7 @@ export function Guard({ children, data, error, needsAuth }: GuardProps) {
 
   if (needsAuth && !mounted) return null
 
-  if (needsAuth && auth.current === null) return <PleaseLogIn />
+  if (needsAuth && auth === null) return <PleaseLogIn />
 
   if (!data && !error) return <LoadingSpinner noText />
   if (error) return <LoadingError error={error.toString()} />

--- a/src/components/navigation/header/header.tsx
+++ b/src/components/navigation/header/header.tsx
@@ -17,14 +17,21 @@ export function Header() {
   const hideQuickbar = router.route === '/search' || router.route === '/'
 
   useEffect(() => {
-    document.body.addEventListener('keydown', (event) => {
+    const escapeHandler = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setMobileMenuOpen(false)
-    })
+    }
+    document.body.addEventListener('keydown', escapeHandler)
 
     // close mobile menu on client side navigation, we need the global Router instance
-    Router.events.on('routeChangeStart', () => {
+    const openMobileMenu = () => {
       setMobileMenuOpen(false)
-    })
+    }
+    Router.events.on('routeChangeStart', openMobileMenu)
+
+    return () => {
+      document.body.removeEventListener('keydown', escapeHandler)
+      Router.events.off('routeChangeStart', openMobileMenu)
+    }
   }, [])
 
   return (

--- a/src/components/navigation/header/menu/auth-items.tsx
+++ b/src/components/navigation/header/menu/auth-items.tsx
@@ -2,6 +2,7 @@ import { faBell } from '@fortawesome/free-solid-svg-icons/faBell'
 import dynamic from 'next/dynamic'
 
 import { Item } from './item'
+import { AuthSessionCookie } from '@/auth/auth-session-cookie'
 import { useAuthentication } from '@/auth/use-authentication'
 import type { UnreadNotificationsCountProps } from '@/components/user-tools/unread-notifications-count'
 import { getAvatarUrl } from '@/components/user/user-link'
@@ -18,6 +19,10 @@ export function AuthItems() {
   const auth = useAuthentication()
   const { strings } = useInstanceData()
   const loggedInData = useLoggedInData()
+
+  console.log('running AuthItems')
+  console.log(AuthSessionCookie.get())
+  console.log(auth.current)
 
   const noAuthData = {
     url: '/auth/login',

--- a/src/components/navigation/header/menu/auth-items.tsx
+++ b/src/components/navigation/header/menu/auth-items.tsx
@@ -1,35 +1,20 @@
 import { faBell } from '@fortawesome/free-solid-svg-icons/faBell'
-import dynamic from 'next/dynamic'
 
 import { Item } from './item'
+import { NoAuthItem } from './no-auth-item'
 import { useAuthentication } from '@/auth/use-authentication'
-import type { UnreadNotificationsCountProps } from '@/components/user-tools/unread-notifications-count'
+import { UnreadNotificationsCount } from '@/components/user-tools/unread-notifications-count'
 import { getAvatarUrl } from '@/components/user/user-link'
-import { useInstanceData } from '@/contexts/instance-context'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
-
-const UnreadNotificationsCount = dynamic<UnreadNotificationsCountProps>(() =>
-  import('@/components/user-tools/unread-notifications-count').then(
-    (mod) => mod.UnreadNotificationsCount
-  )
-)
 
 export function AuthItems() {
   const auth = useAuthentication()
-  const { strings } = useInstanceData()
   const loggedInData = useLoggedInData()
 
-  const noAuthData = {
-    url: '/auth/login',
-    title: strings.header.login,
-    icon: 'user',
-  } as const
-
   if (!auth || !loggedInData || !auth.username)
-    return <Item link={noAuthData} />
+    return <NoAuthItem hidden={false} />
 
   const { id, username } = auth
-
   const userMeReplacement = `user/${id}/${username}`
 
   const [notificationLinkData, userLinkData] = loggedInData.authMenu
@@ -42,16 +27,14 @@ export function AuthItems() {
 
   return (
     <>
-      {UnreadNotificationsCount ? (
-        <Item
-          link={notificationLinkData}
-          elementAsIcon={
-            <div className="-top-[2px] md:relative md:mx-[3px] md:my-[7px]">
-              <UnreadNotificationsCount icon={faBell} />
-            </div>
-          }
-        />
-      ) : null}
+      <Item
+        link={notificationLinkData}
+        elementAsIcon={
+          <div className="-top-[2px] md:relative md:mx-[3px] md:my-[7px]">
+            <UnreadNotificationsCount icon={faBell} />
+          </div>
+        }
+      />
       <Item
         link={updatedSubData}
         elementAsIcon={

--- a/src/components/navigation/header/menu/auth-items.tsx
+++ b/src/components/navigation/header/menu/auth-items.tsx
@@ -2,7 +2,6 @@ import { faBell } from '@fortawesome/free-solid-svg-icons/faBell'
 import dynamic from 'next/dynamic'
 
 import { Item } from './item'
-import { AuthSessionCookie } from '@/auth/auth-session-cookie'
 import { useAuthentication } from '@/auth/use-authentication'
 import type { UnreadNotificationsCountProps } from '@/components/user-tools/unread-notifications-count'
 import { getAvatarUrl } from '@/components/user/user-link'
@@ -20,20 +19,18 @@ export function AuthItems() {
   const { strings } = useInstanceData()
   const loggedInData = useLoggedInData()
 
-  console.log('running AuthItems')
-  console.log(AuthSessionCookie.get())
-  console.log(auth.current)
-
   const noAuthData = {
     url: '/auth/login',
     title: strings.header.login,
     icon: 'user',
   } as const
 
-  if (!auth.current || !loggedInData || !auth.current.username)
+  if (!auth || !loggedInData || !auth.username)
     return <Item link={noAuthData} />
 
-  const userMeReplacement = `user/${auth.current.id}/${auth.current.username}`
+  const { id, username } = auth
+
+  const userMeReplacement = `user/${id}/${username}`
 
   const [notificationLinkData, userLinkData] = loggedInData.authMenu
   const updatedSubData = {
@@ -60,8 +57,8 @@ export function AuthItems() {
         elementAsIcon={
           <img
             className="rounded-full w-6 h-6 inline md:my-[7px]"
-            src={getAvatarUrl(auth.current.username)}
-            title={`${updatedSubData.title} ${auth.current.username}`}
+            src={getAvatarUrl(username)}
+            title={`${updatedSubData.title} ${username}`}
           />
         }
       />

--- a/src/components/navigation/header/menu/item.tsx
+++ b/src/components/navigation/header/menu/item.tsx
@@ -32,9 +32,10 @@ export const preventHover: PointerEventHandler = (event) => {
 export interface ItemProps {
   link: HeaderLinkData
   elementAsIcon?: JSX.Element
+  className?: string
 }
 
-export function Item({ link, elementAsIcon }: ItemProps) {
+export function Item({ link, elementAsIcon, className }: ItemProps) {
   const hasChildren = link.children !== undefined
 
   const textAndIcon = (
@@ -48,7 +49,8 @@ export function Item({ link, elementAsIcon }: ItemProps) {
     <RadixItem
       className={clsx(
         'ease-linear duration-700',
-        'block md:inline-block md:mx-[3px]'
+        'block md:inline-block md:mx-[3px]',
+        className
       )}
       key={link.title}
     >

--- a/src/components/navigation/header/menu/menu.tsx
+++ b/src/components/navigation/header/menu/menu.tsx
@@ -3,6 +3,8 @@ import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
 
 import { Item } from './item'
+import { NoAuthItem } from './no-auth-item'
+import { useAuthentication } from '@/auth/use-authentication'
 import { useInstanceData } from '@/contexts/instance-context'
 
 const AuthItems = dynamic<{}>(() =>
@@ -10,6 +12,7 @@ const AuthItems = dynamic<{}>(() =>
 )
 
 export function Menu() {
+  const auth = useAuthentication()
   const { headerData } = useInstanceData()
   const [mounted, setMounted] = useState(false)
 
@@ -21,7 +24,7 @@ export function Menu() {
         {headerData.map((link) => (
           <Item key={link.title} link={link} />
         ))}
-        {mounted ? <AuthItems /> : null}
+        {auth ? <AuthItems /> : <NoAuthItem hidden={!mounted} />}
       </List>
     </Root>
   )

--- a/src/components/navigation/header/menu/no-auth-item.tsx
+++ b/src/components/navigation/header/menu/no-auth-item.tsx
@@ -1,0 +1,14 @@
+import { Item } from './item'
+import { useInstanceData } from '@/contexts/instance-context'
+
+export function NoAuthItem({ hidden }: { hidden: boolean }) {
+  const { strings } = useInstanceData()
+
+  const noAuthData = {
+    url: '/auth/login',
+    title: strings.header.login,
+    icon: 'user',
+  } as const
+
+  return <Item link={noAuthData} className={hidden ? 'opacity-0' : ''} />
+}

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -48,7 +48,7 @@ export function AddRevision({
     }
 
     const makeDamnSureUserIsLoggedIn = async () => {
-      if (auth.current === null) return false
+      if (auth === null) return false
 
       /*
       the better way would be to check if the authenticated cookie is still

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
 import { filterUnwantedRedirection } from './utils'
+import { getAuthPayloadFromSession } from '@/auth/auth-provider'
 import { fetchAndPersistAuthSession } from '@/auth/fetch-auth-session'
 import { kratos } from '@/auth/kratos'
 import type { AxiosError } from '@/auth/types'
@@ -155,15 +156,12 @@ export function Login({ oauth }: { oauth?: boolean }) {
             )
             return
           }
-
+          const username =
+            getAuthPayloadFromSession(data.session)?.username ?? 'Jane Doe'
           showToastNotice(
-            strings.notices.welcome.replace(
-              '%username%',
-              (data.session.identity.traits as { username: string })?.username
-            )
+            strings.notices.welcome.replace('%username%', username)
           )
-          setTimeout(() => router.push(flow?.return_to ?? redirection), 2000)
-
+          void router.push(flow?.return_to ?? redirection)
           return
         })
         .catch((e: Error) => {

--- a/src/components/pages/auth/logout.tsx
+++ b/src/components/pages/auth/logout.tsx
@@ -43,7 +43,7 @@ export function Logout({ oauth }: { oauth?: boolean }) {
               )
             }
             showToastNotice(strings.notices.bye)
-            setTimeout(() => router.push(redirection), 1000)
+            void router.push(redirection)
             return
           })
           .catch((error: AxiosError) => Promise.reject(error))

--- a/src/components/pages/auth/logout.tsx
+++ b/src/components/pages/auth/logout.tsx
@@ -19,12 +19,12 @@ export function Logout({ oauth }: { oauth?: boolean }) {
   const { strings } = useInstanceData()
   const { logout_challenge } = router.query
 
-  const redirection = filterUnwantedRedirection({
-    desiredPath: sessionStorage.getItem('previousPathname'),
-    unwantedPaths: ['/auth/settings', 'auth/login'],
-  })
-
   useEffect(() => {
+    const redirection = filterUnwantedRedirection({
+      desiredPath: sessionStorage.getItem('previousPathname'),
+      unwantedPaths: ['/auth/settings', 'auth/login'],
+    })
+
     const redirectOnError = () => {
       window.location.href = redirection
       return
@@ -61,15 +61,7 @@ export function Logout({ oauth }: { oauth?: boolean }) {
         }
         return Promise.reject(error)
       })
-  }, [
-    router,
-    oauth,
-    logout_challenge,
-    strings.notices.bye,
-    refreshAuth,
-    auth,
-    redirection,
-  ])
+  }, [router, oauth, logout_challenge, strings.notices.bye, refreshAuth, auth])
 
   return <LoadingSpinner text={strings.auth.loggingOut} />
 }

--- a/src/components/pages/auth/logout.tsx
+++ b/src/components/pages/auth/logout.tsx
@@ -55,7 +55,7 @@ export function Logout({ oauth }: { oauth?: boolean }) {
         }
         return Promise.reject(error)
       })
-  }, [router, oauth, logout_challenge, strings.notices.bye])
+  }, [router, oauth, logout_challenge, strings.notices.bye, refreshAuth])
 
   return <LoadingSpinner text={strings.auth.loggingOut} />
 }

--- a/src/components/pages/auth/settings.tsx
+++ b/src/components/pages/auth/settings.tsx
@@ -28,7 +28,7 @@ export function Settings() {
         window.location.reload()
       }
     })
-  }, [])
+  }, [refreshAuth])
 
   const { flow: flowId, return_to: returnTo } = router.query
 

--- a/src/components/pages/auth/settings.tsx
+++ b/src/components/pages/auth/settings.tsx
@@ -7,18 +7,21 @@ import { useEffect, useState } from 'react'
 
 import { fetchAndPersistAuthSession } from '@/auth/fetch-auth-session'
 import { kratos } from '@/auth/kratos'
+import { useAuth } from '@/auth/use-auth'
 import { Flow, FlowType, handleFlowError } from '@/components/auth/flow'
 import { PageTitle } from '@/components/content/page-title'
+import { LoadingSpinner } from '@/components/loading/loading-spinner'
 import { useInstanceData } from '@/contexts/instance-context'
 
 export function Settings() {
   const [flow, setFlow] = useState<SelfServiceSettingsFlow>()
   const router = useRouter()
+  const { refreshAuth } = useAuth()
   const { strings } = useInstanceData()
 
   useEffect(() => {
     // quick hack to fix non authed header state
-    void fetchAndPersistAuthSession().then(() => {
+    void fetchAndPersistAuthSession(refreshAuth).then(() => {
       const { href } = window.location
       if (href.includes('flow=') && !href.includes('#refreshed')) {
         window.location.href = window.location.href + '#refreshed'
@@ -65,7 +68,9 @@ export function Settings() {
           only="password"
           flow={flow}
         />
-      ) : null}
+      ) : (
+        <LoadingSpinner noText />
+      )}
       <style jsx>{`
         @font-face {
           font-family: 'Karmilla';

--- a/src/components/pages/user/notifications.tsx
+++ b/src/components/pages/user/notifications.tsx
@@ -85,7 +85,7 @@ export const Notifications = ({
   }
 
   function setAllToRead() {
-    if (auth.current === null) return
+    if (auth === null) return
 
     const unreadIds = data?.nodes.flatMap((node) =>
       node.unread ? [node.id] : []

--- a/src/components/pages/user/profile-redirect-me.tsx
+++ b/src/components/pages/user/profile-redirect-me.tsx
@@ -9,11 +9,11 @@ export const ProfileRedirectMe: NextPage = () => {
   const auth = useAuthentication()
 
   useEffect(() => {
-    if (auth.current) {
+    if (auth) {
       // hack until we have a mutation
       const isChanged = document.referrer.endsWith('/user/settings')
       const hash = isChanged ? '#profile-refresh' : window.location.hash
-      const url = `/user/${auth.current.id}/${auth.current.username}${hash}`
+      const url = `/user/${auth.id}/${auth.username}${hash}`
       window.location.replace(url)
     } else {
       window.location.replace('/auth/login')

--- a/src/components/pages/user/profile.tsx
+++ b/src/components/pages/user/profile.tsx
@@ -55,7 +55,7 @@ export const Profile: NextPage<ProfileProps> = ({ userData }) => {
     new Date().getTime() - new Date(date).getTime() < 1 * hourInMilliseconds
 
   useEffect(() => {
-    setIsOwnProfile(auth.current?.username === username)
+    setIsOwnProfile(auth?.username === username)
   }, [auth, username])
 
   return (

--- a/src/components/taxonomy/topic-category.tsx
+++ b/src/components/taxonomy/topic-category.tsx
@@ -38,7 +38,7 @@ export function TopicCategory({
 
   if (
     links.length === 0 ||
-    (!auth.current && links.filter((link) => !link.unrevised).length === 0)
+    (!auth && links.filter((link) => !link.unrevised).length === 0)
   )
     return null
 
@@ -60,7 +60,7 @@ export function TopicCategory({
 
   function renderLink(link: TaxonomyLink, i: number) {
     if (link.unrevised && !mounted) return null
-    if (link.unrevised && mounted && !auth.current) return null
+    if (link.unrevised && mounted && !auth) return null
 
     return (
       <li className="block mb-3 leading-cozy" key={link.url + '_' + link.title}>

--- a/src/components/user-tools/edit-or-invite/edit-or-invite.tsx
+++ b/src/components/user-tools/edit-or-invite/edit-or-invite.tsx
@@ -45,7 +45,7 @@ export function EditOrInvite({
     UuidType.User,
   ].includes(data.type as UuidType)
 
-  const isInvite = !auth.current && showInvite
+  const isInvite = !auth && showInvite
 
   const hasUnrevised =
     unrevisedRevisions !== undefined && unrevisedRevisions > 0

--- a/src/components/user-tools/edit-or-invite/tax-add-or-invite.tsx
+++ b/src/components/user-tools/edit-or-invite/tax-add-or-invite.tsx
@@ -41,7 +41,7 @@ export function TaxAddOrInvite({ data, aboveContent }: TaxAddOrInviteProps) {
   if (!data || data.type !== UuidType.TaxonomyTerm) return null
 
   const isExerciseFolder = data.taxonomyType === TaxonomyTermType.ExerciseFolder
-  const isInvite = !auth.current
+  const isInvite = !auth
 
   const href = getEditHref()
   const showEditAction = href || isInvite

--- a/src/components/user-tools/user-tools.tsx
+++ b/src/components/user-tools/user-tools.tsx
@@ -136,7 +136,7 @@ export function UserTools({
           )
         ) : null}
 
-        {auth.current ? (
+        {auth ? (
           data?.type === UuidType.CoursePage ||
           data?.type === UuidType.Course ? (
             <MoreAuthorToolsCourse data={data} aboveContent={aboveContent} />

--- a/src/components/user/event.tsx
+++ b/src/components/user/event.tsx
@@ -108,7 +108,7 @@ export function Event({
 
       case 'CreateThreadNotificationEvent':
         // for invite to chat mvp
-        if (event.object.id === auth.current?.id) {
+        if (event.object.id === auth?.id) {
           return parseString(strings.events.inviteToChat, {
             chatLink: (
               <a className="serlo-link" href="https://community.serlo.org">

--- a/src/components/user/profile-chat-button.tsx
+++ b/src/components/user/profile-chat-button.tsx
@@ -40,7 +40,7 @@ export function ProfileChatButton({
   }, [])
 
   if (!mounted) return null
-  if (auth.current === null) return null
+  if (auth === null) return null
   const isRegistered = !!chatUrl
 
   const text = isOwnProfile

--- a/src/components/user/profile-settings.tsx
+++ b/src/components/user/profile-settings.tsx
@@ -18,8 +18,8 @@ export function ProfileSettings({ rawDescription }: ProfileSettingsProps) {
 
   const auth = useAuthentication()
 
-  if (!auth.current) return null
-  const username = auth.current.username
+  if (!auth) return null
+  const username = auth.username
 
   if (!loggedInData) return null
   const loggedInStrings = loggedInData.strings.profileSettings

--- a/src/edtr-io/plugins/image.tsx
+++ b/src/edtr-io/plugins/image.tsx
@@ -4,6 +4,7 @@ import { gql } from 'graphql-request'
 import fetch from 'unfetch'
 
 import { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
+import { getAuthPayloadFromSession } from '@/auth/auth-provider'
 import { fetchAndPersistAuthSession } from '@/auth/fetch-auth-session'
 import { MediaType, MediaUploadQuery } from '@/fetcher/graphql-types/operations'
 
@@ -67,15 +68,7 @@ export function createReadFile() {
       fetchAndPersistAuthSession()
         .then((session) => {
           const gqlFetch = createAuthAwareGraphqlFetch(
-            session
-              ? {
-                  username: (session.identity.traits as { username: string })
-                    ?.username,
-                  id: (
-                    session.identity.metadata_public as { legacy_id: number }
-                  )?.legacy_id,
-                }
-              : null
+            getAuthPayloadFromSession(session)
           )
           const args = JSON.stringify({
             query: uploadUrlQuery,

--- a/src/edtr-io/plugins/image.tsx
+++ b/src/edtr-io/plugins/image.tsx
@@ -64,10 +64,10 @@ export function createUploadImageHandler() {
 export function createReadFile() {
   return async function readFile(file: File): Promise<LoadedFile> {
     return new Promise((resolve, reject) => {
-      fetchAndPersistAuthSession(() => {}) // TODO: cleanup quick hack
+      fetchAndPersistAuthSession()
         .then((session) => {
-          const gqlFetch = createAuthAwareGraphqlFetch({
-            current: session
+          const gqlFetch = createAuthAwareGraphqlFetch(
+            session
               ? {
                   username: (session.identity.traits as { username: string })
                     ?.username,
@@ -75,8 +75,8 @@ export function createReadFile() {
                     session.identity.metadata_public as { legacy_id: number }
                   )?.legacy_id,
                 }
-              : null,
-          })
+              : null
+          )
           const args = JSON.stringify({
             query: uploadUrlQuery,
             variables: {

--- a/src/edtr-io/plugins/image.tsx
+++ b/src/edtr-io/plugins/image.tsx
@@ -64,7 +64,7 @@ export function createUploadImageHandler() {
 export function createReadFile() {
   return async function readFile(file: File): Promise<LoadedFile> {
     return new Promise((resolve, reject) => {
-      fetchAndPersistAuthSession()
+      fetchAndPersistAuthSession(() => {}) // TODO: cleanup quick hack
         .then((session) => {
           const gqlFetch = createAuthAwareGraphqlFetch({
             current: session

--- a/src/mutations/helper/use-mutation-fetch.ts
+++ b/src/mutations/helper/use-mutation-fetch.ts
@@ -43,8 +43,7 @@ export function useMutationFetch() {
     query: string,
     input: unknown
   ): Promise<boolean | number> {
-    if (auth.current === null)
-      return handleError('UNAUTHENTICATED', errorStrings)
+    if (auth === null) return handleError('UNAUTHENTICATED', errorStrings)
     try {
       const result = await executeQuery()
       if (hasOwnPropertyTs(result, 'entity')) {

--- a/src/mutations/use-user-set-description-mutation.ts
+++ b/src/mutations/use-user-set-description-mutation.ts
@@ -21,13 +21,13 @@ export function useUserSetDescriptionMutation() {
   const successHandler = useSuccessHandler()
 
   return async function (input: UserSetDescriptionInput) {
-    if (!auth.current) return
+    if (!auth) return
     const success = await mutationFetch(mutation, input)
 
     return successHandler({
       success,
       toastKey: 'save',
-      redirectUrl: `/user/${auth.current.id}/${auth.current.username}`,
+      redirectUrl: `/user/${auth.id}/${auth.username}`,
       useHardRedirect: true,
     })
   }

--- a/src/pages/event/history/[...slug].tsx
+++ b/src/pages/event/history/[...slug].tsx
@@ -34,7 +34,7 @@ function Content({ title, id, alias, isUser }: EventHistoryProps['pageData']) {
 
   useEffect(() => {
     if (!isUser) return
-    setIsOwn(auth.current?.id === id)
+    setIsOwn(auth?.id === id)
   }, [auth, isUser, id])
 
   const hasTitle = title && title.length > 1

--- a/src/pages/user/settings.tsx
+++ b/src/pages/user/settings.tsx
@@ -22,10 +22,7 @@ function Content() {
   const auth = useAuthentication()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { data, error } = useFetch(
-    auth.current?.id ? `/${auth.current?.id}` : undefined,
-    lang
-  )
+  const { data, error } = useFetch(auth?.id ? `/${auth?.id}` : undefined, lang)
 
   const rawDescription =
     data?.uuid.description && data.uuid.description !== 'NULL'
@@ -38,15 +35,13 @@ function Content() {
         data={[
           {
             label: strings.entities.userProfile,
-            url: auth.current
-              ? `/user/${auth.current.id}/${auth.current.username}`
-              : '/user/me',
+            url: auth ? `/user/${auth.id}/${auth.username}` : '/user/me',
           },
         ]}
         asBackButton
       />
       <PageTitle title={strings.pageTitles.editProfile} headTitle />
-      {auth.current ? renderSettings() : <PleaseLogIn />}
+      {auth ? renderSettings() : <PleaseLogIn />}
     </>
   )
 


### PR DESCRIPTION
- use state instead of ref to store authed state
- use window `online` (network change) and document `visibilitychange` (tab change/window change etc) events to refresh frontend auth state
- closes #1887


notes for reviewers:
- never mind the branch name
- [most relevant file](https://github.com/serlo/frontend/pull/1900/files#diff-f303b9fa2f4b9034b25b051c5022232a8bfddb1b8e152f4501be05f93f4672fe)

TODO:
- check for additional rerenders because of this change

--- 

> in 1900 there was the [Paris Exposition](https://en.wikipedia.org/wiki/Exposition_Universelle_(1900))