### PR TITLE
fix: auth provider refresh

### DIFF
--- a/src/auth/auth-provider.tsx
+++ b/src/auth/auth-provider.tsx
@@ -42,10 +42,11 @@ export function AuthProvider({
     // careful: when changed this updates most of the components and can reset state in e.g. the editor!
     // use functional update to get the current value of the payload
     // returning same value will skip set state
-    setAuthenticationPayload((authenticationPayload) => {
-      const isChanged = authenticationPayload?.id !== newPayload?.id
-      return isChanged ? newPayload : authenticationPayload
-    })
+    setAuthenticationPayload((authenticationPayload) =>
+      authenticationPayload?.id !== newPayload?.id
+        ? newPayload
+        : authenticationPayload
+    )
   }
 
   // check if kratos session still exists (single logout)

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -17,6 +17,7 @@ import { SerloEditor } from '@/edtr-io/serlo-editor'
 import { EditorPageData } from '@/fetcher/fetch-editor-data'
 import { getTranslatedType } from '@/helper/get-translated-type'
 import { isProduction } from '@/helper/is-production'
+import { showToastNotice } from '@/helper/show-toast-notice'
 import { useAddPageRevision } from '@/mutations/use-add-page-revision-mutation'
 import {
   OnSaveData,
@@ -50,7 +51,15 @@ export function AddRevision({
       setUserReady(isProduction ? auth !== null : true)
     }
     void confirmAuth()
-  }, [auth])
+
+    // special case for add-revision route
+    if (
+      window.location.href.includes('entity/repository/add-revision') &&
+      !auth
+    ) {
+      showToastNotice(strings.notices.warningLoggedOut, 'warning', 60000)
+    }
+  }, [auth, strings])
 
   if (!setEntityMutation) return null
 

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -53,12 +53,11 @@ export function AddRevision({
     void confirmAuth()
 
     // special case for add-revision route
-    if (
-      window.location.href.includes('entity/repository/add-revision') &&
-      !auth
-    ) {
+    if (userReady !== undefined && !auth) {
       showToastNotice(strings.notices.warningLoggedOut, 'warning', 60000)
     }
+    // do not rerun on userReady change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth, strings])
 
   if (!setEntityMutation) return null

--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -333,6 +333,7 @@ export const instanceData = {
       welcome: '👋 Welcome %username%!',
       bye: '👋 See you soon!',
       alreadyLoggedIn: '👋 Welcome back',
+      warningLoggedOut: '⚠️ You were logged out. Please login again and then use "Load stored edits" to restore your current changes.',
       revisionSaved: 'Revision is saved and will be reviewed soon 👍',
       revisionAccepted: 'Revision was successfully accepted ✅',
       revisionRejected: 'Revision was successfully rejected ❎',


### PR DESCRIPTION
- makes sure we only update auth provider when auth actually changes 
- adds prominent warning for edge case (user gets logged out in the background while on `add-revision` route)

(closes #2338)