### PR TITLE
editor(text-plugin): double enter creates new paragraph

### DIFF
--- a/src/serlo-editor-repo/plugin-text/utils/document.ts
+++ b/src/serlo-editor-repo/plugin-text/utils/document.ts
@@ -36,9 +36,6 @@ export function sliceNodesAfterSelection(editor: SlateEditor) {
 
   let slicedNodes = null
 
-  // Create a new line at selection
-  SlateEditor.insertBreak(editor)
-
   const selectionPoint = editor.selection.anchor.path[0]
   const childrenCount = editor.children.length
 


### PR DESCRIPTION
Change behaviour of new line and new Slate instance (aka new paragraph): 
- new line in same Slate instance with "Enter" and "Shift+Enter"
- new paragraph with "Enter"+"Enter"


### [preview](https://frontend-git-feature-new-para-new-line-serlo.vercel.app/entity/create/Article/60730)