### PR TITLE
fix dom validation

### DIFF
--- a/src/edtr-io/plugins/article/article-exercises.tsx
+++ b/src/edtr-io/plugins/article/article-exercises.tsx
@@ -63,7 +63,7 @@ export function ArticleExercises({
           }}
         </Droppable>
       </DragDropContext>
-      <p className="mt-4 mb-1">
+      <div className="mt-4 mb-1">
         {exerciseFolder.title.value ? (
           <>
             {folderHeader}
@@ -72,7 +72,7 @@ export function ArticleExercises({
             </a>
           </>
         ) : null}
-      </p>
+      </div>
     </>
   )
 


### PR DESCRIPTION
this line is wrapped in p:

https://github.com/serlo/frontend/blob/325799755713328cf0625e3a847066ea3a905c66/src/edtr-io/plugins/article/article-exercises.tsx#L24

but later it's wrapped in p again. Use div instead