### PR TITLE
fix(plugin-text): center align image placeholder

### DIFF
--- a/src/serlo-editor-repo/plugin-image/editor.tsx
+++ b/src/serlo-editor-repo/plugin-image/editor.tsx
@@ -50,7 +50,6 @@ const Caption = styled.div({
   marginTop: '1rem',
   textAlign: 'center',
   fontStyle: 'italic',
-  'span[contenteditable]': { width: 'auto !important' },
 })
 
 export function ImageEditor(props: ImageProps) {


### PR DESCRIPTION
Original bug report:
>Creating a new picture plugin shows ‘optional caption’ on the left side. Centering would be nice.