### PR TITLE
Make quickbar render on top of save button

### DIFF
--- a/src/components/navigation/quickbar.tsx
+++ b/src/components/navigation/quickbar.tsx
@@ -167,7 +167,7 @@ export function Quickbar({ subject, className, placeholder }: QuickbarProps) {
         ref={overlayWrapper}
         className={clsx(
           tw`
-            absolute left-side right-side z-20 ml-2 mt-2
+            absolute left-side right-side z-[100] ml-2 mt-2
             max-w-2xl rounded-xl border bg-white px-5 pb-2 shadow
           `,
           open ? '' : 'hidden'


### PR DESCRIPTION
Instead of defining a z-index of 100 as I did here :zany_face: I'd like to know why the bar with the save button and undo/redo has such a high z-index. Inside the add-revision.tsx: `controls-portal sticky z-[90]`

**Before**

![Screenshot from 2023-07-17 01-13-00](https://github.com/serlo/frontend/assets/28842311/a73938b5-71e6-48ed-84e0-e502451025c2)

**After**

![image](https://github.com/serlo/frontend/assets/28842311/b9c5d8ea-3a42-4d53-839b-9e6530b56587)
