### PR TITLE
fix(plugin-image): redux state change during render

### DIFF
--- a/src/serlo-editor-repo/plugin-image/editor.tsx
+++ b/src/serlo-editor-repo/plugin-image/editor.tsx
@@ -58,15 +58,20 @@ export function ImageEditor(props: ImageProps) {
     !state.caption.defined || isEmpty(state.caption.id)(scopedStore.getState())
   const hasFocus = focused || hasFocusedChild(props.id)(scopedStore.getState())
 
-  if (!editable)
+  React.useEffect(() => {
+    if (editable && !state.caption.defined) {
+      state.caption.create({ plugin: 'text' })
+    }
+  }, [editable, state.caption])
+
+  if (!editable) {
     return (
       <>
         {renderImage()}
         {captionIsEmpty ? null : renderCaption()}
       </>
     )
-
-  if (!state.caption.defined) state.caption.create({ plugin: 'text' })
+  }
 
   return (
     <>


### PR DESCRIPTION
Problem: Redux state was being updated during render
<img width="1038" alt="Screenshot 2023-05-08 at 13 41 37" src="https://user-images.githubusercontent.com/13198821/236861135-4b17c104-5db2-454c-a783-edca454169f9.png">

Relevant `react-redux` issue: https://github.com/reduxjs/react-redux/issues/1640

This PR could help with https://github.com/serlo/frontend/issues/2369

Note: You might notice that there is an issue with the URL field of the image plugin. This was an already existing bug, not introduced by this fix. Will open a new issue for that.

**Update**: The URL field issue was an existing bug, but it was escalated by this PR, as before only the image plugin crashed, now the whole app crashes. Need to investigate and fix that before merging this PR.
**Another update**: Weirdly, after I merged this branch with staging, the app breaking stopped.