### PR TITLE
geogebra: replace iframe

### DIFF
--- a/src/components/content/geogebra.tsx
+++ b/src/components/content/geogebra.tsx
@@ -19,7 +19,7 @@ export function Geogebra({ id }: GeogebraProps) {
         embedUrl={url}
         className="print:hidden"
       >
-        <GeogebraRenderer url={url} />
+        <GeogebraRenderer url={url} id={id} />
       </PrivacyWrapper>
       <p className="serlo-p hidden print:block">[{url}]</p>
     </>

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -97,10 +97,10 @@ export function PrivacyWrapper({
 
     return (
       <div className="text-center">
-        <div className="relative bg-brand-100 pb-[56.2%]">
+        <div className="relative rounded-xl bg-brand-100 pb-[56.2%]">
           <img
             className={clsx(
-              'absolute left-0 h-full w-full object-cover',
+              'absolute left-0 h-full w-full rounded-xl object-cover',
               isTwingle ? 'opacity-50' : 'opacity-90'
             )}
             src={previewImageUrl}

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -43,6 +43,7 @@ export function PrivacyWrapper({
 
   const confirmLoad = () => {
     giveConsent(provider)
+    setConsentGiven(true)
     if (onLoad) onLoad()
     if (showIframe) return
     if (isTwingle && twingleCallback) twingleCallback()

--- a/src/components/content/privacy-wrapper.tsx
+++ b/src/components/content/privacy-wrapper.tsx
@@ -121,7 +121,10 @@ export function PrivacyWrapper({
           </div>
         )}
         <div
-          className="absolute inset-0 -top-28 flex items-center justify-around mobile:-top-12 sm:-top-24"
+          className={clsx(
+            'absolute inset-0 flex items-center justify-around',
+            consentGiven ? '' : '-top-28 mobile:-top-12 sm:-top-24'
+          )}
           onClick={confirmLoad}
         >
           <button

--- a/src/serlo-editor/plugins/geogebra/editor.tsx
+++ b/src/serlo-editor/plugins/geogebra/editor.tsx
@@ -24,7 +24,7 @@ export function GeogebraEditor(props: GeogebraProps) {
           embedUrl={url}
           className={editable && !focused ? 'pointer-events-none' : ''}
         >
-          <GeogebraRenderer url={url} />
+          <GeogebraRenderer url={url} id={cleanId} />
         </EmbedWrapper>
       ) : (
         <div className="rounded-lg bg-editor-primary-50 py-32 text-center">

--- a/src/serlo-editor/plugins/geogebra/renderer.tsx
+++ b/src/serlo-editor/plugins/geogebra/renderer.tsx
@@ -45,8 +45,8 @@ export function GeogebraRenderer({ id, url }: GeogebraRendererProps) {
       <div
         className={
           `geogebra-scaler-${id} ` +
-          tw`absolute top-0 flex h-full w-full items-center
-          justify-center overflow-hidden bg-brand-50 p-0`
+          tw`absolute top-0 flex h-full w-full items-center justify-center
+          overflow-hidden rounded-xl bg-brand-50 p-0`
         }
       >
         {url ? <div id={`ggb-element-${id}`} className="mx-auto"></div> : null}

--- a/src/serlo-editor/plugins/geogebra/renderer.tsx
+++ b/src/serlo-editor/plugins/geogebra/renderer.tsx
@@ -1,22 +1,57 @@
+import Script from 'next/script'
+
 import { tw } from '@/helper/tw'
 
 export interface GeogebraRendererProps {
+  id: string
   url: string
 }
 
-export function GeogebraRenderer({ url }: GeogebraRendererProps) {
+export function GeogebraRenderer({ id, url }: GeogebraRendererProps) {
   return (
-    <div className="block h-0 overflow-hidden p-0">
-      <iframe
-        className={tw`
-              absolute top-0 left-0 z-10 h-full
-              w-full border-none bg-black bg-opacity-30
-            `}
-        title={url}
-        scrolling="no"
-        src={url}
+    <>
+      <Script
+        src="https://www.geogebra.org/apps/deployggb.js"
+        onReady={() => {
+          // https://wiki.geogebra.org/en/Reference:GeoGebra_App_Parameters
+          const params = {
+            appName: '…',
+            showToolBar: false,
+            showAlgebraInput: false,
+            showMenuBar: false,
+            material_id: id,
+            showResetIcon: true,
+            enableLabelDrags: false,
+            enableShiftDragZoom: false,
+            enableRightClick: false,
+            capturingThreshold: null,
+            showToolBarHelp: false,
+            errorDialogsActive: true,
+            useBrowserForJS: false,
+            enableFileFeatures: false,
+            borderColor: 'transparent',
+            scaleContainerClass: `geogebra-scaler-${id}`,
+          }
+
+          if (Object.hasOwn(global, 'GGBApplet')) {
+            //@ts-expect-error no types for Geogebra script
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const applet = new window.GGBApplet(params, true)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            applet.inject(`ggb-element-${id}`)
+          }
+        }}
       />
-    </div>
+      <div
+        className={
+          `geogebra-scaler-${id} ` +
+          tw`absolute top-0 flex h-full w-full items-center
+          justify-center overflow-hidden bg-brand-50 p-0`
+        }
+      >
+        {url ? <div id={`ggb-element-${id}`} className="mx-auto"></div> : null}
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Trying out the direct route: instead of using the Iframe embedding this imports the applet directly via the script. 
Upsides: we can directly set some settings and sizing is more flexible.

example: https://frontend-git-geogebra-direct-load-serlo.vercel.app/43563

