### PR TITLE
kratos: fix `Variable "$input" got invalid value null at "input.session"`

### DIFF
--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -53,7 +53,7 @@ export function Login({ oauth }: { oauth?: boolean }) {
       return
     }
 
-    if (oauth) {
+    if (oauth && auth) {
       void oauthHandler('login', String(loginChallenge))
       return
     }


### PR DESCRIPTION
At `auth/oauth/login` the logged in state check was wrongly deleted at https://github.com/serlo/frontend/pull/1952/commits/cd21d9f2b047192f8e1ba9dca1c045f2cee4a882, leading to an early request to the api, what caused the following error:
>```Variable "$input" got invalid value null at "input.session"; Expected non-nullable type "JSON!" not to be null.: {"response":{"errors":[{"message":"Variable \"$input\" got invalid value null at \"input.session\"; Expected non-nullable type \"JSON!\" not to be null.","locations":[{"line":2,"column":15}],"extensions":{"code":"BAD_USER_INPUT","exception":{"stacktrace":["GraphQLError: Variable \"$input\" got invalid value null at \"input.session\"; Expected non-nullable type \"JSON!\" not to be null.","    at /usr/src/app/node_modules/graphql/execution/values.js:147:11","    at coerceInputValueImpl (/usr/src/app/node_modules/graphql/utilities/coerceInputValue.js:52:5)","    at coerceInputValueImpl (/usr/src/app/node_modules/graphql/utilities/coerceInputValue.js:117:34)","    at coerceInputValueImpl (/usr/src/app/node_modules/graphql/utilities/coerceInputValue.js:49:14)","    at coerceInputValue (/usr/src/app/node_modules/graphql/utilities/coerceInputValue.js:32:10)","    at coerceVariableValues (/usr/src/app/node_modules/graphql/execution/values.js:132:69)","    at getVariableValues (/usr/src/app/node_modules/graphql/execution/values.js:45:21)","    at buildExecutionContext (/usr/src/app/node_modules/graphql/execution/execute.js:280:63)","    at execute (/usr/src/app/node_modules/graphql/execution/execute.js:116:22)","    at execute (/usr/src/app/node_modules/apollo-server-core/dist/requestPipeline.js:205:48)"]}}}],"status":400,"headers":{"map":{"content-length":"1311","content-type":"application/json; charset=utf-8"}}},"request":{"query":"\n    mutation ($input: OauthAcceptInput!) {\n      oauth {\n        acceptLogin(input: $input) {\n          redirectUri\n        }\n      }\n    }\n  ","variables":{"input":{"session":null,"challenge":"2fb817f735c240c59cd129b1d12e5b50"}}}}```
Of course, it can only accept login if the user is already logged in.