### PR TITLE
Prevent block-type math elements in lists & fix bug when merging math element with siblings

### DIFF
--- a/src/serlo-editor-repo/plugin-text/components/math-element.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/math-element.tsx
@@ -14,6 +14,7 @@ import type {
   Paragraph,
   TextEditorPluginConfig,
 } from '../types'
+import { isElementWithinList } from '../utils/list'
 import { MathFormula } from './math-formula'
 
 export interface MathElementProps {
@@ -38,17 +39,7 @@ export function MathElement({
   const preferences = useContext(PreferenceContext)
 
   const isInsideListElement = useMemo(() => {
-    const path = ReactEditor.findPath(editor, element)
-    const ancestorNodes = [...Node.ancestors(editor, path)]
-    return ancestorNodes.some((ancestor) => {
-      const ancestorPath = ancestor[1]
-      const ancestorNode = Node.get(editor, ancestorPath)
-      return (
-        'type' in ancestorNode &&
-        (ancestorNode.type === 'ordered-list' ||
-          ancestorNode.type === 'unordered-list')
-      )
-    })
+    return isElementWithinList(element, editor)
   }, [editor, element])
 
   const shouldShowMathEditor =

--- a/src/serlo-editor-repo/plugin-text/components/math-element.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/math-element.tsx
@@ -63,7 +63,7 @@ export function MathElement({
   }
 
   /**
-   * Applys slate node transformations when MathElement is changed from inline to block type and backwards.
+   * Applies slate node transformations when MathElement is changed from inline to block type and backwards.
    */
   function handleInlineChange(newInlineValue: boolean) {
     // Editor.withoutNormalizing prevents automatically deleting elements by slate normalization until all transformations are done.
@@ -95,17 +95,23 @@ export function MathElement({
         }
         Transforms.insertNodes(editor, newNode, { at: path })
 
-        const hasSiblingAfter = Node.has(editor, Path.next(path))
+        const nextSiblingPath = Path.next(path)
+        const hasSiblingAfter = Node.has(editor, nextSiblingPath)
         if (hasSiblingAfter) {
-          const nextSiblingPath = Path.next(path)
-          // Merge next sibling node with newNode
-          Transforms.mergeNodes(editor, { at: nextSiblingPath })
+          const nodeAfter = Node.get(editor, nextSiblingPath)
+          if ('type' in nodeAfter && nodeAfter.type === 'p') {
+            // Merge next sibling node with newNode
+            Transforms.mergeNodes(editor, { at: nextSiblingPath })
+          }
         }
 
         const hasSiblingBefore = path[path.length - 1] !== 0
         if (hasSiblingBefore) {
-          // Merge newNode with previous sibling node
-          Transforms.mergeNodes(editor, { at: path })
+          const nodeBefore = Node.get(editor, Path.previous(path))
+          if ('type' in nodeBefore && nodeBefore.type === 'p') {
+            // Merge newNode with previous sibling node
+            Transforms.mergeNodes(editor, { at: path })
+          }
         }
       }
 

--- a/src/serlo-editor-repo/plugin-text/components/math-element.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/math-element.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { Editor, Node, Path, Range, Transforms } from 'slate'
 import {
   ReactEditor,
@@ -36,6 +36,20 @@ export function MathElement({
   const editor = useSlate()
   const selected = useSelected()
   const preferences = useContext(PreferenceContext)
+
+  const isInsideListElement = useMemo(() => {
+    const path = ReactEditor.findPath(editor, element)
+    const ancestorNodes = [...Node.ancestors(editor, path)]
+    return ancestorNodes.some((ancestor) => {
+      const ancestorPath = ancestor[1]
+      const ancestorNode = Node.get(editor, ancestorPath)
+      return (
+        'type' in ancestorNode &&
+        (ancestorNode.type === 'ordered-list' ||
+          ancestorNode.type === 'unordered-list')
+      )
+    })
+  }, [editor, element])
 
   const shouldShowMathEditor =
     focused &&
@@ -176,7 +190,7 @@ export function MathElement({
         inline={element.inline}
         readOnly={false}
         visual={isVisualMode}
-        disableBlock={false}
+        disableBlock={isInsideListElement}
         config={{ i18n: config.i18n.math }}
         onInlineChange={handleInlineChange}
         onChange={(src) => updateElement({ src })}

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -23,6 +23,7 @@ import { useFormattingOptions } from '../hooks/use-formatting-options'
 import { useSuggestions } from '../hooks/use-suggestions'
 import { textColors, useTextConfig } from '../hooks/use-text-config'
 import {
+  ListElementType,
   TextEditorConfig,
   TextEditorPluginConfig,
   TextEditorState,
@@ -413,16 +414,16 @@ function renderElementWithEditorContext(
       )
     }
 
-    if (element.type === 'unordered-list') {
+    if (element.type === ListElementType.UNORDERED_LIST) {
       return <ul {...attributes}>{children}</ul>
     }
-    if (element.type === 'ordered-list') {
+    if (element.type === ListElementType.ORDERED_LIST) {
       return <ol {...attributes}>{children}</ol>
     }
-    if (element.type === 'list-item') {
+    if (element.type === ListElementType.LIST_ITEM) {
       return <li {...attributes}>{children}</li>
     }
-    if (element.type === 'list-item-child') {
+    if (element.type === ListElementType.LIST_ITEM_TEXT) {
       return <div {...attributes}>{children}</div>
     }
 

--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -32,7 +32,7 @@ import {
   mergePlugins,
   sliceNodesAfterSelection,
 } from '../utils/document'
-import { isOrderedListActive, isUnorderedListActive } from '../utils/list'
+import { isSelectionWithinList } from '../utils/list'
 import { isSelectionAtEnd, isSelectionAtStart } from '../utils/selection'
 import { HoveringToolbar } from './hovering-toolbar'
 import { LinkControls } from './link-controls'
@@ -192,8 +192,7 @@ export function TextEditor(props: TextEditorProps) {
       }
 
       // Create a new Slate instance on "enter" key
-      const isListActive =
-        isOrderedListActive(editor) || isUnorderedListActive(editor)
+      const isListActive = isSelectionWithinList(editor)
       if (isHotkey('enter', event) && !isListActive) {
         const document = getDocument(id)(store.getState())
         if (!document) return
@@ -267,8 +266,7 @@ export function TextEditor(props: TextEditorProps) {
   }
 
   function handleEditablePaste(event: React.ClipboardEvent) {
-    const isListActive =
-      isOrderedListActive(editor) || isUnorderedListActive(editor)
+    const isListActive = isSelectionWithinList(editor)
 
     const document = getDocument(id)(store.getState())
     if (!document) return

--- a/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor-repo/plugin-text/hooks/use-formatting-options.tsx
@@ -33,8 +33,9 @@ import {
 } from '../utils/color'
 import { isLinkActive, toggleLink } from '../utils/link'
 import {
-  isOrderedListActive,
-  isUnorderedListActive,
+  isSelectionWithinList,
+  isSelectionWithinOrderedList,
+  isSelectionWithinUnorderedList,
   toggleOrderedList,
   toggleUnorderedList,
 } from '../utils/list'
@@ -196,8 +197,7 @@ export const useFormattingOptions = (
       )
       if (!isListsOptionEnabled) return
 
-      const isListActive =
-        isOrderedListActive(editor) || isUnorderedListActive(editor)
+      const isListActive = isSelectionWithinList(editor)
       const isTabShortcut =
         isHotkey('tab', event) || isHotkey('shift+tab', event)
       if (!isListActive && isTabShortcut) return
@@ -294,7 +294,7 @@ function createToolbarControls(
     {
       name: TextEditorFormattingOption.lists,
       title: i18n.list.toggleOrderedList,
-      isActive: isOrderedListActive,
+      isActive: isSelectionWithinOrderedList,
       onClick: toggleOrderedList,
       renderIcon: () => <EdtrIcon icon={edtrListNumbered} />,
     },
@@ -302,7 +302,7 @@ function createToolbarControls(
     {
       name: TextEditorFormattingOption.lists,
       title: i18n.list.toggleUnorderedList,
-      isActive: isUnorderedListActive,
+      isActive: isSelectionWithinUnorderedList,
       onClick: toggleUnorderedList,
       renderIcon: () => <EdtrIcon icon={edtrListBullets} />,
     },

--- a/src/serlo-editor-repo/plugin-text/utils/document.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/document.ts
@@ -1,4 +1,11 @@
-import { Descendant, Node, Editor as SlateEditor, Transforms } from 'slate'
+import {
+  Descendant,
+  Element,
+  Node,
+  Editor as SlateEditor,
+  Transforms,
+  Location,
+} from 'slate'
 
 import { StateTypeValueType } from '../../plugin'
 import type { TextEditorState } from '../types'
@@ -149,4 +156,22 @@ export function mergePlugins(
       return newValue
     }
   }
+}
+
+export function existsInAncestors(
+  predicate: (element: Element) => boolean,
+  { location }: { location: Location },
+  editor: SlateEditor
+) {
+  const matchingNodes = Array.from(
+    SlateEditor.nodes(editor, {
+      at: location,
+      match: (node) =>
+        !SlateEditor.isEditor(node) &&
+        Element.isElement(node) &&
+        predicate(node),
+    })
+  )
+
+  return matchingNodes.length !== 0
 }

--- a/src/serlo-editor-repo/plugin-text/utils/list.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/list.ts
@@ -2,11 +2,14 @@ import { ListsEditor, ListType } from '@prezly/slate-lists'
 import { Element, Editor as SlateEditor } from 'slate'
 import { ReactEditor } from 'slate-react'
 
+import { ListElementType } from '../types'
 import { existsInAncestors } from './document'
 
 export function isElementWithinList(element: Element, editor: SlateEditor) {
   return existsInAncestors(
-    (elem) => elem.type === 'unordered-list' || elem.type === 'ordered-list',
+    (elem) =>
+      elem.type === ListElementType.ORDERED_LIST ||
+      elem.type === ListElementType.UNORDERED_LIST,
     { location: ReactEditor.findPath(editor, element) },
     editor
   )
@@ -14,7 +17,7 @@ export function isElementWithinList(element: Element, editor: SlateEditor) {
 
 export function isSelectionWithinList(
   editor: SlateEditor,
-  listType?: 'unordered-list' | 'ordered-list'
+  listType?: ListElementType
 ) {
   if (!editor.selection) return false
 
@@ -22,7 +25,8 @@ export function isSelectionWithinList(
     (element) => {
       return listType
         ? element.type === listType
-        : element.type === 'ordered-list' || element.type === 'unordered-list'
+        : element.type === ListElementType.ORDERED_LIST ||
+            element.type === ListElementType.UNORDERED_LIST
     },
     { location: SlateEditor.unhangRange(editor, editor.selection) },
     editor
@@ -30,11 +34,11 @@ export function isSelectionWithinList(
 }
 
 export function isSelectionWithinUnorderedList(editor: SlateEditor) {
-  return isSelectionWithinList(editor, 'unordered-list')
+  return isSelectionWithinList(editor, ListElementType.UNORDERED_LIST)
 }
 
 export function isSelectionWithinOrderedList(editor: SlateEditor) {
-  return isSelectionWithinList(editor, 'ordered-list')
+  return isSelectionWithinList(editor, ListElementType.ORDERED_LIST)
 }
 
 export function toggleOrderedList(editor: SlateEditor) {

--- a/src/serlo-editor-repo/plugin-text/utils/selection.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/selection.ts
@@ -7,22 +7,19 @@ import {
   Point,
 } from 'slate'
 
+import { existsInAncestors } from './document'
+
 export function selectionHasElement(
   predicate: (element: Element) => boolean,
   editor: SlateEditor
 ) {
-  const { selection } = editor
-  if (!selection) return false
+  if (!editor.selection) return false
 
-  const [match] = Array.from(
-    SlateEditor.nodes(editor, {
-      at: SlateEditor.unhangRange(editor, selection),
-      match: (n) =>
-        !SlateEditor.isEditor(n) && Element.isElement(n) && predicate(n),
-    })
+  return existsInAncestors(
+    predicate,
+    { location: SlateEditor.unhangRange(editor, editor.selection) },
+    editor
   )
-
-  return !!match
 }
 
 export function trimSelection(editor: SlateEditor): Partial<Range> | null {


### PR DESCRIPTION
### Before

1. Bug: When the user toggles a math element to be inline and there is another block-type math element before or afterwards, merging with this nodes siblings will fail. 
2. Users can create a block-level math element in lists, effectively creating line breaks in lists. 

### After

1. Merging is skipped if the element before or after is not a "paragraph"
2. Checkbox to toggle inline inside math editor is hidden when the math element is inside a list. 

### Refactorings

- Introduced function `existsInAncestors` and used it for checking if A) an element is within a list, B) the current selection is within a list
- Renamed and introduced new functions to make it more clear what the function does. Example: `isOrderedListActive` became `isSelectionWithinOrderedList` 