### PR TITLE
count parents before breadcrumbs logic

### DIFF
--- a/src/fetcher/create-breadcrumbs.tsx
+++ b/src/fetcher/create-breadcrumbs.tsx
@@ -120,10 +120,12 @@ export function createBreadcrumbs(uuid: MainUuidType, instance: Instance) {
     instance: Instance
   ) {
     if (taxonomyPaths === undefined) return undefined
+
+    // we select first shortest taxonomy path as main taxonomy and show it in breadcrumbs
+    // this happens directly on taxonomy parents and is not taking short-cuircuits into account
     let mainTax
     let count = -1
 
-    // select first shortest taxonomy path
     for (const path of taxonomyPaths) {
       if (!path) continue
       if (count === -1 || count > countParents(path)) {


### PR DESCRIPTION
at least fixes https://frontend-git-2181-choose-main-taxonomy-by-shortest-path-serlo.vercel.app//1555