### PR TITLE
fix/editor drag n drop issue

### DIFF
--- a/src/serlo-editor-repo/plugin-rows/editor/render.tsx
+++ b/src/serlo-editor-repo/plugin-rows/editor/render.tsx
@@ -283,7 +283,9 @@ export function RowRenderer({
     drag,
   ])
 
-  dragPreview(drop(dropContainer))
+  setTimeout(() => {
+    dragPreview(drop(dropContainer))
+  })
   const dropPreview =
     collectedDropProps.isDragging &&
     (collectedDropProps.isFile || canDrop(collectedDropProps.id)) ? (

--- a/src/serlo-editor-repo/plugin-text/components/hovering-toolbar.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/hovering-toolbar.tsx
@@ -60,22 +60,24 @@ export function HoveringToolbar(props: HoveringToolbarProps) {
 
   return (
     <>
-      <InlineOverlay
-        config={config}
-        initialPosition={initialPosition}
-        hidden={
-          !selection ||
-          !focused ||
-          isSelectionCollapsed ||
-          SlateEditor.string(editor, selection) === ''
-        }
-      >
-        <HoveringToolbarControls
-          theme={config.theme}
-          controls={controls}
-          editor={editor}
-        />
-      </InlineOverlay>
+      {!isSelectionCollapsed && (
+        <InlineOverlay
+          config={config}
+          initialPosition={initialPosition}
+          hidden={
+            !selection ||
+            !focused ||
+            isSelectionCollapsed ||
+            SlateEditor.string(editor, selection) === ''
+          }
+        >
+          <HoveringToolbarControls
+            theme={config.theme}
+            controls={controls}
+            editor={editor}
+          />
+        </InlineOverlay>
+      )}
       <TimeoutBottomToolbarWrapper
         isTouch={isTouchDevice()}
         visible={!!isSelectionCollapsed && isBottomToolbarActive}


### PR DESCRIPTION
- Refactor and add comments in `hovering-toolbar`, to make its inner logic clearer
- Only render `hovering-toolbar` if selection is not collapsed. Reason: `react-dnd` breaks if the dragged element has a child that is positioned outside the dragged element.
- Only render the `dragPreview` in a `setTimeout`. This fixes the issue where drag preview would not render if a user tries to drag an element that was just dropped. Not sure why this is happening, but it has something to do with how a new row is inserted in the state, and then with how Slate is rendered after a new row is inserted in the state.

**Still buggy:** When the bottom toolbar is shown, the drag preview is still too big. This was an existing bug in the previous version, so we can fix it later.

Note: In general, too many things in the editor are fixed by wrapping code in `setTimeout`. If it continues, we need to look deeper into it.