### PR TITLE
fetch new quickbar data via proxy

### DIFF
--- a/src/components/navigation/quickbar.tsx
+++ b/src/components/navigation/quickbar.tsx
@@ -218,7 +218,7 @@ export function Quickbar({ subject, className, placeholder }: QuickbarProps) {
 }
 
 export async function fetchQuickbarData(subject?: string) {
-  const req = await fetch('https://de.serlo.org/api/stats/quickbar.json')
+  const req = await fetch('/api/frontend/quickbar-data')
   const data = (await req.json()) as QuickbarData
 
   data.forEach((entry) => {

--- a/src/pages/api/frontend/quickbar-data.ts
+++ b/src/pages/api/frontend/quickbar-data.ts
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const quickbar = await fetch(
+    'https://serlo.github.io/quickbar-updater/quickbar.json'
+  )
+  res.json(await quickbar.json())
+}


### PR DESCRIPTION
caching is a bit problematic, stick with cf-worker instead: https://github.com/serlo/cloudflare-worker/pull/439