### PR TITLE
Fix image pasting undo

### DIFF
--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -201,6 +201,7 @@ export function TextEditor(props: TextEditorProps) {
 
   return (
     <HotKeys {...hotKeysProps}>
+      {/* Bugfix note: value is correct here after undoing pasting an image. However, handleEditorChange is not called. */}
       <Slate editor={editor} value={value} onChange={handleEditorChange}>
         {editable && focused && (
           <HoveringToolbar
@@ -244,6 +245,8 @@ function renderElementWithFocused(focused: boolean) {
   return function renderElement(props: RenderElementProps) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { element, attributes, children } = props
+
+    // Bugfix note: Here, children[0].props.text is missing part B (`two`) of the splitted text after undoing pasting an image. 
 
     if (element.type === 'h') {
       return createElement(`h${element.level}`, attributes, <>{children}</>)


### PR DESCRIPTION
I found another minor bug. 

Steps to replicate: 
- Create a paragraph with two lines of text. Example:
```
one
two
```
- Insert image or video with cursor at the end of `one`
- Undo changes

Now you only see `one`. However, when clicking on the editor the second line reappears. 

See notes in this commit for what I found out so far.

