### PR TITLE
Fix error message of h5p type and allow ImagePair plugin

### DIFF
--- a/src/edtr-io/plugins/h5p.tsx
+++ b/src/edtr-io/plugins/h5p.tsx
@@ -17,6 +17,7 @@ const h5pLibraryWhitelist = [
   'H5P.Blanks',
   'H5P.DragText',
   'H5P.ImageHotspotQuestion',
+  'H5P.ImagePair',
   'H5P.MultiMediaChoice',
   'H5P.ImageMultipleHotspotQuestion',
   'H5P.MemoryGame',

--- a/src/edtr-io/plugins/h5p.tsx
+++ b/src/edtr-io/plugins/h5p.tsx
@@ -68,7 +68,7 @@ export function H5pEditor({ state, autofocusRef }: H5pProps) {
 
         if (!h5pLibraryWhitelist.includes(mainLib)) {
           setError(
-            'Unerlaubter Inhaltstyp - nutze bitte nur die vier genannten Inhaltstypen'
+            'Unerlaubter Inhaltstyp - nutze bitte nur die oben genannten Inhaltstypen'
           )
           setMode('edit')
         } else {

--- a/src/edtr-io/plugins/h5p.tsx
+++ b/src/edtr-io/plugins/h5p.tsx
@@ -12,18 +12,23 @@ import { H5p, parseH5pUrl } from '@/components/content/h5p'
 export type H5pPluginState = StringStateType
 export type H5pProps = EditorPluginProps<H5pPluginState>
 
-const h5pLibraryWhitelist = [
-  'H5P.DragQuestion',
-  'H5P.Blanks',
-  'H5P.DragText',
-  'H5P.ImageHotspotQuestion',
-  'H5P.ImagePair',
-  'H5P.MultiMediaChoice',
-  'H5P.ImageMultipleHotspotQuestion',
-  'H5P.MemoryGame',
-  'H5P.Flashcards',
-  'H5P.MarkTheWords',
-]
+/**
+ * A mapping between the H5P exercise key (they call it library) and the
+ * friendly value of how it should be displayed in the editor.
+ */
+const availableH5pExercises: Record<string, string> = {
+  'H5P.DragQuestion': 'Drag and Drop',
+  'H5P.Blanks': 'Fill in the Blanks',
+  'H5P.DragText': 'Drag the Words',
+  'H5P.ImageHotspotQuestion': 'Find the Hotspot',
+  'H5P.ImagePair': 'Image pairing',
+  'H5P.MultiMediaChoice': 'Bildauswahl (Image Choice)',
+  'H5P.ImageMultipleHotspotQuestion':
+    'Hotspots in Bild suchen (mehrere) (Find Multiple Hotspots)',
+  'H5P.MemoryGame': 'Memory',
+  'H5P.Flashcards': 'Flashcards',
+  'H5P.MarkTheWords': 'Mark The Words',
+}
 
 export const H5pPlugin: EditorPlugin<H5pPluginState> = {
   Component: H5pEditor,
@@ -67,7 +72,7 @@ export function H5pEditor({ state, autofocusRef }: H5pProps) {
           json.integration.contents
         )[0].library.split(' ')[0]
 
-        if (!h5pLibraryWhitelist.includes(mainLib)) {
+        if (!Object.keys(availableH5pExercises).includes(mainLib)) {
           setError(
             'Unerlaubter Inhaltstyp - nutze bitte nur die oben genannten Inhaltstypen'
           )
@@ -121,17 +126,9 @@ export function H5pEditor({ state, autofocusRef }: H5pProps) {
               Klicke auf &quot;Neuen Inhalt erstellen&quot; und wähle eines der
               folgenden Inhaltstypen:
               <ul>
-                <li>Fill in the Blanks</li>
-                <li>Drag the Words</li>
-                <li>Find the Hotspot</li>
-                <li>Drag and Drop</li>
-                <li>Bildauswahl (Image Choice)</li>
-                <li>
-                  Hotspots in Bild suchen (mehrere) (Find Multiple Hotspots)
-                </li>
-                <li>Memory</li>
-                <li>Flashcards</li>
-                <li>Mark The Words</li>
+                {Object.values(availableH5pExercises).map((exercise) => (
+                  <li key={exercise}>{exercise}</li>
+                ))}
               </ul>
             </li>
             <li>


### PR DESCRIPTION
I have yet to get an okay from Tina or @Entkenntnis if it's okay to allow the ImagePair plugin.

However, I'd also like to fix the bug that the article can be saved while errors are in it. For this, I'll probably need some guidance but right now the local `error` state is not checked and one can save entities with an errored h5p plugin just fine.

Not sure if we should create another PR for this, or if it's a small change, add it to this one.