### PR TITLE
kratos: Add SSO Button in login for NBP

### DIFF
--- a/src/components/pages/auth/login.tsx
+++ b/src/components/pages/auth/login.tsx
@@ -181,9 +181,6 @@ export function Login({ oauth }: { oauth?: boolean }) {
           void router.push(flow.return_to ?? redirection)
           return
         })
-        .catch((e: Error) => {
-          throw e
-        })
     } catch (e: unknown) {
       try {
         await handleFlowError(

--- a/src/data/de/index.ts
+++ b/src/data/de/index.ts
@@ -370,6 +370,7 @@ export const instanceData = {
       messages: {
         code1010003: "Zur Sicherheit überprüfen wir hier noch mal, ob das dein Account ist.",
         code1010001: "Anmelden",
+        code1010002: "Anmelden mit NBP-Account",
         code1010013: "Weiter",
         code1040001: "Account anlegen",
         code1040003: "Weiter",

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -392,6 +392,7 @@ export const instanceData = {
       messages: {
         code1010003: 'Please confirm this action by verifying that it is you.',
         code1010001: 'Sign in',
+        code1010002: 'Sign in with NBP Account',
         code1010013: 'Continue',
         code1040001: 'Register',
         code1040003: 'Continue',


### PR DESCRIPTION
- It depends on the configuration of kratos (for now only testable using serlo/local-dev-env)
- After coming from OIDC flow, the config of kratos has to hit a route where `fetchAndPersistAuthSession` is called, otherwise the user won't know that they are logged in. For that it would be nice if frontend had an endpoint specific for OIDC
- Styling has to be improved
