### PR TITLE
registration: add interest dropdown

### DIFF
--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -131,30 +131,35 @@ export function Node({
   function renderInput(attributes: UiNodeInputAttributes) {
     const basicFields = {
       className:
-        'text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full',
+        'text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 focus:outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full border-2 border-transparent focus:border-brand border-solid',
       name: attributes.name,
       onChange: (e: { target: { value: string } }) => {
         void onChange(e.target.value)
       },
     }
+
     if (attributes.name === 'traits.interest') {
       return (
-        <select
-          {...{
-            ...basicFields,
-            className: basicFields.className + ' [&:invalid]:text-brand-400',
-          }}
-          required
-        >
-          <option value="" disabled selected className="hidden">
-            - {strings.auth.interests.pleaseChoose} -
-          </option>
-          <option value="parent">{strings.auth.interests.parent}</option>
-          <option value="teacher">{strings.auth.interests.teacher}</option>
-          <option value="pupil">{strings.auth.interests.pupil}</option>
-          <option value="student">{strings.auth.interests.student}</option>
-          <option value="other">{strings.auth.interests.other}</option>
-        </select>
+        <div className="after:content-['▾'] after:absolute after:-ml-9 after:mt-2.5 after:text-brand after:text-2xl border-solid">
+          <select
+            {...{
+              ...basicFields,
+              className:
+                basicFields.className +
+                ` [&:invalid]:text-brand-400 appearance-none`,
+            }}
+            required
+          >
+            <option value="" disabled selected className="hidden">
+              - {strings.auth.interests.pleaseChoose} -
+            </option>
+            <option value="parent">{strings.auth.interests.parent}</option>
+            <option value="teacher">{strings.auth.interests.teacher}</option>
+            <option value="pupil">{strings.auth.interests.pupil}</option>
+            <option value="student">{strings.auth.interests.student}</option>
+            <option value="other">{strings.auth.interests.other}</option>
+          </select>
+        </div>
       )
     }
 

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -1,7 +1,7 @@
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye'
 import { faEyeSlash } from '@fortawesome/free-solid-svg-icons/faEyeSlash'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner'
-import { UiNode } from '@ory/client'
+import { UiNode, UiNodeInputAttributes } from '@ory/client'
 import { isUiNodeInputAttributes } from '@ory/integrations/ui'
 import clsx from 'clsx'
 import { FormEvent, useState } from 'react'
@@ -111,17 +111,7 @@ export function Node({
               <span className="flex justify-between content-end">
                 {fieldName}
               </span>
-              <input
-                className="text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full"
-                type={showPassword ? 'text' : attributes.type}
-                name={attributes.name}
-                pattern={attributes.pattern}
-                value={(value as string) ?? ''}
-                disabled={disabled}
-                onChange={(e) => {
-                  void onChange(e.target.value)
-                }}
-              />
+              {renderInput(attributes)}
             </label>
             {attributes.type === 'password' ? (
               <>
@@ -139,6 +129,40 @@ export function Node({
     message: 'kratos: tried to render a node which is not an input node',
   })
   return null
+
+  function renderInput(attributes: UiNodeInputAttributes) {
+    const basicFields = {
+      className:
+        'text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full',
+      name: attributes.name,
+      onChange: (e: { target: { value: string } }) => {
+        void onChange(e.target.value)
+      },
+    }
+
+    if (attributes.name === 'traits.interest') {
+      return (
+        <select {...basicFields}>
+          <option value=""></option>
+          <option value="parent">Parent</option>
+          <option value="teacher">Teacher</option>
+          <option value="pupil">Pupil</option>
+          <option value="student">Student</option>
+          <option value="other">Other</option>
+        </select>
+      )
+    }
+
+    return (
+      <input
+        {...basicFields}
+        type={showPassword ? 'text' : attributes.type}
+        pattern={attributes.pattern}
+        value={(value as string) ?? ''}
+        disabled={disabled}
+      />
+    )
+  }
 
   function renderShowHide() {
     return (

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -143,12 +143,12 @@ export function Node({
     if (attributes.name === 'traits.interest') {
       return (
         <select {...basicFields}>
-          <option value=""></option>
-          <option value="parent">Parent</option>
-          <option value="teacher">Teacher</option>
-          <option value="pupil">Pupil</option>
-          <option value="student">Student</option>
-          <option value="other">Other</option>
+          <option value="nothing">{strings.auth.interests.pleaseChoose}</option>
+          <option value="parent">{strings.auth.interests.parent}</option>
+          <option value="teacher">{strings.auth.interests.teacher}</option>
+          <option value="pupil">{strings.auth.interests.pupil}</option>
+          <option value="student">{strings.auth.interests.student}</option>
+          <option value="other">{strings.auth.interests.other}</option>
         </select>
       )
     }

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -143,6 +143,7 @@ export function Node({
     if (attributes.name === 'traits.interest') {
       return (
         <select {...basicFields}>
+          {/* value="" would be accepted, avoid it if you want to enforce users to fill in this field. */}
           <option value="nothing">{strings.auth.interests.pleaseChoose}</option>
           <option value="parent">{strings.auth.interests.parent}</option>
           <option value="teacher">{strings.auth.interests.teacher}</option>

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -139,12 +139,18 @@ export function Node({
         void onChange(e.target.value)
       },
     }
-
     if (attributes.name === 'traits.interest') {
       return (
-        <select {...basicFields}>
-          {/* value="" would be accepted, avoid it if you want to enforce users to fill in this field. */}
-          <option value="nothing">{strings.auth.interests.pleaseChoose}</option>
+        <select
+          {...{
+            ...basicFields,
+            className: basicFields.className + ' [&:invalid]:text-brand-400',
+          }}
+          required
+        >
+          <option value="" disabled selected className="hidden">
+            - {strings.auth.interests.pleaseChoose} -
+          </option>
           <option value="parent">{strings.auth.interests.parent}</option>
           <option value="teacher">{strings.auth.interests.teacher}</option>
           <option value="pupil">{strings.auth.interests.pupil}</option>

--- a/src/data/de/index.ts
+++ b/src/data/de/index.ts
@@ -353,7 +353,16 @@ export const instanceData = {
         identifier: "Benutzername oder E-Mailadresse",
         username: "Benutzername",
         password: "Passwort",
-        email: "E-Mail-Adresse"
+        email: "E-Mail-Adresse",
+        interest: 'Ich bin hier als...'
+      },
+      interests: {
+        pleaseChoose: 'Bitte wähle eines',
+        parent: 'Elternteil',
+        teacher: 'LehrerIn',
+        pupil: 'SchülerIn',
+        student: 'StudentIn',
+        other: 'Sonstige',
       },
       messages: {
         code1010003: "Zur Sicherheit überprüfen wir hier noch mal, ob das dein Account ist.",

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -376,7 +376,15 @@ export const instanceData = {
         username: 'Username',
         password: 'Password',
         email: 'Email',
-        interest: 'You are here as...'
+        interest: "I'm here as..."
+      },
+      interests: {
+        pleaseChoose: 'Please choose one',
+        parent: 'Parent',
+        teacher: 'Teacher',
+        pupil: 'Pupil',
+        student: 'University student',
+        other: 'Other',
       },
       messages: {
         code1010003: 'Please confirm this action by verifying that it is you.',

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -379,7 +379,7 @@ export const instanceData = {
         interest: "I'm here as..."
       },
       interests: {
-        pleaseChoose: 'Please choose one',
+        pleaseChoose: 'please choose',
         parent: 'Parent',
         teacher: 'Teacher',
         pupil: 'Pupil',

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -376,6 +376,7 @@ export const instanceData = {
         username: 'Username',
         password: 'Password',
         email: 'Email',
+        interest: 'You are here as...'
       },
       messages: {
         code1010003: 'Please confirm this action by verifying that it is you.',


### PR DESCRIPTION
In legacy the field "I'm here as..." was called `interests`. 
That's the reason for the field name (in singular though).

Note that it has to be deployed in conjunction with https://github.com/serlo/cloudflare-worker/pull/380.
Otherwise, it will lead to errors.

The node.tsx component is getting every time worse with so many flags, we may want to use this feat to refactor it or to refactor the auth components to not be dependent of it.