### PR TITLE
fix(plugin-text): merge plugins when list selected

### DIFF
--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -177,6 +177,8 @@ export function TextEditor(props: TextEditorProps) {
       // (only if selection is collapsed and suggestions are not shown)
       const { selection } = editor
       if (selection && Range.isCollapsed(selection) && !showSuggestions) {
+        const isListActive = isSelectionWithinList(editor)
+
         // Special handler for links. If you move right and end up at the right edge of a link,
         // this handler unselects the link, so you can write normal text behind it.
         if (isHotkey('right', event)) {
@@ -224,7 +226,6 @@ export function TextEditor(props: TextEditorProps) {
         }
 
         // Create a new Slate instance on "enter" key
-        const isListActive = isSelectionWithinList(editor)
         if (isHotkey('enter', event) && !isListActive) {
           const document = selectDocument(store.getState(), id)
           if (!document) return
@@ -261,7 +262,7 @@ export function TextEditor(props: TextEditorProps) {
           isHotkey('backspace', event) && isSelectionAtStart(editor, selection)
         const isDeleteAtEnd =
           isHotkey('delete', event) && isSelectionAtEnd(editor, selection)
-        if (isBackspaceAtStart || isDeleteAtEnd) {
+        if ((isBackspaceAtStart || isDeleteAtEnd) && !isListActive) {
           event.preventDefault()
 
           // Get direction of merge

--- a/src/serlo-editor/plugins/text/utils/document.ts
+++ b/src/serlo-editor/plugins/text/utils/document.ts
@@ -8,7 +8,6 @@ import {
 } from 'slate'
 
 import type { TextEditorState } from '../types'
-import { isSelectionWithinList } from './list'
 import { isSelectionAtEnd } from './selection'
 import { StateTypeValueType } from '@/serlo-editor/plugin'
 import {
@@ -65,8 +64,6 @@ export function mergePlugins(
   store: RootStore,
   id: string
 ) {
-  const isListSelected = isSelectionWithinList(editor)
-
   const mayManipulateSiblings = selectMayManipulateSiblings(
     store.getState(),
     id
@@ -123,16 +120,13 @@ export function mergePlugins(
         removePluginChild({ parent: parent.id, child: previousSibling.id })
       )
 
-      // Set selection where it was before the merge
-      // (this happens magically if a list was selected)
-      if (!isListSelected) {
-        setTimeout(() => {
-          Transforms.select(editor, {
-            offset: 0,
-            path: [previousDocumentChildrenCount, 0],
-          })
+      // Set selection to where it was before the merge
+      setTimeout(() => {
+        Transforms.select(editor, {
+          offset: 0,
+          path: [previousDocumentChildrenCount, 0],
         })
-      }
+      })
 
       // Return the merge value
       return newValue


### PR DESCRIPTION
**Bug**: When trying to merge a text plugin that has only a list, with a previous text plugin, by pressing "Backspace", an error is thrown and the editor breaks.

**Solution**: Prioritize removing list on Backspace over merging plugins, when a list is selected.