### PR TITLE
feat(plugin-text): handle hotkeys

### DIFF
--- a/src/serlo-editor-repo/core/store.tsx
+++ b/src/serlo-editor-repo/core/store.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-redux'
 import { Unsubscribe } from 'redux'
 
-import { Action, getScope, ScopedState, State } from '../store'
+import { Action, getScope, ScopedState, ScopedStore, State } from '../store'
 
 /** @public */
 export const ScopeContext = React.createContext<{
@@ -104,7 +104,7 @@ export const useStore = createStoreHook(EditorContext)
 export function useScopedStore(enforcedScope?: string) {
   const scope = useScope(enforcedScope)
   const store = useStore()
-  return React.useMemo(() => {
+  return React.useMemo((): ScopedStore => {
     return {
       dispatch: scopeDispatch(store.dispatch, scope),
       getState: () => {

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -29,7 +29,10 @@ import {
   TextEditorPluginConfig,
   TextEditorState,
 } from '../types'
-import { sliceNodesAfterSelection } from '../utils/document'
+import {
+  emptyDocumentFactory,
+  sliceNodesAfterSelection,
+} from '../utils/document'
 import { markdownShortcuts } from '../utils/markdown'
 import { HoveringToolbar } from './hovering-toolbar'
 import { LinkControls } from './link-controls'
@@ -157,18 +160,16 @@ export function TextEditor(props: TextEditorProps) {
 
         const slicedNodes = sliceNodesAfterSelection(editor)
         setTimeout(() => {
-          if (slicedNodes) {
-            store.dispatch(
-              insertChildAfter({
-                parent: parent.id,
-                sibling: id,
-                document: {
-                  plugin: document.plugin,
-                  state: slicedNodes,
-                },
-              })
-            )
-          }
+          store.dispatch(
+            insertChildAfter({
+              parent: parent.id,
+              sibling: id,
+              document: {
+                plugin: document.plugin,
+                state: slicedNodes || emptyDocumentFactory().value,
+              },
+            })
+          )
         })
       }
     }

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -116,9 +116,7 @@ export function TextEditor(props: TextEditorProps) {
   }
 
   function handleEditableKeyDown(event: React.KeyboardEvent) {
-    const isEnterKey = isHotkey('enter', event)
-
-    if (config.noLinebreaks && isEnterKey) {
+    if (config.noLinebreaks && event.key === 'Enter') {
       event.preventDefault()
     }
 
@@ -145,7 +143,7 @@ export function TextEditor(props: TextEditorProps) {
       }
 
       // Create a new Slate instance on enter
-      if (isEnterKey) {
+      if (isHotkey('enter', event)) {
         const document = getDocument(id)(store.getState())
         if (!document) return
 

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -116,6 +116,12 @@ export function TextEditor(props: TextEditorProps) {
   }
 
   function handleEditableKeyDown(event: React.KeyboardEvent) {
+    const isEnterKey = isHotkey('enter', event)
+
+    if (config.noLinebreaks && isEnterKey) {
+      event.preventDefault()
+    }
+
     if (editor.selection && Range.isCollapsed(editor.selection)) {
       // Special handler for links. If you move right and end up at the right edge of a link,
       // this handler unselects the link, so you can write normal text behind it.
@@ -139,7 +145,7 @@ export function TextEditor(props: TextEditorProps) {
       }
 
       // Create a new Slate instance on enter
-      if (isHotkey('enter', event)) {
+      if (isEnterKey) {
         const document = getDocument(id)(store.getState())
         if (!document) return
 

--- a/src/serlo-editor-repo/plugin-text/utils/document.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/document.ts
@@ -2,6 +2,7 @@ import { Editor as SlateEditor, Transforms } from 'slate'
 
 import { StateTypeValueType } from '../../plugin'
 import type { TextEditorState } from '../types'
+import { isSelectionAtEnd } from './selection'
 
 export const emptyDocumentFactory =
   (): StateTypeValueType<TextEditorState> => ({
@@ -12,14 +13,18 @@ export const emptyDocumentFactory =
 export function sliceNodesAfterSelection(editor: SlateEditor) {
   if (!editor.selection) return
 
+  let slicedNodes = null
+
   // Create a new line at selection
   SlateEditor.insertBreak(editor)
 
   const selectionPoint = editor.selection.anchor.path[0]
   const childrenCount = editor.children.length
 
-  // Save the sliced nodes to a constant
-  const slicedNodes = editor.children.slice(selectionPoint, childrenCount)
+  // If the initial selection was not at the end, save the sliced nodes
+  if (!isSelectionAtEnd(editor, editor.selection)) {
+    slicedNodes = editor.children.slice(selectionPoint, childrenCount)
+  }
 
   // Remove the sliced nodes from the current Slate instance
   Transforms.removeNodes(editor, {

--- a/src/serlo-editor-repo/plugin-text/utils/document.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/document.ts
@@ -1,8 +1,22 @@
-import { Editor as SlateEditor, Transforms } from 'slate'
+import { Descendant, Node, Editor as SlateEditor, Transforms } from 'slate'
 
 import { StateTypeValueType } from '../../plugin'
 import type { TextEditorState } from '../types'
 import { isSelectionAtEnd } from './selection'
+import {
+  ScopedStore,
+  focusNext,
+  focusPrevious,
+  getDocument,
+  getParent,
+  mayInsertChild,
+  mayRemoveChild,
+  removeChild,
+} from '@/serlo-editor-repo/store'
+
+interface DocumentState {
+  value: Descendant[]
+}
 
 export const emptyDocumentFactory =
   (): StateTypeValueType<TextEditorState> => ({
@@ -35,4 +49,104 @@ export function sliceNodesAfterSelection(editor: SlateEditor) {
   })
 
   return slicedNodes
+}
+
+export function mergePlugins(
+  direction: 'previous' | 'next',
+  editor: SlateEditor,
+  store: ScopedStore,
+  id: string
+) {
+  const mayRemove = mayRemoveChild(id)(store.getState())
+  const parent = getParent(id)(store.getState())
+  if (!mayRemove || !parent) return
+
+  // If the editor is empty, remove the current Slate instance
+  // and focus the one it's been merged with
+  if (Node.string(editor) === '') {
+    const focusAction = direction === 'previous' ? focusPrevious : focusNext
+    store.dispatch(focusAction())
+    store.dispatch(removeChild({ parent: parent.id, child: id }))
+    return
+  }
+
+  const mayInsert = mayInsertChild(id)(store.getState())
+  const currentDocument = getDocument(id)(store.getState())
+  if (!mayInsert || !currentDocument) return
+
+  const allChildrenOfParent = parent.children || []
+  const indexWithinParent = allChildrenOfParent.findIndex(
+    (child) => child.id === id
+  )
+
+  if (direction === 'previous') {
+    // Exit if text plugin is the first child of its parent
+    const isFirstChild = indexWithinParent < 1
+    if (isFirstChild) return
+
+    // Exit if unable to get value of previous sibling
+    const previousSibling = allChildrenOfParent[indexWithinParent - 1]
+    const previousDocument = getDocument(previousSibling.id)(store.getState())
+    if (!previousDocument) return
+
+    // If previous and current plugin are both text plugins
+    // merge them and return the merge value
+    if (previousDocument.plugin === currentDocument.plugin) {
+      const previousDocumentValue = (previousDocument.state as DocumentState)
+        .value
+      const previousDocumentChildrenCount = previousDocumentValue.length
+
+      // Merge editor values
+      const newValue = [...previousDocumentValue, ...editor.children]
+
+      // Set the merge value to current Slate instance
+      editor.children = newValue
+
+      setTimeout(() => {
+        // Remove the merged plugin
+        store.dispatch(
+          removeChild({ parent: parent.id, child: previousSibling.id })
+        )
+        // Set selection where it was before the merge
+        Transforms.select(editor, {
+          offset: 0,
+          path: [previousDocumentChildrenCount, 0],
+        })
+      })
+
+      // Return the merge value
+      return newValue
+    }
+  } else {
+    // Exit if text plugin is the last child of its parent
+    const isLastChild = indexWithinParent + 1 >= allChildrenOfParent.length
+    if (isLastChild) return
+
+    // Exit if unable to get value of next sibling
+    const nextSibling = allChildrenOfParent[indexWithinParent + 1]
+    const nextDocument = getDocument(nextSibling.id)(store.getState())
+    if (!nextDocument) return
+
+    // If next and current plugin are both text plugins
+    // merge them and return the merge value
+    if (nextDocument.plugin === currentDocument.plugin) {
+      const nextDocumentValue = (nextDocument.state as DocumentState).value
+
+      // Merge editor values
+      const newValue = [...editor.children, ...nextDocumentValue]
+
+      // Set the merge value to current Slate instance
+      editor.children = newValue
+
+      setTimeout(() => {
+        // Remove the merged plugin
+        store.dispatch(
+          removeChild({ parent: parent.id, child: nextSibling.id })
+        )
+      })
+
+      // Return the merge value
+      return newValue
+    }
+  }
 }

--- a/src/serlo-editor-repo/plugin-text/utils/selection.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/selection.ts
@@ -1,4 +1,11 @@
-import { Editor as SlateEditor, Element, Range, Transforms } from 'slate'
+import {
+  Editor as SlateEditor,
+  Element,
+  Range,
+  Transforms,
+  BaseRange,
+  Point,
+} from 'slate'
 
 export function selectionHasElement(
   predicate: (element: Element) => boolean,
@@ -45,4 +52,9 @@ export function trimSelection(editor: SlateEditor): Partial<Range> | null {
   Transforms.setSelection(editor, trimmedSelection)
 
   return trimmedSelection
+}
+
+export function isSelectionAtEnd(editor: SlateEditor, selection: BaseRange) {
+  const lastPointInEditor = SlateEditor.end(editor, [selection.anchor.path[0]])
+  return Point.compare(lastPointInEditor, selection.focus) < 1
 }

--- a/src/serlo-editor-repo/plugin-text/utils/selection.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/selection.ts
@@ -54,7 +54,13 @@ export function trimSelection(editor: SlateEditor): Partial<Range> | null {
   return trimmedSelection
 }
 
+export function isSelectionAtStart(editor: SlateEditor, selection: BaseRange) {
+  const firstPointInEditor = SlateEditor.start(editor, [0])
+  return Point.compare(firstPointInEditor, selection.focus) > -1
+}
+
 export function isSelectionAtEnd(editor: SlateEditor, selection: BaseRange) {
-  const lastPointInEditor = SlateEditor.end(editor, [selection.anchor.path[0]])
+  const childrenCount = editor.children.length
+  const lastPointInEditor = SlateEditor.end(editor, [childrenCount - 1])
   return Point.compare(lastPointInEditor, selection.focus) < 1
 }

--- a/src/serlo-editor-repo/store/index.ts
+++ b/src/serlo-editor-repo/store/index.ts
@@ -28,6 +28,7 @@ export type {
   State,
   Store,
   ScopedState,
+  ScopedStore,
   InternalState,
   InternalStore,
   InternalScopedState,

--- a/src/serlo-editor-repo/store/storetypes.ts
+++ b/src/serlo-editor-repo/store/storetypes.ts
@@ -1,4 +1,4 @@
-import { Store as ReduxStore } from 'redux'
+import { Store as ReduxStore, Unsubscribe } from 'redux'
 
 import { EditorPlugin } from '../internal__plugin'
 import { Action, InternalAction, ReversibleAction } from './actions'
@@ -14,6 +14,13 @@ export type InternalState = Record<string, InternalScopedState>
 export type Store = ReduxStore<State, Action>
 /** @internal */
 export type InternalStore = ReduxStore<InternalState, InternalAction>
+
+/** @public */
+export interface ScopedStore {
+  dispatch: (scopedAction: (scope: string) => Action) => void
+  getState: () => ScopedState
+  subscribe: (listener: () => void) => Unsubscribe
+}
 
 /** @public */
 export interface ScopedState {


### PR DESCRIPTION
- Insert a new text plugin on enter key press
- Focus the newly inserted text plugin (implementation taken from https://github.com/serlo/frontend/pull/2301 and tweaked a bit to fit for inserting with enter as well)
- Prevent adding line breaks if `noLinebreaks` config flag is active
- Also fixes a bug with inserting an image when selection is at the end (where a text plugin would be inserted after the inserted image)
- Remove an empty text plugin on backspace or delete key press
- Merge text plugin with previous text plugin on backspace if selection at start
- Merge with next text plugin on delete if selection at end