### PR TITLE
fix and simplify highlight plugin

### DIFF
--- a/src/edtr-io/plugins/highlight/editor.tsx
+++ b/src/edtr-io/plugins/highlight/editor.tsx
@@ -14,7 +14,7 @@ export function HighlightEditor(props: HighlightProps) {
     if (!edit) {
       setTimeout(() => {
         setEditThrottled(false)
-      }, 500)
+      }, 100)
     } else {
       setEditThrottled(true)
     }
@@ -26,6 +26,7 @@ export function HighlightEditor(props: HighlightProps) {
         value={state.code.value}
         name="text"
         placeholder={i18n.code.placeholder}
+        spellCheck={false}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           state.code.set(e.target.value)
         }}
@@ -54,16 +55,11 @@ export function HighlightEditor(props: HighlightProps) {
           <select
             onChange={(e) => state.language.set(e.target.value)}
             className="cursor-pointer"
+            value={state.language.value}
           >
             {languages.map((language) => {
               return (
-                <option
-                  key={language}
-                  value={language}
-                  selected={
-                    state.language.value === language ? true : undefined
-                  }
-                >
+                <option key={language} value={language}>
                   {language}
                 </option>
               )

--- a/src/edtr-io/plugins/highlight/editor.tsx
+++ b/src/edtr-io/plugins/highlight/editor.tsx
@@ -1,31 +1,8 @@
-import {
-  EditorCheckbox,
-  EditorInput,
-  EditorInlineSettings,
-} from '@edtr-io/editor-ui'
-import { styled } from '@edtr-io/ui'
 import { useState } from 'react'
 
 import { HighlightProps } from '.'
 
-const Textarea = styled.textarea({
-  height: '250px',
-  width: '100%',
-  margin: 'auto',
-  padding: '10px',
-  resize: 'none',
-  fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-  border: 'none',
-  outline: 'none',
-  boxShadow: '0 1px 1px 0 rgba(0,0,0,0.50)',
-  '&::-webkit-input-placeholder': {
-    color: 'rgba(0,0,0,0.5)',
-  },
-})
-
-const CheckboxContainer = styled.div({
-  float: 'right',
-})
+const languages = ['text', 'c', 'javascript', 'jsx', 'markup', 'java', 'python']
 
 export function HighlightEditor(props: HighlightProps) {
   const { config, state, focused, editable } = props
@@ -42,9 +19,10 @@ export function HighlightEditor(props: HighlightProps) {
       setEditThrottled(true)
     }
   }
+
   return throttledEdit || edit ? (
     <>
-      <Textarea
+      <textarea
         value={state.code.value}
         name="text"
         placeholder={i18n.code.placeholder}
@@ -53,36 +31,11 @@ export function HighlightEditor(props: HighlightProps) {
         }}
         // make sure editor does not create new plugin on enter etc
         onKeyDown={(e) => e.stopPropagation()}
+        className="h-32 w-full m-auto p-side resize-y font-mono shadow-menu border-none"
       >
         {state.code.value}
-      </Textarea>
-      <EditorInlineSettings>
-        <EditorInput
-          list="available-languages"
-          label="Language:"
-          value={state.language.value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            state.language.set(e.target.value)
-          }}
-          placeholder={i18n.language.placeholder}
-        />
-        <datalist id="available-languages">
-          {['c', 'javascript', 'jsx', 'markup', 'java', 'python'].map(
-            (language) => {
-              return <option key={language} value={language} />
-            }
-          )}
-        </datalist>
-        <CheckboxContainer>
-          <EditorCheckbox
-            label={i18n.showLineNumbers.label}
-            onChange={() => {
-              state.showLineNumbers.set(!state.showLineNumbers.value)
-            }}
-            checked={state.showLineNumbers.value}
-          />
-        </CheckboxContainer>
-      </EditorInlineSettings>
+      </textarea>
+      {renderSettings()}
     </>
   ) : (
     <Renderer
@@ -92,4 +45,42 @@ export function HighlightEditor(props: HighlightProps) {
       code={state.code.value}
     />
   )
+
+  function renderSettings() {
+    return (
+      <div className="mt-2 flex justify-between">
+        <label>
+          Language:{' '}
+          <select
+            onChange={(e) => state.language.set(e.target.value)}
+            className="cursor-pointer"
+          >
+            {languages.map((language) => {
+              return (
+                <option
+                  key={language}
+                  value={language}
+                  selected={
+                    state.language.value === language ? true : undefined
+                  }
+                >
+                  {language}
+                </option>
+              )
+            })}
+          </select>
+        </label>
+        <label className="cursor-pointer">
+          {i18n.showLineNumbers.label}:{' '}
+          <input
+            type="checkbox"
+            onChange={() => {
+              state.showLineNumbers.set(!state.showLineNumbers.value)
+            }}
+            checked={state.showLineNumbers.value}
+          />
+        </label>
+      </div>
+    )
+  }
 }

--- a/src/edtr-io/plugins/highlight/editor.tsx
+++ b/src/edtr-io/plugins/highlight/editor.tsx
@@ -51,6 +51,8 @@ export function HighlightEditor(props: HighlightProps) {
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           state.code.set(e.target.value)
         }}
+        // make sure editor does not create new plugin on enter etc
+        onKeyDown={(e) => e.stopPropagation()}
       >
         {state.code.value}
       </Textarea>

--- a/src/edtr-io/plugins/paste-hack/editor.tsx
+++ b/src/edtr-io/plugins/paste-hack/editor.tsx
@@ -113,6 +113,7 @@ export const PasteHackEditor: React.FunctionComponent<PasteHackPluginProps> = (
             'mt-1 mb-7 flex items-center rounded-2xl w-full p-2',
             'bg-brand-200 border-2 border-brand-200 focus-within:outline-none focus-within:border-brand-500'
           )}
+          // make sure editor does not create new plugin on enter etc
           onKeyDown={(e) => e.stopPropagation()}
         />
         <button


### PR DESCRIPTION
- closes #2183
- removes styled components
- relies on native styling and cleaner markup

(might look wonky on some OSs/Browsers but works way better and styling overhaul will come soon anyway)