### PR TITLE
feat(editor): add simple tooltips (text-toolbar and some other icon buttons)

### DIFF
--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -456,6 +456,15 @@
       transition: all 0.2s ease-in-out;
     }
   }
+
+  .serlo-tooltip-trigger {
+    @apply relative;
+
+    &:hover > .serlo-tooltip,
+    &:focus > .serlo-tooltip {
+      @apply pointer-events-auto opacity-100;
+    }
+  }
 }
 
 /* print and pdf styles */

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -462,7 +462,7 @@
 
     &:hover > .serlo-tooltip,
     &:focus > .serlo-tooltip {
-      @apply pointer-events-auto opacity-95 not-sr-only absolute pb-[0.7rem];
+      @apply opacity-95 not-sr-only absolute pb-[0.7rem];
     }
   }
 }

--- a/src/assets-webkit/styles/serlo-tailwind.css
+++ b/src/assets-webkit/styles/serlo-tailwind.css
@@ -462,7 +462,7 @@
 
     &:hover > .serlo-tooltip,
     &:focus > .serlo-tooltip {
-      @apply pointer-events-auto opacity-100;
+      @apply pointer-events-auto opacity-95 not-sr-only absolute pb-[0.7rem];
     }
   }
 }

--- a/src/edtr-io/plugins/article/article-related-content.tsx
+++ b/src/edtr-io/plugins/article/article-related-content.tsx
@@ -145,14 +145,14 @@ export function ArticleRelatedContent({
           onClick={() => data[category].remove(index)}
         >
           <EditorTooltip text={articleStrings.removeLabel} />
-          <Icon icon={faTrashAlt} />
+          <Icon icon={faTrashAlt} aria-hidden="true" />
         </button>
         <button
           {...dragHandleProps}
           className={`${buttonClass} serlo-tooltip-trigger`}
         >
           <EditorTooltip text={articleStrings.dragLabel} />
-          <Icon icon={faGripVertical} />
+          <Icon icon={faGripVertical} aria-hidden="true" />
         </button>
       </>
     )

--- a/src/edtr-io/plugins/article/article-related-content.tsx
+++ b/src/edtr-io/plugins/article/article-related-content.tsx
@@ -144,14 +144,14 @@ export function ArticleRelatedContent({
           className={`${buttonClass} serlo-tooltip-trigger`}
           onClick={() => data[category].remove(index)}
         >
-          <EditorTooltip text={articleStrings.removeLabel} hideOnHover />
+          <EditorTooltip text={articleStrings.removeLabel} />
           <Icon icon={faTrashAlt} />
         </button>
         <button
           {...dragHandleProps}
           className={`${buttonClass} serlo-tooltip-trigger`}
         >
-          <EditorTooltip text={articleStrings.dragLabel} hideOnHover />
+          <EditorTooltip text={articleStrings.dragLabel} />
           <Icon icon={faGripVertical} />
         </button>
       </>

--- a/src/edtr-io/plugins/article/article-related-content.tsx
+++ b/src/edtr-io/plugins/article/article-related-content.tsx
@@ -14,6 +14,7 @@ import { useInstanceData } from '@/contexts/instance-context'
 import { useLoggedInData } from '@/contexts/logged-in-data-context'
 import { getTranslatedType } from '@/helper/get-translated-type'
 import { categoryIconMapping } from '@/helper/icon-by-entity-type'
+import { EditorTooltip } from '@/serlo-editor-repo/editor-ui/editor-tooltip'
 
 interface ArticleRelatedContentProps {
   data: ArticleProps['state']['relatedContent']
@@ -140,17 +141,17 @@ export function ArticleRelatedContent({
     return (
       <>
         <button
-          title={articleStrings.removeLabel}
-          className={buttonClass}
+          className={`${buttonClass} serlo-tooltip-trigger`}
           onClick={() => data[category].remove(index)}
         >
+          <EditorTooltip text={articleStrings.removeLabel} hideOnHover />
           <Icon icon={faTrashAlt} />
         </button>
         <button
-          title={articleStrings.dragLabel}
           {...dragHandleProps}
-          className={buttonClass}
+          className={`${buttonClass} serlo-tooltip-trigger`}
         >
+          <EditorTooltip text={articleStrings.dragLabel} hideOnHover />
           <Icon icon={faGripVertical} />
         </button>
       </>

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
@@ -18,7 +18,7 @@ export function createPluginToolbarButton(_config: DefaultPluginToolbarConfig) {
           ref={ref}
           onClick={onClick}
         >
-          <EditorTooltip text={label} className="-ml-4 !pb-2" hideOnHover />
+          <EditorTooltip text={label} className="-ml-4 !pb-2" />
           <StyledIconContainer>{icon}</StyledIconContainer>
         </Button>
       </div>

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
@@ -19,7 +19,7 @@ export function createPluginToolbarButton(_config: DefaultPluginToolbarConfig) {
           onClick={onClick}
         >
           <EditorTooltip text={label} className="-ml-4 !pb-2" />
-          <StyledIconContainer>{icon}</StyledIconContainer>
+          <StyledIconContainer aria-hidden="true">{icon}</StyledIconContainer>
         </Button>
       </div>
     )

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-button.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react'
 
+import { EditorTooltip } from '../editor-ui/editor-tooltip'
 import { PluginToolbarButtonProps } from '../plugin-toolbar'
 import { Button } from './button'
 import { DefaultPluginToolbarConfig } from './config'
@@ -9,16 +10,16 @@ export function createPluginToolbarButton(_config: DefaultPluginToolbarConfig) {
   const PluginToolbarButton = forwardRef<
     HTMLButtonElement,
     PluginToolbarButtonProps
-  >(function PluginToolbarButton(props, ref) {
+  >(function PluginToolbarButton({ className, label, onClick, icon }, ref) {
     return (
       <div>
         <Button
-          className={props.className}
-          title={props.label}
+          className={`${className ?? ''} serlo-tooltip-trigger`}
           ref={ref}
-          onClick={props.onClick}
+          onClick={onClick}
         >
-          <StyledIconContainer>{props.icon}</StyledIconContainer>
+          <EditorTooltip text={label} className="-ml-4 !pb-2" hideOnHover />
+          <StyledIconContainer>{icon}</StyledIconContainer>
         </Button>
       </div>
     )

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
@@ -32,7 +32,7 @@ export function createPluginToolbarOverlayButton(
             setOpen(true)
           }}
         >
-          <EditorTooltip text={label} className="-ml-4 !pb-2" hideOnHover />
+          <EditorTooltip text={label} className="-ml-4 !pb-2" />
           <StyledIconContainer>{icon}</StyledIconContainer>
         </Button>
       </>

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import Modal from 'react-modal'
 
+import { EditorTooltip } from '../editor-ui/editor-tooltip'
 import { PluginToolbarOverlayButtonProps } from '../plugin-toolbar'
 import { Button } from './button'
 import { DefaultPluginToolbarConfig } from './config'
@@ -26,12 +27,12 @@ export function createPluginToolbarOverlayButton(
           }}
         />
         <Button
-          className={className}
+          className={`${className ?? ''} serlo-tooltip-trigger`}
           onClick={() => {
             setOpen(true)
           }}
-          title={label}
         >
+          <EditorTooltip text={label} className="-ml-4 !pb-2" hideOnHover />
           <StyledIconContainer>{icon}</StyledIconContainer>
         </Button>
       </>

--- a/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
+++ b/src/serlo-editor-repo/default-plugin-toolbar/plugin-toolbar-overlay-button.tsx
@@ -33,7 +33,7 @@ export function createPluginToolbarOverlayButton(
           }}
         >
           <EditorTooltip text={label} className="-ml-4 !pb-2" />
-          <StyledIconContainer>{icon}</StyledIconContainer>
+          <StyledIconContainer aria-hidden="true">{icon}</StyledIconContainer>
         </Button>
       </>
     )

--- a/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
@@ -1,0 +1,34 @@
+import { useInstanceData } from '@/contexts/instance-context'
+import { isMac } from '@/helper/client-detection'
+
+export function EditorTooltip({
+  text,
+  hotkeys,
+}: {
+  text?: string
+  hotkeys?: string
+}) {
+  const { strings } = useInstanceData()
+  if (!text && !hotkeys) return null
+
+  const hotkeysTranslated = hotkeys?.replace(
+    '%ctrlOrCmd%',
+    isMac ? '⌘' : strings.keys.ctrl
+  )
+
+  return (
+    <span
+      className="serlo-tooltip pointer-events-none opacity-0 transition-opacity hover:block absolute cursor-default bottom-full pb-[0.7rem]"
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onMouseUp={(e) => e.stopPropagation()}
+    >
+      <span className="block text-sm font-bold bg-almost-black py-1.5 px-2 rounded z-50 text-center text-white w-80 max-w-fit ">
+        {text}
+        {hotkeys ? (
+          <span className="block text-gray-400">{hotkeysTranslated}</span>
+        ) : null}
+      </span>
+    </span>
+  )
+}

--- a/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
@@ -7,12 +7,10 @@ export function EditorTooltip({
   text,
   hotkeys,
   className,
-  hideOnHover,
 }: {
   text?: string
   hotkeys?: string
   className?: string
-  hideOnHover?: boolean
 }) {
   const { strings } = useInstanceData()
   if (!text && !hotkeys) return null
@@ -22,23 +20,12 @@ export function EditorTooltip({
     isMac ? '⌘' : strings.keys.ctrl
   )
 
-  const blockEvent = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    e.preventDefault()
-  }
-
   return (
     <span
       className={clsx(
-        'serlo-tooltip block pointer-events-none opacity-0 transition-opacity sr-only cursor-default bottom-full pb-[0.7rem]',
-        hideOnHover
-          ? '!pointer-events-none'
-          : 'hover:not-sr-only hover:absolute',
+        'serlo-tooltip block pointer-events-none opacity-0 transition-opacity sr-only cursor-default bottom-full',
         className
       )}
-      onClick={blockEvent}
-      onMouseDown={blockEvent}
-      onMouseUp={blockEvent}
     >
       <span className="block text-sm font-bold bg-almost-black py-1.5 px-2 rounded z-50 text-center text-white w-80 max-w-fit ">
         {text}

--- a/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
@@ -16,12 +16,17 @@ export function EditorTooltip({
     isMac ? '⌘' : strings.keys.ctrl
   )
 
+  const blockEvent = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+  }
+
   return (
     <span
       className="serlo-tooltip pointer-events-none opacity-0 transition-opacity hover:block absolute cursor-default bottom-full pb-[0.7rem]"
-      onClick={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-      onMouseUp={(e) => e.stopPropagation()}
+      onClick={blockEvent}
+      onMouseDown={blockEvent}
+      onMouseUp={blockEvent}
     >
       <span className="block text-sm font-bold bg-almost-black py-1.5 px-2 rounded z-50 text-center text-white w-80 max-w-fit ">
         {text}

--- a/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
+++ b/src/serlo-editor-repo/editor-ui/editor-tooltip.tsx
@@ -1,12 +1,18 @@
+import clsx from 'clsx'
+
 import { useInstanceData } from '@/contexts/instance-context'
 import { isMac } from '@/helper/client-detection'
 
 export function EditorTooltip({
   text,
   hotkeys,
+  className,
+  hideOnHover,
 }: {
   text?: string
   hotkeys?: string
+  className?: string
+  hideOnHover?: boolean
 }) {
   const { strings } = useInstanceData()
   if (!text && !hotkeys) return null
@@ -23,7 +29,13 @@ export function EditorTooltip({
 
   return (
     <span
-      className="serlo-tooltip pointer-events-none opacity-0 transition-opacity hover:block absolute cursor-default bottom-full pb-[0.7rem]"
+      className={clsx(
+        'serlo-tooltip block pointer-events-none opacity-0 transition-opacity sr-only cursor-default bottom-full pb-[0.7rem]',
+        hideOnHover
+          ? '!pointer-events-none'
+          : 'hover:not-sr-only hover:absolute',
+        className
+      )}
       onClick={blockEvent}
       onMouseDown={blockEvent}
       onMouseUp={blockEvent}
@@ -31,7 +43,7 @@ export function EditorTooltip({
       <span className="block text-sm font-bold bg-almost-black py-1.5 px-2 rounded z-50 text-center text-white w-80 max-w-fit ">
         {text}
         {hotkeys ? (
-          <span className="block text-gray-400">{hotkeysTranslated}</span>
+          <span className="block text-gray-300">{hotkeysTranslated}</span>
         ) : null}
       </span>
     </span>

--- a/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-button.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-button.tsx
@@ -1,21 +1,37 @@
-import { styled } from '../../ui'
-import { colors } from '@/helper/colors'
+import clsx from 'clsx'
+import { MouseEventHandler } from 'react'
 
-export const HoveringToolbarButton = styled.button<{
+import { EditorTooltip } from '@/serlo-editor-repo/editor-ui/editor-tooltip'
+
+export function HoveringToolbarButton({
+  active,
+  children,
+  tooltipText,
+  onMouseDown,
+}: {
   active?: boolean
-}>(({ active }) => ({
-  color: active ? colors.almostBlack : '#b6b6b6',
-  backgroundColor: active ? colors.editorPrimary200 : 'transparent',
-  cursor: 'pointer',
-  boxShadow: active ? 'inset 0 1px 3px 0 rgba(0,0,0,0.50)' : undefined,
-  outline: 'none',
-  height: '25px',
-  border: 'none',
-  borderRadius: '4px',
-  margin: '5px',
-  padding: '0px',
-  width: '25px',
-  '&:hover': {
-    color: active ? 'black' : colors.editorPrimary,
-  },
-}))
+  children: React.ReactNode
+  tooltipText?: string
+  onMouseDown: MouseEventHandler
+}) {
+  const textParts = tooltipText?.split('(')
+
+  return (
+    <button
+      className={clsx(
+        active
+          ? 'text-almost-black shadow-menu bg-editor-primary-200 hover:text-black'
+          : '#b6b6b6 hover:text-editor-primary',
+        'cursor-pointer outline-none h-6 b-0 rounded m-[5px] p-0 w-6',
+        'serlo-tooltip-trigger'
+      )}
+      onMouseDown={onMouseDown}
+    >
+      <EditorTooltip
+        text={textParts?.[0]}
+        hotkeys={textParts?.[1]?.slice(0, -1)}
+      />
+      {children}
+    </button>
+  )
+}

--- a/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-controls.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/hovering-toolbar-controls.tsx
@@ -16,8 +16,10 @@ function isNestedControlButton(
   return R.has('children', control)
 }
 
-export function HoveringToolbarControls(props: HoveringToolbarControlsProps) {
-  const { controls, editor } = props
+export function HoveringToolbarControls({
+  controls,
+  editor,
+}: HoveringToolbarControlsProps) {
   const [subMenu, setSubMenu] = useState<number>()
 
   if (typeof subMenu !== 'number') {
@@ -26,7 +28,7 @@ export function HoveringToolbarControls(props: HoveringToolbarControlsProps) {
         {controls.map((control, index) => (
           <HoveringToolbarButton
             active={control.isActive(editor)}
-            title={control.title}
+            tooltipText={control.title}
             onMouseDown={(event) => {
               event.preventDefault()
               isNestedControlButton(control)
@@ -65,7 +67,7 @@ export function HoveringToolbarControls(props: HoveringToolbarControlsProps) {
       {subMenuControls.map((control, index) => (
         <HoveringToolbarButton
           active={control.isActive(editor)}
-          title={control.title}
+          tooltipText={control.title}
           onMouseDown={(event) => {
             event.preventDefault()
             control.onClick(editor)

--- a/src/serlo-editor-repo/plugin-text/components/hovering-toolbar.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/hovering-toolbar.tsx
@@ -18,9 +18,13 @@ const initialPosition = isTouchDevice()
   ? InlineOverlayPosition.below
   : InlineOverlayPosition.above
 
-export function HoveringToolbar(props: HoveringToolbarProps) {
+export function HoveringToolbar({
+  editor,
+  config,
+  controls,
+  focused,
+}: HoveringToolbarProps) {
   const [isBottomToolbarActive, setIsBottomToolbarActive] = useState(false)
-  const { editor, config, controls, focused } = props
   const { selection } = editor
   const text = Node.string(editor)
   const isSelectionCollapsed = selection && Range.isCollapsed(selection)


### PR DESCRIPTION
[test here](https://frontend-git-editor-tooltips-first-go-serlo.vercel.app/entity/repository/add-revision/1555)

<img width="343" alt="image" src="https://github.com/serlo/frontend/assets/1258870/41026cc7-da36-408a-a6bc-9a96e4348afa">
