### PR TITLE
fix(plugin-math): visual formula issues

### DIFF
--- a/src/serlo-editor-repo/math/visual-editor.tsx
+++ b/src/serlo-editor-repo/math/visual-editor.tsx
@@ -95,6 +95,12 @@ export function VisualEditor(props: VisualEditorProps) {
       onChange={(ref) => {
         props.onChange(ref.latex())
       }}
+      onCopy={(event: React.ClipboardEvent) => {
+        event.stopPropagation()
+      }}
+      onCut={(event: React.ClipboardEvent) => {
+        event.stopPropagation()
+      }}
       // @ts-expect-error https://github.com/serlo/serlo-editor-issues-and-documentation/issues/67
       config={mathQuillConfig}
       mathquillDidMount={onMount}


### PR DESCRIPTION
- fix copy and cut functionality in visual formula (it was already fixed for LaTeX formula in previous PRs)

https://trello.com/c/t8wqq0DB/122-bug-cutting-a-part-of-a-formula-not-possible-text-plugin