### PR TITLE
fix(plugin-text): trim selection before creating math, code or link elements

### DIFF
--- a/src/serlo-editor-repo/plugin-text/utils/link.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/link.ts
@@ -1,7 +1,7 @@
 import { Editor as SlateEditor, Element, Node, Range, Transforms } from 'slate'
 
 import type { Link } from '../types'
-import { selectionHasElement } from './selection'
+import { selectionHasElement, trimSelection } from './selection'
 
 function matchLinks(node: Node) {
   return Element.isElement(node) && node.type === 'a'
@@ -34,6 +34,7 @@ export function toggleLink(editor: SlateEditor) {
     return
   }
 
+  trimSelection(editor)
   Transforms.wrapNodes(
     editor,
     {

--- a/src/serlo-editor-repo/plugin-text/utils/rich-text.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/rich-text.ts
@@ -34,6 +34,7 @@ export function isCodeActive(editor: SlateEditor) {
 }
 
 export function toggleCode(editor: SlateEditor) {
+  trimSelection(editor)
   if (isCodeActive(editor)) {
     SlateEditor.removeMark(editor, 'code')
   } else {

--- a/src/serlo-editor-repo/plugin-text/utils/selection.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/selection.ts
@@ -18,7 +18,7 @@ export function selectionHasElement(
   return !!match
 }
 
-export function trimSelection(editor: SlateEditor) {
+export function trimSelection(editor: SlateEditor): Partial<Range> | null {
   const selection = editor.selection
 
   if (!selection) return null
@@ -37,8 +37,12 @@ export function trimSelection(editor: SlateEditor) {
     selectedText = selectedText.substring(0, selectedText.length - 1)
   }
 
-  Transforms.setSelection(editor, {
+  const trimmedSelection = {
     anchor: { ...selection.anchor, offset: anchorOffset },
     focus: { ...selection.focus, offset: focusOffset },
-  })
+  }
+
+  Transforms.setSelection(editor, trimmedSelection)
+
+  return trimmedSelection
 }


### PR DESCRIPTION
https://github.com/serlo/frontend/issues/2271

- `toggleMath` util also restructured to minimize nesting using early returns.