### PR TITLE
fix: Redirect user to OAuth client after first wrong login attempt

### DIFF
--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -43,8 +43,6 @@ const throwError = (error?: unknown) => {
 }
 
 export const oauthHandler = async (type: HandlerType, challenge?: string) => {
-  console.log(`starting oauth flow type: "${type}"`)
-  console.log(challenge)
   const session = AuthSessionCookie.parse()
 
   if (!challenge) throwError('no challenge provided!')

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -153,7 +153,7 @@ export function Login({ oauth }: { oauth?: boolean }) {
         .submitSelfServiceLoginFlow(flow.id, values)
         .then(({ data }) => {
           void fetchAndPersistAuthSession(refreshAuth, data.session)
-          if (oauth) void oauthHandler('login', String(loginChallenge))
+          if (oauth) return oauthHandler('login', String(loginChallenge))
           const username =
             getAuthPayloadFromSession(data.session)?.username ?? 'Jane Doe'
           showToastNotice(

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -147,9 +147,9 @@ export function Login({ oauth }: { oauth?: boolean }) {
 
   async function onLogin(values: SubmitSelfServiceLoginFlowBody) {
     if (!flow?.id) return
-    await router.push(`${router.pathname}?flow=${flow.id}`, undefined, {
-      shallow: true,
-    })
+
+    router.query.flow = flow.id
+    await router.push(router)
 
     const redirection = filterUnwantedRedirection({
       desiredPath: sessionStorage.getItem('previousPathname'),

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -47,13 +47,8 @@ export function Login({ oauth }: { oauth?: boolean }) {
     }
 
     if (oauth) {
-      if (auth) {
-        void oauthHandler('login', String(loginChallenge))
-        return
-      } else {
-        // eslint-disable-next-line no-console
-        console.log('attempted oauth without auth')
-      }
+      void oauthHandler('login', String(loginChallenge))
+      return
     }
 
     if (flowId) {

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -5,7 +5,14 @@ import type {
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
-import { filterUnwantedRedirection, registrationUrl } from './utils'
+import {
+  filterUnwantedRedirection,
+  loginUrl,
+  logoutUrl,
+  registrationUrl,
+  verificationUrl,
+  recoveryUrl,
+} from './utils'
 import { getAuthPayloadFromSession } from '@/auth/auth-provider'
 import { fetchAndPersistAuthSession } from '@/auth/cookie/fetch-and-persist-auth-session'
 import { kratos } from '@/auth/kratos'
@@ -119,7 +126,7 @@ export function Login({ oauth }: { oauth?: boolean }) {
         <div className="mx-side mt-2 pt-3">
           {replacePlaceholders(loginStrings.forgotPassword, {
             forgotLinkText: (
-              <Link href="/auth/recovery" className="font-bold">
+              <Link href={recoveryUrl} className="font-bold">
                 {loginStrings.forgotLinkText}
               </Link>
             ),
@@ -145,7 +152,7 @@ export function Login({ oauth }: { oauth?: boolean }) {
 
     const redirection = filterUnwantedRedirection({
       desiredPath: sessionStorage.getItem('previousPathname'),
-      unwantedPaths: ['auth/verification', 'auth/logout', 'auth/login'],
+      unwantedPaths: [verificationUrl, logoutUrl, loginUrl, recoveryUrl],
     })
 
     try {

--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -143,9 +143,6 @@ export function Login({ oauth }: { oauth?: boolean }) {
   async function onLogin(values: SubmitSelfServiceLoginFlowBody) {
     if (!flow?.id) return
 
-    router.query.flow = flow.id
-    await router.push(router)
-
     const redirection = filterUnwantedRedirection({
       desiredPath: sessionStorage.getItem('previousPathname'),
       unwantedPaths: ['auth/verification', 'auth/logout', 'auth/login'],

--- a/src/components/pages/auth/recovery.tsx
+++ b/src/components/pages/auth/recovery.tsx
@@ -41,9 +41,7 @@ export function Recovery() {
     return kratos
       .submitSelfServiceRecoveryFlow(String(flow?.id), values)
       .then(({ data }) => setFlow(data))
-      .catch(
-        handleFlowError(router, FlowType.recovery, setFlow, strings, true)
-      )
+      .catch(handleFlowError(router, FlowType.recovery, setFlow, strings, true))
   }
   if (!flow) return null
   return (

--- a/src/components/pages/auth/recovery.tsx
+++ b/src/components/pages/auth/recovery.tsx
@@ -37,18 +37,12 @@ export function Recovery() {
       .catch(handleFlowError(router, FlowType.recovery, setFlow, strings))
   }, [flowId, router, router.isReady, returnTo, flow, strings, checkInstance])
 
-  const onSubmit = (values: SubmitSelfServiceRecoveryFlowBody) => {
-    return router
-      .push(`${router.pathname}?flow=${String(flow?.id)}`, undefined, {
-        shallow: true,
-      })
-      .then(() =>
-        kratos
-          .submitSelfServiceRecoveryFlow(String(flow?.id), values)
-          .then(({ data }) => setFlow(data))
-          .catch(
-            handleFlowError(router, FlowType.recovery, setFlow, strings, true)
-          )
+  async function onSubmit(values: SubmitSelfServiceRecoveryFlowBody) {
+    return kratos
+      .submitSelfServiceRecoveryFlow(String(flow?.id), values)
+      .then(({ data }) => setFlow(data))
+      .catch(
+        handleFlowError(router, FlowType.recovery, setFlow, strings, true)
       )
   }
   if (!flow) return null

--- a/src/components/pages/auth/registration.tsx
+++ b/src/components/pages/auth/registration.tsx
@@ -71,35 +71,23 @@ export function Registration() {
 
   async function onSubmit(values: SubmitSelfServiceRegistrationFlowBody) {
     const valuesWithLanguage = { ...values, 'traits.language': lang }
-
-    await router
-      // On submission, add the flow ID to the URL but do not navigate. This prevents the user loosing
-      // their data when they reload the page.
-      .push(`${router.pathname}?flow=${String(flow?.id)}`, undefined, {
-        shallow: true,
-      })
+    nProgress.start()
+    return kratos
+      .submitSelfServiceRegistrationFlow(String(flow?.id), valuesWithLanguage)
       .then(() => {
-        nProgress.start()
-        return kratos
-          .submitSelfServiceRegistrationFlow(
-            String(flow?.id),
-            valuesWithLanguage
-          )
-          .then(() => {
-            setIsSuccessfullySubmitted(true)
-            window.scrollTo({ top: 0, behavior: 'smooth' })
-          })
-          .catch(
-            handleFlowError(
-              router,
-              FlowType.registration,
-              reorderAndSetFlow,
-              strings
-            )
-          )
-          .finally(() => {
-            nProgress.done()
-          })
+        setIsSuccessfullySubmitted(true)
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      })
+      .catch(
+        handleFlowError(
+          router,
+          FlowType.registration,
+          reorderAndSetFlow,
+          strings
+        )
+      )
+      .finally(() => {
+        nProgress.done()
       })
   }
 

--- a/src/components/pages/auth/settings.tsx
+++ b/src/components/pages/auth/settings.tsx
@@ -5,7 +5,6 @@ import {
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
-import { settingsUrl } from './utils'
 import { fetchAndPersistAuthSession } from '@/auth/cookie/fetch-and-persist-auth-session'
 import { kratos } from '@/auth/kratos'
 import { useAuth } from '@/auth/use-auth'

--- a/src/components/pages/auth/settings.tsx
+++ b/src/components/pages/auth/settings.tsx
@@ -107,15 +107,11 @@ export function Settings() {
     </div>
   )
 
-  function onSubmit(values: SubmitSelfServiceSettingsFlowBody) {
+  async function onSubmit(values: SubmitSelfServiceSettingsFlowBody) {
     if (!flow) return Promise.reject()
-    return router
-      .push(`${settingsUrl}?flow=${flow.id}`, undefined, { shallow: true })
-      .then(() =>
-        kratos
-          .submitSelfServiceSettingsFlow(String(flow.id), values)
-          .then(({ data }) => setFlow(data))
-          .catch(handleFlowError(router, FlowType.settings, setFlow, strings))
-      )
+    return kratos
+      .submitSelfServiceSettingsFlow(String(flow.id), values)
+      .then(({ data }) => setFlow(data))
+      .catch(handleFlowError(router, FlowType.settings, setFlow, strings))
   }
 }

--- a/src/components/pages/auth/utils.ts
+++ b/src/components/pages/auth/utils.ts
@@ -3,6 +3,7 @@ export const registrationUrl = '/auth/registration'
 export const verificationUrl = '/auth/verification'
 export const settingsUrl = '/auth/settings'
 export const logoutUrl = '/auth/logout'
+export const recoveryUrl = 'auth/recovery'
 
 export function filterUnwantedRedirection({
   desiredPath,

--- a/src/components/pages/auth/verification.tsx
+++ b/src/components/pages/auth/verification.tsx
@@ -71,28 +71,22 @@ export function Verification() {
     checkInstance,
   ])
 
-  const onSubmit = (values: SubmitSelfServiceVerificationFlowBody) => {
-    return router
-      .push(`${router.pathname}?flow=${String(flow?.id)}`, undefined, {
-        shallow: true,
-      })
-      .then(() =>
-        kratos
-          .submitSelfServiceVerificationFlow(
-            String(flow?.id),
-            values,
-            undefined
-          )
-          .then(({ data }) => setFlow(data))
-          .catch(
-            handleFlowError(
-              router,
-              FlowType.verification,
-              setFlow,
-              strings,
-              true
-            )
-          )
+  const onSubmit = async (values: SubmitSelfServiceVerificationFlowBody) => {
+    return kratos
+      .submitSelfServiceVerificationFlow(
+        String(flow?.id),
+        values,
+        undefined
+      )
+      .then(({ data }) => setFlow(data))
+      .catch(
+        handleFlowError(
+          router,
+          FlowType.verification,
+          setFlow,
+          strings,
+          true
+        )
       )
   }
 

--- a/src/components/pages/auth/verification.tsx
+++ b/src/components/pages/auth/verification.tsx
@@ -32,9 +32,7 @@ export function Verification() {
   useEffect(() => {
     checkInstance({ redirect: true })
 
-    if (!router.isReady || flow) {
-      return
-    }
+    if (!router.isReady || flow) return
 
     const flowHandler = async ({
       data,
@@ -73,20 +71,10 @@ export function Verification() {
 
   const onSubmit = async (values: SubmitSelfServiceVerificationFlowBody) => {
     return kratos
-      .submitSelfServiceVerificationFlow(
-        String(flow?.id),
-        values,
-        undefined
-      )
+      .submitSelfServiceVerificationFlow(String(flow?.id), values, undefined)
       .then(({ data }) => setFlow(data))
       .catch(
-        handleFlowError(
-          router,
-          FlowType.verification,
-          setFlow,
-          strings,
-          true
-        )
+        handleFlowError(router, FlowType.verification, setFlow, strings, true)
       )
   }
 


### PR DESCRIPTION
~It has to be used in conjunction with remember=false.~ Actually, it doesn't, I was misled by the fact described [here](https://github.com/serlo/frontend/pull/1952#issuecomment-1345386501)

It should also fix the infinite login in serlo login page after coming from rocket chat.

Pushing flow id to url is a way of user not lose data. We may want to test if it is what we actually want to happen. edit: tested and it is indeed better, see discussion below.

Thinking: may we want to do the same for other flows... 🤔 edit: answer is yes