### PR TITLE
fix(editor-toolbar): Improve z-index sorting of undo/save toolbar & text editor toolbar & tooltips & latex editor

### DIFF
--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -120,7 +120,7 @@ export function AddRevision({
         )}${id ? ` (${id})` : ''}`}</title>
       </Head>
       {renderBacklink()}
-      <div className="controls-portal sticky top-0 z-[100] bg-white" />
+      <div className="controls-portal sticky top-0 z-[90] bg-white" />
       <div className="edtr-io serlo-editor-hacks mx-auto mb-24 max-w-[816px]">
         <SerloEditor
           entityNeedsReview={entityNeedsReview}

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise-group.tsx
@@ -60,7 +60,7 @@ function TextExerciseGroupTypeEditor(
   })
 
   return (
-    <article className="exercisegroup mt-12">
+    <article className="exercisegroup mt-16">
       {props.renderIntoToolbar(
         <ContentLoaders
           id={props.state.id.value}

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
@@ -43,7 +43,7 @@ function TextExerciseTypeEditor(
   const editorStrings = useEditorStrings()
 
   return (
-    <article className="text-exercise mt-12">
+    <article className="text-exercise mt-16">
       {props.renderIntoToolbar(
         <ContentLoaders
           id={props.state.id.value}

--- a/src/serlo-editor/plugins/text/components/inline-overlay.tsx
+++ b/src/serlo-editor/plugins/text/components/inline-overlay.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div({
   left: '-10000px',
   opacity: 0,
   transition: 'opacity 0.5s',
-  zIndex: 95,
+  zIndex: 105,
   whiteSpace: 'nowrap',
 })
 


### PR DESCRIPTION
## Before
Undo/save bar overlays elements & makes them look broken. 

![Screenshot from 2023-07-10 16-26-12](https://github.com/serlo/frontend/assets/59921805/bca357b8-1331-4174-bb85-0d59cde644f5)
![Screenshot from 2023-07-10 12-58-21](https://github.com/serlo/frontend/assets/59921805/1bc43254-a21e-4cb3-b04e-2012ff2fae5b)
![Screenshot from 2023-07-10 16-31-30](https://github.com/serlo/frontend/assets/59921805/295d3b94-407d-4897-912d-baa47715c134)
![Screenshot from 2023-07-10 19-43-43](https://github.com/serlo/frontend/assets/59921805/367a3e98-691e-42d2-a2d7-406a1bf94137)

## Changes
1) More margin at the top to prevent issue 1. However, it still happens in certain scroll positions of the content. Adding a high z-index to the tooltips does not work sadly because they are constrained by the z-index of a parent. 
2) Reduce z-index of undo&save bar to move it below text toolbar & latex editor to prevent issues 2-4