### PR TITLE
Change editor roadmap according to newest releases and current Trello board

### DIFF
--- a/src/components/pages/editor/editor-roadmap.tsx
+++ b/src/components/pages/editor/editor-roadmap.tsx
@@ -4,33 +4,30 @@ const roadmapData = [
   {
     title: 'Latest Releases',
     steps: [
-      'Table plugin',
-      'Math equations plugin',
-      'Highlighting box plugin',
-      'Improved plugin selection menu',
+      'Redesigned plugin selection, custom icons',
       'Helpful tooltips that open directly on hover',
-      'Integrate H5P elements in Serlo Editor content',
-      'Custom search to link to other Serlo entities',
+      'Integrate H5P exercises in Serlo Editor content',
+      'Feature to easily find and link Serlo content',
+      'Simple Autosave',
     ],
   },
   {
     title: 'Next up',
     steps: [
-      'Duplicate existing entities',
       'Redesigned plugin toolbar',
-      'Migrations from old to new versions of the Serlo Editor data format',
       'Accessibility improvements for pictures',
-      'Easily link to sections of any Serlo entity through URL',
+      'Import existing Serlo content',
+      'Directly link to sections in Serlo content',
     ],
   },
   {
     title: 'Soon',
     steps: [
-      'Differentiate between new paragraph and new lines',
-      'Add plugins within paragraphs',
-      'Improved focus management',
+      'Improve Image plugin, easier uploads',
       'Better keyboard navigation',
+      'Improved focus management',
       'Impact dashboard – supporting authors with usage data',
+      'Differentiate between new paragraph and new lines',
     ],
   },
   {

--- a/src/components/pages/editor/editor-roadmap.tsx
+++ b/src/components/pages/editor/editor-roadmap.tsx
@@ -3,22 +3,34 @@ import { tw } from '@/helper/tw'
 const roadmapData = [
   {
     title: 'Latest Releases',
-    steps: ['Table plugin', 'Math equations plugin', 'Highlighting box plugin'],
+    steps: [
+      'Table plugin',
+      'Math equations plugin',
+      'Highlighting box plugin',
+      'Improved plugin selection menu',
+      'Helpful tooltips that open directly on hover',
+      'Integrate H5P elements in Serlo Editor content',
+      'Custom search to link to other Serlo entities',
+    ],
   },
   {
     title: 'Next up',
     steps: [
-      'Better rich text editing UX (Update Slate to 0.82) ',
-      'Improved plugin selection menu',
-      'Helpful tooltips that open directly on hover',
+      'Duplicate existing entities',
+      'Redesigned plugin toolbar',
+      'Migrations from old to new versions of the Serlo Editor data format',
+      'Accessibility improvements for pictures',
+      'Easily link to sections of any Serlo entity through URL',
     ],
   },
   {
     title: 'Soon',
     steps: [
-      'Integrate H5P elements in Serlo Editor content (new plugin)',
-      'Migration algorithm from old to new versions of the Serlo Editor data format',
-      'New data format for easy exchange  between different LMS',
+      'Differentiate between new paragraph and new lines',
+      'Add plugins within paragraphs',
+      'Improved focus management',
+      'Better keyboard navigation',
+      'Impact dashboard – supporting authors with usage data',
     ],
   },
   {
@@ -26,11 +38,9 @@ const roadmapData = [
     steps: [
       'Fill-in-the-gap exercise (new plugin)',
       'Drag & Drop exercise (new plugin)',
-      'Improved focus management',
       'Better support for LMS integrations',
       'Copy & Paste content across plugins',
       'Automated OER license management',
-      'Impact dashboard – supporting authors with usage data',
     ],
   },
 ]

--- a/src/components/pages/editor/editor-roadmap.tsx
+++ b/src/components/pages/editor/editor-roadmap.tsx
@@ -15,7 +15,7 @@ const roadmapData = [
     title: 'Next up',
     steps: [
       'Redesigned plugin toolbar',
-      'Accessibility improvements for pictures',
+      'Accessibility improvements for pictures using AI',
       'Import existing Serlo content',
       'Directly link to sections in Serlo content',
     ],


### PR DESCRIPTION
Had a meeting with @silvia-br and @LarsTheGlidingSquirrel and made some updates to the roadmap of the /editor presentational website. To not make the "Latest Releases" too long, we removed some points that we thought are no longer needed and updated the roadmap with the prioritized tasks in Trello and the ones that we are currently working on.

@elbotho feel free to make changes directly in the PR. Silvia expressed that you may not like the wording `Duplicate existing entities` but we agreed that it sounds less confusing than `Import existing entities`. 

We also included the `Custom search to link to other Serlo entities` into latest releases, assuming that we can deploy it alongside the big PR you just merged https://github.com/serlo/frontend/pull/2439. :tada: 

One last thing where someone can maybe find a better wording is the `Anchor` task: https://trello.com/c/W6ZXhNpv/95-anchor-sprungmarke 
We settled on `Easily link to sections of any Serlo entity through URL` but I'm not too happy with that description. We wanted to not have the word 'Anchor' in there as presumably a lot of people won't know what an anchor within a URL is.  