### PR TITLE
fix: Proper vertical-align for placeholders in slate

### DIFF
--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -580,12 +580,3 @@ main b {
 body {
   @apply tracking-slightly-tighter;
 }
-
-/*
- * Fix for misplacement of slate placeholders
- *
- * TODO: Investigate whether we still need this fix after slate upgrade
- */
-span[data-slate-leaf='true'] > span > span[contenteditable='false'] {
-  vertical-align: initial !important;
-}

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -580,3 +580,12 @@ main b {
 body {
   @apply tracking-slightly-tighter;
 }
+
+/*
+ * Fix for misplacement of slate placeholders
+ *
+ * TODO: Investigate whether we still need this fix after slate upgrade
+ */
+span[data-slate-leaf='true'] > span > span[contenteditable='false'] {
+  vertical-align: initial !important;
+}

--- a/src/edtr-io/serlo-editor.tsx
+++ b/src/edtr-io/serlo-editor.tsx
@@ -111,6 +111,13 @@ export function SerloEditor({
         div[data-slate-editor] {
           -webkit-user-modify: read-write !important;
         }
+        /*
+         * Fix for misplacement of slate placeholders
+         * TODO: Investigate whether we still need this fix after slate upgrade
+         */
+        span[data-slate-leaf='true'] > span > span[contenteditable='false'] {
+          vertical-align: initial !important;
+        }
       `}</style>
     </SaveContext.Provider>
   )


### PR DESCRIPTION
Steps to reproduce:

1. Open the editor
2. Add a box and select "blanko"
3. You cannot click the title in most cases (it seems it is overlapped by the div of the "+" button from the rows plugin below -> See screenshot)

![2023-01-31-165906_393x97_scrot](https://user-images.githubusercontent.com/1327215/215812627-b89b4ba5-f1de-4574-ae46-85cf621c4a18.png)

This is a workaround which fixes this issue for me. See https://github.com/serlo/ece-as-a-service/pull/166/commits/c4188671dcfe51781d975a6e6b02bb628e15e9d9