### PR TITLE
Disable markdown shortcuts in box title, image caption & certain table cells

### DIFF
--- a/src/edtr-io/plugins/box/index.tsx
+++ b/src/edtr-io/plugins/box/index.tsx
@@ -29,6 +29,7 @@ export function createBoxState(
       config: {
         controls: ['code', 'katex', 'math'],
         noLinebreaks: true,
+        disableMarkdownShortcuts: true,
       },
     }),
     anchorId: string(''),

--- a/src/edtr-io/plugins/serlo-table/index.tsx
+++ b/src/edtr-io/plugins/serlo-table/index.tsx
@@ -184,6 +184,7 @@ function SerloTableEditor(props: SerloTableProps) {
                 config: {
                   placeholder: '',
                   controls: isHead ? headerTextControls : cellTextControls,
+                  disableMarkdownShortcuts: isHead,
                 },
               })}
               {renderSwitchButton(cell, isHead, isClear)}

--- a/src/serlo-editor-repo/plugin-image/index.ts
+++ b/src/serlo-editor-repo/plugin-image/index.ts
@@ -48,6 +48,7 @@ export function createImagePlugin(
           config: {
             controls: ['code', 'katex', 'links', 'math', 'richText'],
             noLinebreaks: true,
+            disableMarkdownShortcuts: true,
             blockquote: '',
           },
         })

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -218,7 +218,9 @@ export function TextEditor(props: TextEditorProps) {
 
     suggestions.handleHotkeys(event)
     textControls.handleHotkeys(event, editor)
-    markdownShortcuts().onKeyDown(event, editor)
+    if (!config.disableMarkdownShortcuts) {
+      markdownShortcuts().onKeyDown(event, editor)
+    }
     if (config.controls.includes(TextEditorControl.lists)) {
       slateListsOnKeyDown(editor, event)
     }

--- a/src/serlo-editor-repo/plugin-text/hooks/use-text-config.tsx
+++ b/src/serlo-editor-repo/plugin-text/hooks/use-text-config.tsx
@@ -42,6 +42,7 @@ export function useTextConfig(
     theme = {},
     blockquote,
     noLinebreaks,
+    disableMarkdownShortcuts = false,
   } = config
   const { editor } = useTheme()
 
@@ -180,5 +181,6 @@ export function useTextConfig(
     }),
     blockquote,
     noLinebreaks,
+    disableMarkdownShortcuts,
   }
 }

--- a/src/serlo-editor-repo/plugin-text/types/config.ts
+++ b/src/serlo-editor-repo/plugin-text/types/config.ts
@@ -18,6 +18,7 @@ export interface TextEditorConfig {
   theme?: DeepPartial<TextEditorPluginConfig['theme']>
   blockquote?: string
   noLinebreaks?: boolean
+  disableMarkdownShortcuts?: boolean
 }
 
 /** @public */
@@ -132,4 +133,5 @@ export interface TextEditorPluginConfig {
   theme: Theme
   blockquote?: string
   noLinebreaks?: boolean
+  disableMarkdownShortcuts: boolean
 }


### PR DESCRIPTION
In this PR, markdown shortcuts will no longer work inside box title, image caption and certain table cells (top-row, left-column or both)

This reproduces the current behavior in production. 