### PR TITLE
fix(editor): nested row parent add button inaccessible

### DIFF
--- a/src/serlo-editor-repo/plugin-rows/components/row-separator.tsx
+++ b/src/serlo-editor-repo/plugin-rows/components/row-separator.tsx
@@ -21,6 +21,7 @@ const Separator = styled.div<SeparatorProps>(({ isFirst, isLast }) => ({
       : 'translateY(100%)',
   top: isFirst ? 0 : undefined,
   bottom: isFirst ? undefined : 0,
+  zIndex: 1,
 }))
 
 const TriggerArea = styled.div({


### PR DESCRIPTION
Bug:
<img width="800" alt="Screenshot 2023-05-08 at 16 40 11" src="https://user-images.githubusercontent.com/13198821/236860720-0d511189-39fd-4492-b1f5-b5c2e77f4fb0.png">
<img width="792" alt="Screenshot 2023-05-08 at 16 43 48" src="https://user-images.githubusercontent.com/13198821/236860726-c28941c6-e7f9-4491-b0a6-9fb2fe52a106.png">

Quick fix: Increase the z-index of row separator, to make the button clickable.

Long term: There are UX/UI packages on the way to remove the button completely, so it's not really worth it to make the styles more beautiful right now.