### PR TITLE
bugfix: only show deleteOwnComment when the user is allowed to

### DIFF
--- a/src/components/comments/dropdown-menu.tsx
+++ b/src/components/comments/dropdown-menu.tsx
@@ -90,7 +90,7 @@ export function DropdownMenu({
               : strings.comments.archiveThread}
           </>
         )}
-      {(canDelete || startEditing) &&
+      {(canDelete || (startEditing && !isParent)) &&
         buildButton(
           onDelete,
           <>


### PR DESCRIPTION
You are only able to delete a comment when it is an answer to another comment. But not if it is the start of a thread.