### PR TITLE
fix(geogebra-plugin): Make button 'activate' clickable when editable=false

### DIFF
--- a/src/serlo-editor/plugins/geogebra/editor.tsx
+++ b/src/serlo-editor/plugins/geogebra/editor.tsx
@@ -22,7 +22,7 @@ export function GeogebraEditor(props: GeogebraProps) {
           type="applet"
           provider="GeoGebra"
           embedUrl={url}
-          className={focused ? '' : 'pointer-events-none'}
+          className={editable && !focused ? 'pointer-events-none': ''}
         >
           <GeogebraRenderer url={url} />
         </EmbedWrapper>

--- a/src/serlo-editor/plugins/geogebra/editor.tsx
+++ b/src/serlo-editor/plugins/geogebra/editor.tsx
@@ -22,7 +22,7 @@ export function GeogebraEditor(props: GeogebraProps) {
           type="applet"
           provider="GeoGebra"
           embedUrl={url}
-          className={editable && !focused ? 'pointer-events-none': ''}
+          className={editable && !focused ? 'pointer-events-none' : ''}
         >
           <GeogebraRenderer url={url} />
         </EmbedWrapper>


### PR DESCRIPTION
## Before

When content is rendered by the editor with `editable: false` the button to 'activate' the plugin appears but cannot be clicked. 

This was an issue in `serlo-editor-for-edusharing`