### PR TITLE
fix: Center first explanation in equation plugin

### DIFF
--- a/src/components/content/equations.tsx
+++ b/src/components/content/equations.tsx
@@ -112,7 +112,7 @@ export function Equations({
 
     return (
       <>
-        <tr className="whitespace-normal text-brandgreen-darker">
+        <tr className="whitespace-normal text-brandgreen-darker text-center">
           <td className="relative -left-side pb-4" colSpan={3}>
             {renderNested(firstExplanation, 'firstExplanation')}
           </td>

--- a/src/edtr-io/plugins/equations/editor.tsx
+++ b/src/edtr-io/plugins/equations/editor.tsx
@@ -21,6 +21,7 @@ import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { EquationsProps, stepProps } from '.'
 import {
   EquationsRenderer,
+  FirstExplanationTr,
   ExplanationTr,
   LeftTd,
   MathTd,
@@ -277,7 +278,7 @@ export function EquationsEditor(props: EquationsProps) {
 
     return (
       <tbody onFocus={() => gridFocus.setFocus('firstExplanation')}>
-        <ExplanationTr>
+        <FirstExplanationTr>
           <td />
           <td colSpan={3}>
             {state.firstExplanation.render({
@@ -286,7 +287,7 @@ export function EquationsEditor(props: EquationsProps) {
               },
             })}
           </td>
-        </ExplanationTr>
+        </FirstExplanationTr>
         <tr style={{ height: '30px' }}>
           <td />
           <td />

--- a/src/edtr-io/plugins/equations/renderer.tsx
+++ b/src/edtr-io/plugins/equations/renderer.tsx
@@ -31,10 +31,10 @@ export const TransformTd = styled(MathTd)({
   paddingLeft: '5px',
 })
 
-export const ExplanationTr = styled.tr({
-  div: {
-    margin: 0,
-  },
+export const ExplanationTr = styled.tr({ div: { margin: 0 } })
+export const FirstExplanationTr = styled(ExplanationTr)({
+  textAlign: 'center',
+  div: { margin: 0 },
 })
 
 export enum TransformationTarget {
@@ -109,11 +109,11 @@ export function EquationsRenderer({ state }: EquationsProps) {
 
     return (
       <>
-        <ExplanationTr>
+        <FirstExplanationTr>
           <td colSpan={3} className={tdPadding}>
             {state.firstExplanation.render()}
           </td>
-        </ExplanationTr>
+        </FirstExplanationTr>
         <tr style={{ height: '30px' }}>
           <td />
           {renderDownArrow()}


### PR DESCRIPTION
Before: 
![2023-01-27-140030_127x212_scrot](https://user-images.githubusercontent.com/1327215/215093664-05654a0c-59b0-4e8b-b05d-a405656fd427.png)
 After: 
![2023-01-27-140252_122x219_scrot](https://user-images.githubusercontent.com/1327215/215093689-47c1b131-ce22-4198-9a60-41f188849403.png)
