### PR TITLE
yarn: Add config "supportedArchitectures"

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,9 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs
     spec: 'https://mskelton.dev/yarn-outdated/v2'
 
+supportedArchitectures:
+  os:
+    - linux
+    - darwin
+
 yarnPath: .yarn/releases/yarn-3.2.1.cjs


### PR DESCRIPTION
See https://yarnpkg.com/configuration/yarnrc#supportedArchitectures (This should install the next version for `darwin` and `linux`)