### PR TITLE
Fix single logout url

### DIFF
--- a/src/components/pages/auth/logout.tsx
+++ b/src/components/pages/auth/logout.tsx
@@ -37,7 +37,7 @@ export function Logout({ oauth }: { oauth?: boolean }) {
       : false
 
     const redirection = isSSO
-      ? 'https://aai-dev.nbpdev.de/realms/nbp-aai/protocol/openid-connect/logout'
+      ? 'https://aai-test.nbpdev.de/realms/nbp-aai/protocol/openid-connect/logout'
       : filterUnwantedRedirection({
           desiredPath: sessionStorage.getItem('previousPathname'),
           unwantedPaths: [settingsUrl, loginUrl, registrationUrl],


### PR DESCRIPTION
The test environment of the NBP id provider has changed. Now we should use another url