### PR TITLE
single logout: revalidate kratos session

### DIFF
--- a/src/auth/auth-provider.tsx
+++ b/src/auth/auth-provider.tsx
@@ -3,7 +3,9 @@ import type { AuthorizationPayload } from '@serlo/authorization'
 import { createContext, ReactNode, useEffect, useState } from 'react'
 
 import { AuthSessionCookie } from './cookie/auth-session-cookie'
+import { fetchAndPersistAuthSession } from './cookie/fetch-and-persist-auth-session'
 import type { createAuthAwareGraphqlFetch } from '@/api/graphql-fetch'
+import { isProduction } from '@/helper/is-production'
 
 export type AuthenticationPayload = {
   username: string
@@ -33,6 +35,13 @@ export function AuthProvider({
     setAuthenticationPayload(getAuthPayloadFromSession(session))
   }
 
+  // check if kratos session still exists (single logout)
+  useEffect(() => {
+    if (authenticationPayload && !isProduction)
+      void fetchAndPersistAuthSession(refreshAuth)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   useEffect(() => {
     const refreshWhenVisible = () => {
       if (!document.visibilityState) return
@@ -41,12 +50,14 @@ export function AuthProvider({
       // use functional update to get the current value of the payload
       // returning same value will skip set state
       setAuthenticationPayload((authenticationPayload) => {
-        if (cookiePayload?.id !== authenticationPayload?.id) {
-          return cookiePayload
-        } else {
-          return authenticationPayload
-        }
+        return cookiePayload?.id !== authenticationPayload?.id
+          ? cookiePayload
+          : authenticationPayload
       })
+
+      // check if kratos session still exists (single logout)
+      if (authenticationPayload && !isProduction)
+        void fetchAndPersistAuthSession(refreshAuth)
     }
     document.addEventListener('visibilitychange', refreshWhenVisible) //on tab focus change
     window.addEventListener('online', () => refreshWhenVisible) //on reconnect
@@ -55,6 +66,7 @@ export function AuthProvider({
       document.removeEventListener('visibilitychange', refreshWhenVisible)
       window.removeEventListener('online', () => refreshWhenVisible)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const authorizationPayload = useAuthorizationPayload(

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from '../navigation/breadcrumbs'
 import { StaticInfoPanel } from '../static-info-panel'
 import { loginUrl } from './auth/utils'
 import { fetchAndPersistAuthSession } from '@/auth/cookie/fetch-and-persist-auth-session'
+import { useAuth } from '@/auth/use-auth'
 import { useAuthentication } from '@/auth/use-authentication'
 import { useInstanceData } from '@/contexts/instance-context'
 import { UuidType } from '@/data-types'
@@ -37,6 +38,7 @@ export function AddRevision({
   const { strings } = useInstanceData()
 
   const auth = useAuthentication()
+  const { refreshAuth } = useAuth()
 
   const setEntityMutation = useSetEntityMutation()
   const addPageRevision = useAddPageRevision()
@@ -46,11 +48,11 @@ export function AddRevision({
 
   useEffect(() => {
     async function confirmAuth() {
-      await fetchAndPersistAuthSession()
+      await fetchAndPersistAuthSession(refreshAuth)
       setUserReady(isProduction ? auth !== null : true)
     }
     void confirmAuth()
-  }, [auth])
+  }, [auth, refreshAuth])
 
   if (!setEntityMutation) return null
 


### PR DESCRIPTION
revalidates the kratos session from server:
- on tab change
- on coming online again
- on first opening a page
- not in production

If we stick to this we can probably simplify the tabchange and online check in the future.