### PR TITLE
fix(editor): plugin configuration modal issue

### DIFF
--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
@@ -83,6 +83,7 @@ function WrappedModal({
           right: 'auto',
           bottom: 'auto',
           margin: '0 auto',
+          transform: 'none',
         },
       }}
     >


### PR DESCRIPTION
Frontend and editor modals use different positioning techniques. For frontend, it's position absolute+transition. For editor, it's flexbox justify content. The frontend CSS was spilling into the editor CSS, so this is just a quick fix to make sure editor modal content isn't transform-pushed to the left.

With bug:
<img width="1350" alt="Screenshot 2023-05-08 at 10 45 01" src="https://user-images.githubusercontent.com/13198821/236778956-198857fd-3794-45db-9a4a-f7e80231175b.png">

With fix:
<img width="1238" alt="Screenshot 2023-05-08 at 10 45 06" src="https://user-images.githubusercontent.com/13198821/236778970-e95ffa0b-c39f-46eb-aa02-e4f474b91d71.png">
