### PR TITLE
Remove problematic page with id "49982" from SSG

### DIFF
--- a/src/data/de/menu-data.ts
+++ b/src/data/de/menu-data.ts
@@ -221,11 +221,11 @@ export const secondaryMenus: InstanceData['secondaryMenus'] = [
         id: 75274,
       },
       { title: 'Gymnasium', url: '/informatik/60396/gymnasium', id: 60396 },
-      {
-        title: 'Bei Serlo-Informatik mitarbeiten',
-        url: '/49982/mitmachen-in-informatik',
-        id: 49982,
-      },
+      // {
+      // title: 'Bei Serlo-Informatik mitarbeiten',
+      // url: '/49982/mitmachen-in-informatik',
+      // id: 49982,
+      // },
     ],
   },
   {


### PR DESCRIPTION
This page is cursed, having a Unicode character (ellipsis … unicode U+2026) that crashes the database layer or api (when reading from Redis). Will probably need to write a proper migration for it :crying_cat_face: 

By commenting out the lines, at least the frontend gets to build and we can continue developing and testing until we find a proper fix for it :shrug:  