### PR TITLE
fix(plugin-text): hovering toolbar submenu behavior

### DIFF
--- a/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-controls.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-controls.tsx
@@ -76,6 +76,7 @@ export function HoveringToolbarControls(props: HoveringToolbarControlsProps) {
           onMouseDown={(event) => {
             event.preventDefault()
             control.onClick(editor)
+            setSubMenu(undefined)
           }}
           key={index}
         >

--- a/src/serlo-editor-repo/plugin-text/utils/color.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/color.ts
@@ -1,4 +1,4 @@
-import { Editor as SlateEditor } from 'slate'
+import { Editor as SlateEditor, Transforms } from 'slate'
 
 export const isAnyColorActive = (editor: SlateEditor) =>
   typeof SlateEditor.marks(editor)?.color === 'number'
@@ -16,6 +16,7 @@ export const toggleColor = (colorIndex: number) => (editor: SlateEditor) => {
   } else {
     SlateEditor.addMark(editor, 'color', colorIndex)
   }
+  Transforms.collapse(editor, { edge: 'end' })
 }
 
 export const getColorIndex = (editor: SlateEditor) => {

--- a/src/serlo-editor-repo/plugin-text/utils/color.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/color.ts
@@ -1,5 +1,7 @@
 import { Editor as SlateEditor, Transforms } from 'slate'
 
+import { trimSelection } from './selection'
+
 export const isAnyColorActive = (editor: SlateEditor) =>
   typeof SlateEditor.marks(editor)?.color === 'number'
 
@@ -11,6 +13,7 @@ export const resetColor = (editor: SlateEditor) => {
 }
 
 export const toggleColor = (colorIndex: number) => (editor: SlateEditor) => {
+  trimSelection(editor)
   if (isColorActive(colorIndex)(editor)) {
     SlateEditor.removeMark(editor, 'color')
   } else {


### PR DESCRIPTION
- When selecting a heading, the hovering toolbar will reset to the root menu, closing the headings sub-menu
- When selecting a color, the same will happen as above, + the selection will collapse to the end

Both behaviors are taken from the current live version.