### PR TITLE
fix(plugin-math): prevent default on cut

### DIFF
--- a/src/serlo-editor-repo/math/editor.tsx
+++ b/src/serlo-editor-repo/math/editor.tsx
@@ -77,6 +77,9 @@ const MathEditorTextArea = (props: MathEditorTextAreaProps) => {
       onCopy={(event: React.ClipboardEvent) => {
         event.stopPropagation()
       }}
+      onCut={(event: React.ClipboardEvent) => {
+        event.stopPropagation()
+      }}
       onMoveOutRight={props.onMoveOutRight}
       onMoveOutLeft={props.onMoveOutLeft}
       value={latex}


### PR DESCRIPTION
https://trello.com/c/t8wqq0DB/122-bug-cutting-a-part-of-a-formula-not-possible-text-plugin