### PR TITLE
chore/resolve deprecated todos and eslint issues

### DIFF
--- a/src/edtr-io/plugins/helpers/inline-input.tsx
+++ b/src/edtr-io/plugins/helpers/inline-input.tsx
@@ -23,7 +23,12 @@ export function InlineInput(props: {
 }) {
   const { onChange, value, placeholder } = props
 
-  const initialValue = useMemo(() => deserialize(value), [])
+  const initialValue = useMemo(
+    () => deserialize(value),
+    // initialValue should not be recalculated on rerender
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const [editor] = useState(() => withReact(createEditor()))
 

--- a/src/serlo-editor-repo/core/store.tsx
+++ b/src/serlo-editor-repo/core/store.tsx
@@ -18,10 +18,9 @@ export const ScopeContext = React.createContext<{
 }>({ scope: '' })
 
 /** @public */
-export const EditorContext = React.createContext<
-  // TODO: This is a workaround until API extractor supports import() types, see https://github.com/microsoft/rushstack/pull/1916
-  ReactReduxContextValue<State>
->(undefined as unknown as ReactReduxContextValue<State>)
+export const EditorContext = React.createContext(
+  undefined as unknown as ReactReduxContextValue<State>
+)
 
 /** @public */
 export const ErrorContext = React.createContext<

--- a/src/serlo-editor-repo/core/sub-document/index.tsx
+++ b/src/serlo-editor-repo/core/sub-document/index.tsx
@@ -47,6 +47,7 @@ export class ErrorBoundary extends React.Component<{
     if (typeof this.context === 'function') {
       this.context(error, errorInfo)
     }
+    // eslint-disable-next-line no-console
     console.log(error, errorInfo)
   }
 

--- a/src/serlo-editor-repo/core/sub-document/renderer.tsx
+++ b/src/serlo-editor-repo/core/sub-document/renderer.tsx
@@ -15,7 +15,6 @@ export function SubDocumentRenderer({ id, pluginProps }: SubDocumentProps) {
   const theme = useTheme()
   if (!document) return null
   if (!plugin) {
-    // TODO:
     // eslint-disable-next-line no-console
     console.log('Plugin does not exist')
     return null

--- a/src/serlo-editor-repo/editor-ui/editor-bottom-toolbar.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-bottom-toolbar.tsx
@@ -1,14 +1,7 @@
-import { StyledComponent } from 'styled-components'
-
 import { EditorThemeProps, styled, useEditorUiTheme } from '../ui'
 
 /** @public */
-// TODO: This is a workaround until API extractor supports import() types, see https://github.com/microsoft/rushstack/pull/1916
-export const EditorBottomToolbar: StyledComponent<
-  'div',
-  never,
-  EditorThemeProps
-> = styled.div<EditorThemeProps>(() => {
+export const EditorBottomToolbar = styled.div<EditorThemeProps>(() => {
   const theme = useEditorUiTheme('bottomToolbar', (theme) => {
     return {
       backgroundColor: theme.backgroundColor,

--- a/src/serlo-editor-repo/editor-ui/editor-button.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-button.tsx
@@ -1,35 +1,30 @@
-import { StyledComponent } from 'styled-components'
-
 import { styled, useEditorUiTheme } from '../ui'
 
 /** @public */
-// TODO: This is a workaround until API extractor supports import() types, see https://github.com/microsoft/rushstack/pull/1916
-export const EditorButton: StyledComponent<'button', never> = styled.button(
-  () => {
-    const theme = useEditorUiTheme('button', (theme) => {
-      return {
-        backgroundColor: theme.backgroundColor,
-        color: theme.color,
-        borderColor: theme.color,
-        hoverBackgroundColor: 'rgba(0,0,0,0.50)',
-        hoverColor: theme.primary.background,
-        hoverBorderColor: theme.primary.background,
-      }
-    })
+export const EditorButton = styled.button(() => {
+  const theme = useEditorUiTheme('button', (theme) => {
     return {
-      margin: '3px',
       backgroundColor: theme.backgroundColor,
-      outline: 'none',
-      border: 'none',
-      boxShadow: '0 1px 2px 0 rgba(0,0,0,0.50)',
       color: theme.color,
-      borderRadius: '4px',
-      cursor: 'pointer',
-      '&:hover': {
-        backgroundColor: theme.hoverBackgroundColor,
-        color: theme.hoverColor,
-        borderColor: theme.hoverBorderColor,
-      },
+      borderColor: theme.color,
+      hoverBackgroundColor: 'rgba(0,0,0,0.50)',
+      hoverColor: theme.primary.background,
+      hoverBorderColor: theme.primary.background,
     }
+  })
+  return {
+    margin: '3px',
+    backgroundColor: theme.backgroundColor,
+    outline: 'none',
+    border: 'none',
+    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.50)',
+    color: theme.color,
+    borderRadius: '4px',
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.hoverBackgroundColor,
+      color: theme.hoverColor,
+      borderColor: theme.hoverBorderColor,
+    },
   }
-)
+})

--- a/src/serlo-editor-repo/editor-ui/editor-inline-settings.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-inline-settings.tsx
@@ -1,9 +1,6 @@
-import { StyledComponent } from 'styled-components'
-
 import { styled } from '../ui'
 
 /** @public */
-// TODO: This is a workaround until API extractor supports import() types, see https://github.com/microsoft/rushstack/pull/1916
-export const EditorInlineSettings: StyledComponent<'div', never> = styled.div({
+export const EditorInlineSettings = styled.div({
   marginTop: '15px',
 })

--- a/src/serlo-editor-repo/math/visual-editor.tsx
+++ b/src/serlo-editor-repo/math/visual-editor.tsx
@@ -105,7 +105,6 @@ export function VisualEditor(props: VisualEditorProps) {
     if (ref.latex() === '' && props.state !== '') {
       props.onError()
     }
-    // TODO: Check if this can be removed
     setTimeout(() => {
       ref.focus()
     })

--- a/src/serlo-editor-repo/store/plugins/reducer.ts
+++ b/src/serlo-editor-repo/store/plugins/reducer.ts
@@ -1,20 +1,12 @@
 import { EditorPlugin } from '../../internal__plugin'
-import { StateType } from '../../internal__plugin-state'
 import { createSelector, createSubReducer, SubReducer } from '../helpers'
-import { Selector } from '../storetypes'
 
 /** @internal */
 export const pluginsReducer: SubReducer<Record<string, EditorPlugin>> =
   createSubReducer('plugins', {}, {})
 
 /** @public */
-export const getPlugins: Selector<
-  Record<
-    string,
-    // TODO: This is a workaround until API extractor supports import() types, see https://github.com/microsoft/rushstack/pull/1916
-    EditorPlugin<StateType>
-  >
-> = createSelector((state) => state.plugins)
+export const getPlugins = createSelector((state) => state.plugins)
 /** @public */
 export const getPlugin = createSelector(
   (state, type: string): EditorPlugin | null => {


### PR DESCRIPTION
Note: API extractor was removed when moving the editor code from edtr-io to frontend, therefore workaround for it can be removed.