### PR TITLE
fix(plugin-equation): Give placeholder text some vertical room.

### DIFF
--- a/src/edtr-io/plugins/equations/editor.tsx
+++ b/src/edtr-io/plugins/equations/editor.tsx
@@ -249,7 +249,7 @@ export function EquationsEditor(props: EquationsProps) {
                           ) : (
                             <td />
                           )}
-                          <td colSpan={2}>
+                          <td colSpan={2} style={{ minWidth: '10rem' }}>
                             {step.explanation.render({
                               config: {
                                 placeholder:


### PR DESCRIPTION
Quick fix to prevent wrapping placeholder text in equations plugin multiple times like:
![image](https://user-images.githubusercontent.com/59921805/233979130-bc320475-93d5-402e-879f-bd3469516132.png)