### PR TITLE
fix: Make box plugin only show empty content warning message when editable is true and box is empty.

### DIFF
--- a/src/edtr-io/plugins/box/renderer.tsx
+++ b/src/edtr-io/plugins/box/renderer.tsx
@@ -1,7 +1,6 @@
 import { selectIsEmptyRows } from '@edtr-io/plugin-rows'
-import { store } from '@edtr-io/store'
+import { useAppSelector } from '@edtr-io/store'
 import clsx from 'clsx'
-import { useState } from 'react'
 
 import { BoxProps } from '.'
 import { boxTypeStyle, defaultStyle } from '@/components/content/box'
@@ -26,17 +25,14 @@ export function BoxRenderer(props: BoxProps) {
     ? style.colorClass
     : defaultStyle.colorClass
   const icon = Object.hasOwn(style, 'icon') ? style.icon : undefined
-  const [contentIsEmpty, setContentIsEmpty] = useState(true)
+  const contentId = content.get()
+  const contentIsEmpty = useAppSelector((state) =>
+    selectIsEmptyRows(state, contentId)
+  )
   const { strings } = useInstanceData()
   const loggedInData = useLoggedInData()
   if (!loggedInData) return null
   const editorStrings = loggedInData.strings.editor
-
-  const checkContentEmpty = () => {
-    const isEmptyNow =
-      selectIsEmptyRows(store.getState(), content.get()) ?? true
-    if (isEmptyNow !== contentIsEmpty) setContentIsEmpty(isEmptyNow)
-  }
 
   return (
     <>
@@ -82,11 +78,7 @@ export function BoxRenderer(props: BoxProps) {
   }
 
   function renderContent() {
-    return (
-      <div className="-ml-3" onKeyUp={checkContentEmpty}>
-        {content.render()}
-      </div>
-    )
+    return <div className="-ml-3">{content.render()}</div>
   }
 
   function renderInlineSettings() {
@@ -146,7 +138,7 @@ export function BoxRenderer(props: BoxProps) {
   }
 
   function renderWarning() {
-    return contentIsEmpty ? (
+    return contentIsEmpty && props.editable ? (
       <div className="mt-1 text-right">
         <span className="bg-editor-primary-100 p-0.5 text-sm">
           ⚠️ {editorStrings.box.emptyContentWarning}


### PR DESCRIPTION
### Before

Box showed this warning even when box is not editable in edu-sharing integration: 
![image](https://github.com/serlo/frontend/assets/59921805/bff5459e-8724-48ac-aef9-2b8cb5d3e13a)

Component used `useState` to show/hide this message and updated the state on key presses. However, deleting a plugin did not update this state -> Message should have been displayed but was not. 

### After

Warning is hidden when props.editable is false. 

Use `useAppSelector` instead of component state to check if the box content is empty and subscribe to re-render if the state changes. 