### PR TITLE
fix(plugin-text): disable tab list shortcut

### DIFF
--- a/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
@@ -193,10 +193,13 @@ export const useFormattingOptions = (
       const isListsOptionEnabled = formattingOptions.includes(
         TextEditorFormattingOption.lists
       )
-      const isTab = isHotkey('tab', event)
-      const isShiftTab = isHotkey('shift+tab', event)
+      if (!isListsOptionEnabled) return
 
-      if (isListsOptionEnabled || isTab || isShiftTab) return
+      const isListActive =
+        isOrderedListActive(editor) || isUnorderedListActive(editor)
+      const isTabShortcut =
+        isHotkey('tab', event) || isHotkey('shift+tab', event)
+      if (!isListActive && isTabShortcut) return
 
       return slateListsOnKeyDown(editor, event)
     },

--- a/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
@@ -190,9 +190,15 @@ export const useFormattingOptions = (
 
   const handleListsShortcuts = useCallback(
     (event: React.KeyboardEvent, editor: SlateEditor) => {
-      if (formattingOptions.includes(TextEditorFormattingOption.lists)) {
-        return slateListsOnKeyDown(editor, event)
-      }
+      const isListsOptionEnabled = formattingOptions.includes(
+        TextEditorFormattingOption.lists
+      )
+      const isTab = isHotkey('tab', event)
+      const isShiftTab = isHotkey('shift+tab', event)
+
+      if (isListsOptionEnabled || isTab || isShiftTab) return
+
+      return slateListsOnKeyDown(editor, event)
     },
     [formattingOptions]
   )


### PR DESCRIPTION
Description of the bug from beta testing page:
>Moving through table cells by pressing ‘tab’ only works to some extend. As soon as a normal cell is reached ‘tab’ creates an enumeration. Is that a behavior we want to have?

Fix: As the lists package we're using doesn't support choosing which shortcuts to enable, we now manually skip the package's keydown handling if a list is not selected and the shortcut is tab or shift+tab.