### PR TITLE
lumi proxy

### DIFF
--- a/src/components/content/exercises/exercise.tsx
+++ b/src/components/content/exercises/exercise.tsx
@@ -212,7 +212,11 @@ export function Exercise({ node, renderNested, path }: ExerciseProps) {
         )
       }
       if (state.interactive.plugin === 'h5p') {
-        return <H5p url={state.interactive.state} />
+        return (
+          <Lazy>
+            <H5p url={state.interactive.state} />
+          </Lazy>
+        )
       }
     }
   }

--- a/src/components/content/h5p.tsx
+++ b/src/components/content/h5p.tsx
@@ -6,15 +6,20 @@ export interface H5pProps {
   url: string
 }
 
+export function parseH5pUrl(url: string) {
+  const result = /https:\/\/app\.lumi\.education\/run\/(\w+)/i.exec(url)
+  return result ? result[1] : null
+}
+
 export function H5p({ url }: H5pProps) {
-  const id = /https:\/\/app\.lumi\.education\/run\/(.+)/i.exec(url)
+  const id = parseH5pUrl(url)
   const { strings } = useInstanceData()
 
   if (!id) {
     return <p className="serlo-p">{strings.errors.defaultMessage}</p>
   }
 
-  const src = `/api/frontend/lumi/embed/${id[1]}`
+  const src = `/api/frontend/lumi/embed/${id}`
 
   return (
     <div className="mx-side mb-block">

--- a/src/components/content/h5p.tsx
+++ b/src/components/content/h5p.tsx
@@ -1,12 +1,20 @@
 import Script from 'next/script'
 
+import { useInstanceData } from '@/contexts/instance-context'
+
 export interface H5pProps {
   url: string
 }
 
 export function H5p({ url }: H5pProps) {
   const id = /https:\/\/app\.lumi\.education\/run\/(.+)/i.exec(url)
-  const src = `/api/frontend/lumi/embed/${id ? id[1] : '_'}`
+  const { strings } = useInstanceData()
+
+  if (!id) {
+    return <p className="serlo-p">{strings.errors.defaultMessage}</p>
+  }
+
+  const src = `/api/frontend/lumi/embed/${id[1]}`
 
   return (
     <div className="mx-side mb-block">

--- a/src/components/content/h5p.tsx
+++ b/src/components/content/h5p.tsx
@@ -1,36 +1,23 @@
 import Script from 'next/script'
 
-import { PrivacyWrapper } from './privacy-wrapper'
-import { ExternalProvider } from '@/helper/use-consent'
-
 export interface H5pProps {
   url: string
 }
 
 export function H5p({ url }: H5pProps) {
   const id = /https:\/\/app\.lumi\.education\/run\/(.+)/i.exec(url)
-  const src = `https://app.Lumi.education/api/v1/run/${id ? id[1] : '_'}/embed`
+  const src = `/api/frontend/lumi/embed/${id ? id[1] : '_'}`
 
   return (
-    <>
-      <PrivacyWrapper
-        type="h5p"
-        provider={ExternalProvider.H5p}
-        embedUrl={url}
-        className="print:hidden"
-      >
-        <div className="mx-side mb-block">
-          <iframe
-            src={src}
-            width="727"
-            height="500"
-            allowFullScreen
-            allow="geolocation *; microphone *; camera *; midi *; encrypted-media *"
-          ></iframe>
-          <Script src="/_assets/h5p-resizer.js" />
-        </div>
-      </PrivacyWrapper>
-      <p className="serlo-p hidden print:block">[{url}]</p>
-    </>
+    <div className="mx-side mb-block">
+      <iframe
+        src={src}
+        width="727"
+        height="500"
+        allowFullScreen
+        allow="geolocation *; microphone *; camera *; midi *; encrypted-media *"
+      ></iframe>
+      <Script src="/_assets/h5p-resizer.js" />
+    </div>
   )
 }

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -1,4 +1,3 @@
-import { faFaceGrinStars } from '@fortawesome/free-regular-svg-icons'
 import { faHeart, faSpinner } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { useState, KeyboardEvent, useEffect } from 'react'
@@ -17,7 +16,7 @@ interface PrivacyWrapperProps {
   children: JSX.Element
   className?: string
   placeholder?: JSX.Element
-  type: 'video' | 'applet' | 'twingle' | 'h5p'
+  type: 'video' | 'applet' | 'twingle'
   provider: ExternalProvider
   embedUrl?: string
   twingleCallback?: () => void
@@ -87,7 +86,6 @@ export function PrivacyWrapper({
       provider: provider,
     })
     if (isTwingle && showIframe) return null
-    if (type === 'h5p' && showIframe) return null
 
     const previewImageUrl = isTwingle
       ? '/_assets/img/donations-form.png'
@@ -137,8 +135,6 @@ export function PrivacyWrapper({
                   ? faSpinner
                   : type === 'twingle'
                   ? faHeart
-                  : type === 'h5p'
-                  ? faFaceGrinStars
                   : entityIconMapping[type]
               }
             />{' '}

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -184,8 +184,7 @@ export const instanceData = {
       text: 'By clicking on image or button above you agree that external content from %provider% will be loaded. Also personal data may be transferred to this service in accordance with our %privacypolicy%.',
       video: 'Play Video from %provider%',
       applet: 'Load Applet from %provider%',
-      twingle: 'Load Donation Form',
-      h5p: 'Load Interactive Content'
+      twingle: 'Load Donation Form'
     },
     comments: {
       question: 'Do you have a question?',

--- a/src/edtr-io/plugins/h5p.tsx
+++ b/src/edtr-io/plugins/h5p.tsx
@@ -5,22 +5,15 @@ import {
   string,
   StringStateType,
 } from '@edtr-io/plugin'
-import Script from 'next/script'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+
+import { H5p, parseH5pUrl } from '@/components/content/h5p'
 
 export type H5pPluginState = StringStateType
 export type H5pProps = EditorPluginProps<H5pPluginState>
 
 const h5pLibraryWhitelist = [
-  'H5P.AdvancedText',
-  'FontAwesome',
-  'jQuery.ui',
-  'H5P.JoubelUI',
-  'H5P.Transition',
-  'H5P.FontIcons',
-  'H5P.Question',
   'H5P.DragQuestion',
-  'H5P.TextUtilities',
   'H5P.Blanks',
   'H5P.DragText',
   'H5P.ImageHotspotQuestion',
@@ -30,22 +23,69 @@ export const H5pPlugin: EditorPlugin<H5pPluginState> = {
   Component: H5pEditor,
   config: {},
   state: string(),
-  /*onText(value) {
-      if (/geogebra\.org\/m\/(.+)/.test(value)) {
-        return { state: value }
-      }
-    },*/
 }
 
-export function H5pEditor(props: H5pProps) {
-  const { state } = props
+// Note: This plugin will not be translated for now, as i18n work is deprioritized
+export function H5pEditor({ state, autofocusRef }: H5pProps) {
+  const hasState = !!state.value
 
   const [mode, setMode] = useState<'edit' | 'loading' | 'preview'>(
-    state.value ? 'preview' : 'edit'
+    hasState ? 'preview' : 'edit'
   )
-  const [url, setUrl] = useState(state.value ? state.value : '')
 
   const [error, setError] = useState('')
+  const [downloadUrl, setDownloadUrl] = useState('')
+
+  function validateInput(str: string) {
+    if (!parseH5pUrl(str)) {
+      setError('Die URL muss mit https://app.lumi.education/run/ beginnen.')
+    } else {
+      setError('')
+    }
+  }
+
+  async function checkContent() {
+    const id = parseH5pUrl(state.value)
+    if (!id) {
+      validateInput(state.value)
+    } else {
+      try {
+        const res = await fetch('https://app.lumi.education/api/v1/run/' + id)
+        const json = (await res.json()) as {
+          downloadPath: string
+          integration: {
+            contents: { [key: string]: { library: string } }
+          }
+        }
+        const mainLib = Object.values(
+          json.integration.contents
+        )[0].library.split(' ')[0]
+
+        if (!h5pLibraryWhitelist.includes(mainLib)) {
+          setError(
+            'Unerlaubter Inhaltstyp - nutze bitte nur die vier genannten Inhaltstypen'
+          )
+          setMode('edit')
+        } else {
+          setMode('preview')
+          setDownloadUrl(json.downloadPath)
+        }
+      } catch (e) {
+        // e.g. invalid id
+        setError(
+          'H5P-Inhalt konnte nicht geladen werden, prüfe nochmal die URL'
+        )
+        setMode('edit')
+      }
+    }
+  }
+
+  useEffect(() => {
+    validateInput(state.value)
+    void checkContent()
+    // only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   if (mode === 'edit' || mode === 'loading') {
     return (
@@ -83,7 +123,7 @@ export function H5pEditor(props: H5pProps) {
               Erstelle deinen Inhalt, speichere ihn und klicke dann auf
               &quot;Inhalt bereitstellen&quot;.
             </li>
-            <li>Füge den Bereitstellungslink hier ein:</li>
+            <li>Füge die Verknüpfung zur Bereitstellung hier ein:</li>
           </ul>
         </div>
         <div>
@@ -93,24 +133,13 @@ export function H5pEditor(props: H5pProps) {
               placeholder="https://app.lumi.education/run/J3j0eR"
               value={state.value}
               onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
-                //console.log('on input', e.target.value)
-                if (
-                  e.target.value
-                    .toLowerCase()
-                    .startsWith('https://app.lumi.education/run/')
-                ) {
-                  setError('')
-                } else {
-                  setError(
-                    'Die URL muss mit https://app.lumi.education/run/ beginnen.'
-                  )
-                }
-                setUrl(e.target.value)
-                state.set(e.target.value)
+                const val = e.target.value
+                validateInput(val)
+                state.set(val)
               }}
               inputWidth="70%"
               width="100%"
-              ref={props.autofocusRef}
+              ref={autofocusRef}
             />
           </EditorInlineSettings>
         </div>
@@ -118,39 +147,10 @@ export function H5pEditor(props: H5pProps) {
         <p>
           <button
             className="mt-2 serlo-button bg-brandgreen-300 disabled:bg-gray-300 disabled:cursor-default"
-            disabled={!!(!url || error || mode === 'loading')}
+            disabled={state.value === '' || error !== '' || mode === 'loading'}
             onClick={() => {
               setMode('loading')
-              void (async () => {
-                const match = /https:\/\/app\.lumi\.education\/run\/(.+)/i.exec(
-                  url
-                )
-                try {
-                  const id = match ? match[1] : ''
-                  const res = await fetch(
-                    'https://app.lumi.education/api/v1/run/' + id
-                  )
-                  const json = (await res.json()) as {
-                    dependencies: { machineName: string }[]
-                  }
-                  if (
-                    !json.dependencies.every((dep) =>
-                      h5pLibraryWhitelist.includes(dep.machineName)
-                    )
-                  ) {
-                    setError(
-                      'Unerlaubte Plugintypen - nutze bitte nur die vier genannten Inhaltstypen'
-                    )
-                    setMode('edit')
-                  }
-                  //console.log(json)
-                  props.state.set(url)
-                  setMode('preview')
-                } catch (e) {
-                  alert(e)
-                  setMode('edit')
-                }
-              })()
+              void checkContent()
             }}
           >
             {mode === 'loading' ? '... wird geladen ...' : 'Einfügen'}
@@ -169,7 +169,7 @@ export function H5pEditor(props: H5pProps) {
   return (
     <>
       <p className="mb-8">
-        H5P-Inhalt: <strong>{props.state.value}</strong>
+        H5P-Inhalt: <strong>{state.value}</strong>
         <button
           onClick={() => {
             setMode('edit')
@@ -178,30 +178,18 @@ export function H5pEditor(props: H5pProps) {
         >
           Ändern
         </button>
+        {downloadUrl && (
+          <a
+            href={`https://app.lumi.education${downloadUrl}`}
+            className="serlo-link ml-3"
+            target="_blank"
+            rel="noreferrer"
+          >
+            herunterladen
+          </a>
+        )}
       </p>
-      <H5pRenderer {...props} disableCursorEvents />
+      <H5p url={state.value} />
     </>
-  )
-}
-
-type H5pRendererProps = H5pProps & {
-  disableCursorEvents?: boolean
-}
-
-export function H5pRenderer(props: H5pRendererProps) {
-  const id = /https:\/\/app\.lumi\.education\/run\/(.+)/i.exec(
-    props.state.value
-  )
-  return (
-    <div className="mx-side mb-block">
-      <iframe
-        src={`https://app.Lumi.education/api/v1/run/${id ? id[1] : '_'}/embed`}
-        width="727"
-        height="500"
-        allowFullScreen
-        allow="geolocation *; microphone *; camera *; midi *; encrypted-media *"
-      ></iframe>
-      <Script src="/_assets/h5p-resizer.js" />
-    </div>
   )
 }

--- a/src/pages/api/frontend/lumi/embed/[id].ts
+++ b/src/pages/api/frontend/lumi/embed/[id].ts
@@ -1,0 +1,33 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const embedUrl = `https://app.Lumi.education/api/v1/run/${
+    req.query.id as string
+  }/embed`
+
+  const lumiRes = await fetch(embedUrl)
+  const html = await lumiRes.text()
+
+  const prepared = html
+    .replace(/(<script\s+src=")\/api\/v1\/h5p/g, '$1/api/frontend/lumi/proxy')
+    .replace(
+      /("stylesheet"\s+href=")\/api\/v1\/h5p/g,
+      '$1/api/frontend/lumi/proxy'
+    )
+    .replace('"url": "/api/v1/h5p"', '"url": "/api/frontend/lumi/proxy"')
+    .replace(
+      '"contentUserData": "/api/v1/h5p/contentUserData/:contentId/:dataType/:subContentId"',
+      '"contentUserData": "/api/frontend/lumi/proxy/contentUserData/:contentId/:dataType/:subContentId"'
+    )
+    .replace(
+      '"setFinished": "/api/v1/h5p/finishedData"',
+      '"setFinished": "/api/frontend/lumi/proxy/finishedData"'
+    )
+
+  //console.log(prepared)
+
+  res.send(prepared)
+}

--- a/src/pages/api/frontend/lumi/proxy/[...slug].ts
+++ b/src/pages/api/frontend/lumi/proxy/[...slug].ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const url = req.url ?? ''
+  const lumiUrl = url.replace(
+    '/api/frontend/lumi/proxy',
+    'https://app.lumi.education/api/v1/h5p'
+  )
+  const lumiRes = await fetch(lumiUrl, { method: req.method })
+  //console.log(lumiRes.headers.get('Content-Type'))
+  res.setHeader('Content-Type', lumiRes.headers.get('Content-Type') ?? '')
+  res.send(Buffer.from(await lumiRes.arrayBuffer()))
+}

--- a/src/pages/api/frontend/lumi/proxy/[...slug].ts
+++ b/src/pages/api/frontend/lumi/proxy/[...slug].ts
@@ -12,5 +12,8 @@ export default async function handler(
   const lumiRes = await fetch(lumiUrl, { method: req.method })
   //console.log(lumiRes.headers.get('Content-Type'))
   res.setHeader('Content-Type', lumiRes.headers.get('Content-Type') ?? '')
+  if (lumiRes.headers.has('Cache-Control')) {
+    res.setHeader('Cache-Control', lumiRes.headers.get('Cache-Control') ?? '')
+  }
   res.send(Buffer.from(await lumiRes.arrayBuffer()))
 }


### PR DESCRIPTION
Use frontend api route as proxy, so we can safely load embedded content from lumi without exposing personal information from client. This way we can avoid using a wrapper altogether and always load h5p content directly.

works nicely so far, example https://frontend-git-2191-lumi-proxy-serlo.vercel.app/269868 (or create new one on staging)

(thinking aloud: by setting good cache headers we can also improve performance significantly without putting load on lumi, using the proxy, we can also get acceses to finishedData and get some metrics out of it - win win here)