### PR TITLE
Fix equations editor unnecessary rerender

### DIFF
--- a/src/serlo-editor/editor-ui/document-editor.tsx
+++ b/src/serlo-editor/editor-ui/document-editor.tsx
@@ -24,7 +24,7 @@ export interface DocumentEditorProps {
   focused: boolean // `true` if the document is focused
 }
 
-// @TODO Rename this to `PluginSettings` or something similar after moving the toolbar out of it.
+// TODO: Rename this to `PluginSettings` or something similar after moving the toolbar out of it.
 export function DocumentEditor({
   focused,
   children,

--- a/src/serlo-editor/plugins/equations/editor.tsx
+++ b/src/serlo-editor/plugins/equations/editor.tsx
@@ -53,7 +53,6 @@ export function EquationsEditor(props: EquationsProps) {
   const { focused, state } = props
 
   const dispatch = useAppDispatch()
-  const focusTree = useAppSelector(selectFocusTree)
   const focusedElement = useAppSelector(selectFocused)
   const nestedFocus =
     focused ||
@@ -70,8 +69,14 @@ export function EquationsEditor(props: EquationsProps) {
   const gridFocus = useGridFocus({
     rows: state.steps.length,
     columns: 4,
-    focusNext: () => dispatch(focusNext(focusTree)),
-    focusPrevious: () => dispatch(focusPrevious(focusTree)),
+    focusNext: () => {
+      const focusTree = selectFocusTree(store.getState())
+      dispatch(focusNext(focusTree))
+    },
+    focusPrevious: () => {
+      const focusTree = selectFocusTree(store.getState())
+      dispatch(focusPrevious(focusTree))
+    },
     transformationTarget,
     onFocusChanged: (state) => {
       if (state === 'firstExplanation') {


### PR DESCRIPTION
Just two small fixes: 
1. Equations editor no longer rerenders when focus tree changes. Instead focus tree is obtained only when needed. 
2. Change `@TODO` to `TODO:` so that eslint catches it