### PR TITLE
RFC: use slate paragraphs and add soft breaks

### DIFF
--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -239,8 +239,10 @@ export function TextEditor(props: TextEditorProps) {
             // soft break
             event.preventDefault()
             editor.insertText('\n')
+          } else {
+            // native behaviour (adds new paragraph) but remove empty line first
+            editor.deleteBackward('character')
           }
-          // otherwise native behaviour (adds new paragraph)
 
           // TODO: test <br/> serializer somehow
           // TODO: add placeholder (with add element that can split text plugin)
@@ -484,7 +486,7 @@ export function TextEditor(props: TextEditorProps) {
         )
       }
       return (
-        <p {...attributes} className="serlo-p">
+        <p {...attributes} className="serlo-p border border-gray-200">
           {children}
         </p>
       )

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -25,11 +25,7 @@ import { useFormattingOptions } from '../hooks/use-formatting-options'
 import { useSuggestions } from '../hooks/use-suggestions'
 import { useTextConfig } from '../hooks/use-text-config'
 import { ListElementType, TextEditorConfig, TextEditorState } from '../types'
-import {
-  emptyDocumentFactory,
-  mergePlugins,
-  sliceNodesAfterSelection,
-} from '../utils/document'
+import { mergePlugins, sliceNodesAfterSelection } from '../utils/document'
 import { isSelectionWithinList } from '../utils/list'
 import { isSelectionAtEnd, isSelectionAtStart } from '../utils/selection'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
@@ -227,6 +223,14 @@ export function TextEditor(props: TextEditorProps) {
         }
 
         // Create a new Slate instance on "enter" key
+        if (isHotkey(['enter', 'shift+enter'], event) && !isListActive) {
+          event.preventDefault()
+          editor.insertText('\n')
+          // TODO: handle in de/serializer (convert to br)
+          // TODO: add placeholder
+          // TODO: check if last line was empty. if yes, add p
+        }
+        /*
         if (isHotkey('enter', event) && !isListActive) {
           const document = selectDocument(store.getState(), id)
           if (!document) return
@@ -256,6 +260,7 @@ export function TextEditor(props: TextEditorProps) {
             )
           })
         }
+        */
 
         // Merge with previous Slate instance on "backspace" key,
         // or merge with next Slate instance on "delete" key
@@ -461,7 +466,11 @@ export function TextEditor(props: TextEditorProps) {
           </MathElement>
         )
       }
-      return <div {...attributes}>{children}</div>
+      return (
+        <p {...attributes} className="serlo-p">
+          {children}
+        </p>
+      )
     },
     [focused]
   )

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -111,7 +111,9 @@ export function TextEditor(props: TextEditorProps) {
 
     // If the first child of the editor is not a paragraph, do nothing
     const isFirstChildParagraph =
-      'type' in editor.children[0] && editor.children[0].type === 'p'
+      editor.children[0] &&
+      'type' in editor.children[0] &&
+      editor.children[0].type === 'p'
     if (!isFirstChildParagraph) return
 
     // If the editor is empty, set the cursor at the start
@@ -242,7 +244,8 @@ export function TextEditor(props: TextEditorProps) {
 
           // TODO: test <br/> serializer somehow
           // TODO: add placeholder (with add element that can split text plugin)
-          // TODO: think about what should happen when some text is selected
+
+          // TODO: think about what should happen when some text is selected (no blocker)
         }
         /*
         if (isHotkey('enter', event) && !isListActive) {

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -222,13 +222,27 @@ export function TextEditor(props: TextEditorProps) {
           }
         }
 
-        // Create a new Slate instance on "enter" key
+        // Use soft break when last line in not empty
         if (isHotkey(['enter', 'shift+enter'], event) && !isListActive) {
-          event.preventDefault()
-          editor.insertText('\n')
-          // TODO: handle in de/serializer (convert to br)
-          // TODO: add placeholder
-          // TODO: check if last line was empty. if yes, add p
+          const { path, offset } = selection.focus
+          const node = Node.get(editor, path)
+
+          const previousLines =
+            Object.hasOwn(node, 'text') &&
+            node.text.substring(0, offset).split('\n')
+          if (
+            !previousLines ||
+            previousLines[previousLines.length - 1].length !== 0
+          ) {
+            // soft break
+            event.preventDefault()
+            editor.insertText('\n')
+          }
+          // otherwise native behaviour (adds new paragraph)
+
+          // TODO: test <br/> serializer somehow
+          // TODO: add placeholder (with add element that can split text plugin)
+          // TODO: think about what should happen when some text is selected
         }
         /*
         if (isHotkey('enter', event) && !isListActive) {

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -529,7 +529,13 @@ export function TextEditor(props: TextEditorProps) {
                     contentEditable={false}
                   >
                     {config.placeholder ?? pluginStrings.text.placeholder}{' '}
-                    <button className="z-80 serlo-button-editor-secondary serlo-tooltip-trigger pointer-events-auto h-8 w-8">
+                    <button
+                      className="z-80 serlo-button-editor-secondary serlo-tooltip-trigger pointer-events-auto h-8 w-8"
+                      onClick={() => {
+                        editor.insertText('/')
+                        // TODO: focus somehow so the suggestions actually show…
+                      }}
+                    >
                       <EditorTooltip
                         text="Neuen Block einfügen"
                         hotkeys="/"

--- a/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
@@ -150,9 +150,7 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
       return
     }
 
-    // Otherwise, replace the text plugin with the selected plugin
-    // TODO: we want to replace only one paragraph not the whole plugin now
-    // that means we need to split the text-plugin here
+    // split the text-plugin and insert new plugin
 
     const storeState = store.getState() as unknown
 


### PR DESCRIPTION
I think this is the way we should have used paragraphs in slate in the first place ;) 
Not sure if changing this now makes sense, but I think the approach is cleaner.

Before: 
- We render the native slate paragraphs as `div` without margin and therefore basically use it as a line-container
- `shift+enter` triggers slate behaviour:p new Paragraph that gets displayed as new line.
- `enter` we create a new text-plugin after the current one

This PR:
- native slate paragraphs are rendered as `<p class="serlo-p">…` with proper spacing etc.
- `shift+enter` and `enter`:
   - if the current line is empty: new paragraph (basically pressing enter twice)
   - if it is not empty: soft break using `\n`
- `\n` should get serialized as `<br/>` (needs testing)
This way people can create Paragraphs (semantically and visually correct) and new lines without knowing about the difference between `enter` and `shift+enter`.

