### PR TITLE
fix: safari plugin suggestions don't react to clicking text plugin

### DIFF
--- a/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
+++ b/src/serlo-editor-repo/plugin-text/components/text-editor.tsx
@@ -463,6 +463,7 @@ export function TextEditor(props: TextEditorProps) {
           onPaste={handleEditablePaste}
           renderElement={handleRenderElement}
           renderLeaf={renderLeaf}
+          className="[&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
         />
         {editable && focused && (
           <>

--- a/src/serlo-editor-repo/plugin-text/hooks/use-suggestions.tsx
+++ b/src/serlo-editor-repo/plugin-text/hooks/use-suggestions.tsx
@@ -98,6 +98,8 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
     // just clear the editor
     if (pluginName === 'text') {
       editor.deleteBackward('line')
+      // in browsers other than chrome the cursor is sometimes in front of the `/` so to make sure:
+      editor.deleteForward('line')
       return
     }
 


### PR DESCRIPTION
[report](https://serlo.slack.com/archives/C0BMSC431/p1687188541796019)

[example](https://frontend-git-fix-safari-text-suggestion-serlo.vercel.app/entity/repository/add-revision/277143)