### PR TITLE
a11y: color contrast

### DIFF
--- a/public/_assets/img/header-curve.svg
+++ b/public/_assets/img/header-curve.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 4" preserveAspectRatio="none">
-<path d="M0,1c0,0,10,2,29,2c14,0,37-2,49-2S100,2,100,2V4L0,4V1z" style="fill:#fff"/>
+    <path d="M0,1c0,0,10,2,29,2c14,0,37-2,49-2S100,2,100,2V4L0,4V1z" style="fill:#fff" />
 </svg>

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -89,7 +89,7 @@
       @apply absolute special-content-list-counter special-increment-list-counter;
       @apply font-bold text-center rounded-full -ml-6;
       @apply mt-0.5 bg-brand-150 w-[17px] h-[17px] text-xs;
-      @apply leading-tight text-brand pt-0.25;
+      @apply leading-tight text-brand-700 pt-0.25;
     }
     & > li {
       @apply mb-2;

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -10,7 +10,7 @@
 
 @layer components {
   .serlo-link {
-    @apply text-brand no-underline break-words hover:underline;
+    @apply text-brand-700 no-underline break-words hover:underline;
   }
   .serlo-button {
     @apply inline-block transition-all rounded-4xl py-1 px-2;
@@ -26,13 +26,13 @@
     @apply serlo-button text-white bg-brandgreen hover:bg-brandgreen-300;
   }
   .serlo-button-light {
-    @apply serlo-button text-brand bg-brand-100 hover:text-white hover:bg-brand;
+    @apply serlo-button text-brand-700 bg-brand-100 hover:text-white hover:bg-brand;
   }
   .serlo-button-green-transparent {
     @apply serlo-button text-brandgreen bg-transparent hover:text-white hover:bg-brandgreen;
   }
   .serlo-button-blue-transparent {
-    @apply serlo-button text-brand bg-transparent hover:text-white hover:bg-brand;
+    @apply serlo-button text-brand bg-transparent hover:text-white hover:bg-brand-700;
   }
   .serlo-p {
     @apply mx-side mt-0 mb-block special-hyphens-auto text-lg leading-cozy;
@@ -251,7 +251,7 @@
   }
 
   .serlo-header-navtrigger[data-state='open'] {
-    @apply bg-brand text-white;
+    @apply bg-brand-700 text-white;
   }
 
   .serlo-fa-icon {

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -88,7 +88,7 @@
     & > li:before {
       @apply absolute special-content-list-counter special-increment-list-counter;
       @apply font-bold text-center rounded-full -ml-6;
-      @apply mt-0.5 bg-brand-200 w-4 h-4 text-xs;
+      @apply mt-0.5 bg-brand-150 w-[17px] h-[17px] text-xs;
       @apply leading-tight text-brand pt-0.25;
     }
     & > li {

--- a/src/components/auth/node.tsx
+++ b/src/components/auth/node.tsx
@@ -131,7 +131,7 @@ export function Node({
   function renderInput(attributes: UiNodeInputAttributes) {
     const basicFields = {
       className:
-        'text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-150 focus:bg-brand-150 focus:outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full border-2 border-transparent focus:border-brand border-solid',
+        'text-xl serlo-input-font-reset serlo-button-light hover:bg-brand-200 focus:bg-brand-200 focus:outline-none -ml-1 mt-1 text-brand hover:text-brand px-4 py-2 w-full border-2 border-transparent focus:border-brand border-solid',
       name: attributes.name,
       onChange: (e: { target: { value: string } }) => {
         void onChange(e.target.value)

--- a/src/components/content/exercises/input-exercise.tsx
+++ b/src/components/content/exercises/input-exercise.tsx
@@ -43,10 +43,10 @@ export function InputExercise({
       <input
         className={clsx(
           'print:hidden serlo-input-font-reset',
-          'rounded-3xl py-2 px-3 active:font-bold focus:font-bold ',
-          'border-3 border-brand bg-brand mb-5 text-white',
+          'rounded-3xl py-2 px-3 font-bold',
+          'border-3 border-brand-400 mb-5 text-white focus:border-brand active:border-brand',
           'focus:outline-none focus:bg-white focus:text-brand focus:opacity-100 focus:placeholder-opacity-0',
-          'placeholder-white'
+          'placeholder-brand'
         )}
         type="text"
         value={value}

--- a/src/components/content/horizon.tsx
+++ b/src/components/content/horizon.tsx
@@ -30,7 +30,7 @@ export function Horizon({ data }: HorizonProps) {
             key={index}
           >
             <Link
-              className="text-brand text-left leading-cozy hover:no-underline hover:text-truegray-700"
+              className="text-brand-700 text-left leading-cozy hover:no-underline hover:text-truegray-700"
               href={horizonEntry.url}
               noExternalIcon
               path={[]}

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -106,7 +106,7 @@ export function PrivacyWrapper({
           />
         </div>
         {!consentGiven && (
-          <div className="relative z-10 py-2 text-left px-side bg-brand-100 text-brand cursor-default">
+          <div className="relative z-10 py-2 text-left px-side bg-brand-100 text-brand-700 cursor-default">
             {replacePlaceholders(strings.embed.text, {
               provider: <b>{provider}</b>,
               privacypolicy: (

--- a/src/components/navigation/header/header.tsx
+++ b/src/components/navigation/header/header.tsx
@@ -52,7 +52,7 @@ export function Header() {
           <Logo foldOnMobile />
           <div
             className={clsx(
-              'min-h-[50px] md:block mt-[1.7rem] md:mt-7',
+              'min-h-[50px] md:block mt-[1.7rem] md:mt-8',
               'order-last md:order-none lg:order-last ',
               'w-full md:w-auto',
               mobileMenuOpen ? '' : 'hidden'

--- a/src/components/navigation/header/menu/auth-items.tsx
+++ b/src/components/navigation/header/menu/auth-items.tsx
@@ -30,7 +30,7 @@ export function AuthItems() {
       <Item
         link={notificationLinkData}
         elementAsIcon={
-          <div className="-top-[2px] md:relative md:mx-[3px] md:my-[7px]">
+          <div className="-top-[2px] md:relative md:mx-[3px]">
             <UnreadNotificationsCount icon={faBell} />
           </div>
         }
@@ -39,7 +39,7 @@ export function AuthItems() {
         link={updatedSubData}
         elementAsIcon={
           <img
-            className="rounded-full w-6 h-6 inline md:my-[7px]"
+            className="rounded-full w-6 h-6 inline"
             src={getAvatarUrl(username)}
             title={`${updatedSubData.title} ${username}`}
           />

--- a/src/components/navigation/header/menu/item.tsx
+++ b/src/components/navigation/header/menu/item.tsx
@@ -19,7 +19,7 @@ export const styledLinkCls = /* className={ */ clsx(
   'w-full text-[1.33rem] font-bold',
   'text-brand block border-b border-brand-400 p-4',
   'md:serlo-menu-entry-special',
-  'md:block md:serlo-button-blue-transparent md:text-[0.9rem] md:leading-tight md:transition md:text-brand-500',
+  'md:block md:serlo-button-blue-transparent md:text-[0.9rem] md:leading-tight md:transition md:text-brand-700',
   'md:my-0 md:mt-[2px] md:py-0.5 md:px-[7px]',
   'md:text-center',
   'hover:no-underline hover:bg-brand-300'

--- a/src/components/navigation/header/menu/menu.tsx
+++ b/src/components/navigation/header/menu/menu.tsx
@@ -1,4 +1,5 @@
 import { Root, List } from '@radix-ui/react-navigation-menu'
+import clsx from 'clsx'
 import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
 
@@ -18,13 +19,20 @@ export function Menu() {
 
   useEffect(() => setMounted(true), [])
 
+  const showAuth = auth && mounted
+
   return (
     <Root>
-      <List className="md:text-right block m-0 p-0 relative sm:min-w-[27rem]">
+      <List
+        className={clsx(
+          'md:text-right block m-0 p-0 relative sm:min-w-[27rem]',
+          showAuth ? '' : 'md:mt-0.5 md:mr-3.5'
+        )}
+      >
         {headerData.map((link) => (
           <Item key={link.title} link={link} />
         ))}
-        {auth && mounted ? <AuthItems /> : <NoAuthItem hidden={!mounted} />}
+        {showAuth ? <AuthItems /> : <NoAuthItem hidden={!mounted} />}
       </List>
     </Root>
   )

--- a/src/components/navigation/quickbar.tsx
+++ b/src/components/navigation/quickbar.tsx
@@ -185,7 +185,7 @@ export function Quickbar({ subject, className, placeholder }: QuickbarProps) {
                     {x.entry.path.length > 0 ? ' > ' : ''}
                   </span>
 
-                  <span className="text-lg text-brand group-hover:underline">
+                  <span className="text-lg text-brand-700 group-hover:underline">
                     {x.entry.isTax ? (
                       <>{x.entry.title}&nbsp;&gt;</>
                     ) : (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
           400: '#8EC5E2',
           500: '#51A5D1',
           600: brand,
+          700: '#0076b9', // slighly darker brand blue for better color contrast with white (for smaller text) and light blue.
         },
         brandgreen: {
           DEFAULT: brandGreen,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
           DEFAULT: brand,
           50: '#F4F9FC',
           100: '#EFF7FB',
-          150: '#D9EBF5',
+          150: '#E6F2F9',
           200: '#D9EBF5',
           300: '#BBDCED',
           400: '#8EC5E2',


### PR DESCRIPTION
- improved `<ol>` contrast and positioning
- significantly darker header menu text color (and less layout shift between auth/non-auth)
- additional slightly darker blue for smaller texts (e.g. links) and when blue is used on light blue (e.g. buttons)
- more contrast in exercise input field (placeholder)

<img width="643" alt="image" src="https://user-images.githubusercontent.com/1258870/232522637-850b86bd-026e-4459-89c6-96b2b7b780d8.png">
<img width="319" alt="image" src="https://user-images.githubusercontent.com/1258870/232523158-61919bdc-aab5-4609-abea-a17f350d9861.png">
<img width="282" alt="image" src="https://user-images.githubusercontent.com/1258870/232523226-ad2758e9-0a25-45a7-8c67-26c1b6bac06c.png">
<img width="329" alt="image" src="https://user-images.githubusercontent.com/1258870/232523455-51e3344b-08bd-4c33-8286-aa7f87634ccf.png">

