### PR TITLE
handle empty value in plugin-text deserialization

### DIFF
--- a/src/serlo-editor-repo/plugin-text/index.tsx
+++ b/src/serlo-editor-repo/plugin-text/index.tsx
@@ -35,7 +35,6 @@ const createTextPlugin = (
       return value
     },
     deserialize(value) {
-      // sometimes, the value is empty, e.g. https://github.com/serlo/frontend/issues/2411
       if (value.length === 0) {
         return emptyDocumentFactory()
       }

--- a/src/serlo-editor-repo/plugin-text/index.tsx
+++ b/src/serlo-editor-repo/plugin-text/index.tsx
@@ -35,6 +35,11 @@ const createTextPlugin = (
       return value
     },
     deserialize(value) {
+      // sometimes, the value is empty, e.g. https://github.com/serlo/frontend/issues/2411
+      if (value.length === 0) {
+        return emptyDocumentFactory()
+      }
+
       // If the first child of the Element is an empty object,
       // replace it with an empty document.
       // https://docs.slatejs.org/concepts/11-normalizing#built-in-constraints


### PR DESCRIPTION
The debugging shows that `value` can be  `[]`. Now the deserializer handles this case and it fixes the bug.

example: https://frontend-git-2411-editor-crash-on-certain-articles-serlo.vercel.app//entity/repository/add-revision/270596/270598