### PR TITLE
Add data-qa attributes

### DIFF
--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
@@ -37,7 +37,7 @@ export function AnchorLinkCopyTool({ pluginId }: AnchorLinkCopyToolProps) {
       }}
       label={editorStrings.plugins.rows.copyAnchorLink}
       icon={faHashtag}
-      className="mt-2.5 border-t pt-2.5"
+      className="qa-copy-anchor-link-button mt-2.5 border-t pt-2.5"
     />
   )
 }

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
@@ -37,7 +37,8 @@ export function AnchorLinkCopyTool({ pluginId }: AnchorLinkCopyToolProps) {
       }}
       label={editorStrings.plugins.rows.copyAnchorLink}
       icon={faHashtag}
-      className="qa-copy-anchor-link-button mt-2.5 border-t pt-2.5"
+      className="mt-2.5 border-t pt-2.5"
+      dataQa="copy-anchor-link-button"
     />
   )
 }

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/dropdown-button.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/dropdown-button.tsx
@@ -8,6 +8,7 @@ interface DropdownButtonProps {
   label: string
   icon: IconDefinition
   className?: string
+  dataQa?: string
 }
 
 export function DropdownButton({
@@ -15,11 +16,13 @@ export function DropdownButton({
   label,
   icon,
   className,
+  dataQa,
 }: DropdownButtonProps) {
   return (
     <button
       className={clsx('group/button w-full px-3 text-left', className)}
       onClick={onClick}
+      data-qa={dataQa}
     >
       <span className="serlo-button-editor-secondary w-fit rounded-xl bg-transparent text-sm group-hover/button:bg-editor-primary-200">
         <FaIcon icon={icon} /> {label}

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -78,11 +78,13 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         onClick={handleDuplicatePlugin}
         label={pluginStrings.rows.duplicate}
         icon={faClone}
+        className="qa-duplicate-plugin-button"
       />
       <DropdownButton
         onClick={handleRemovePlugin}
         label={pluginStrings.rows.remove}
         icon={faTrashAlt}
+        className="qa-remove-plugin-button"
       />
       <AnchorLinkCopyTool pluginId={pluginId} />
     </>

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -78,13 +78,13 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         onClick={handleDuplicatePlugin}
         label={pluginStrings.rows.duplicate}
         icon={faClone}
-        className="qa-duplicate-plugin-button"
+        dataQa="duplicate-plugin-button"
       />
       <DropdownButton
         onClick={handleRemovePlugin}
         label={pluginStrings.rows.remove}
         icon={faTrashAlt}
-        className="qa-remove-plugin-button"
+        dataQa="remove-plugin-button"
       />
       <AnchorLinkCopyTool pluginId={pluginId} />
     </>

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
@@ -255,7 +255,7 @@ function createToolbarControls(
         isActive: isHeadingActive(level),
         onClick: toggleHeading(level),
         renderIcon: () => (
-          <span className={`qa-plugin-toolbar-heading-${level}`}>H{level}</span>
+          <span data-qa={`plugin-toolbar-heading-${level}`}>H{level}</span>
         ),
       })),
     },

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
@@ -249,12 +249,14 @@ function createToolbarControls(
       isActive: isAnyHeadingActive,
       renderIcon: () => <EdtrIcon icon={edtrText} />,
       renderCloseMenuIcon: () => <EdtrIcon icon={edtrClose} />,
-      children: ([1, 2, 3] as const).map((level) => ({
+      subMenuButtons: ([1, 2, 3] as const).map((level) => ({
         name: TextEditorFormattingOption.headings,
         title: `${textStrings.heading} ${level}`,
         isActive: isHeadingActive(level),
         onClick: toggleHeading(level),
-        renderIcon: () => <span>H{level}</span>,
+        renderIcon: () => (
+          <span className={`qa-plugin-toolbar-heading-${level}`}>H{level}</span>
+        ),
       })),
     },
     // Colors
@@ -269,7 +271,7 @@ function createToolbarControls(
         return <ColorTextIcon color={color} />
       },
       renderCloseMenuIcon: () => <EdtrIcon icon={edtrClose} />,
-      children: [
+      subMenuButtons: [
         {
           name: TextEditorFormattingOption.colors,
           title: textStrings.resetColor,

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-control-button.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-control-button.tsx
@@ -16,7 +16,10 @@ export function PluginToolbarTextControlButton({
   tooltipText,
   onMouseDown,
 }: PluginToolbarTextControlButtonProps) {
-  const textParts = tooltipText?.split('(')
+  const [text, hotkeyWithClosingBracket] = tooltipText?.split('(') || [
+    undefined,
+    undefined,
+  ]
 
   return (
     <button
@@ -25,13 +28,16 @@ export function PluginToolbarTextControlButton({
           ? 'bg-editor-primary-200 text-almost-black shadow-menu hover:text-black'
           : '#b6b6b6 hover:text-editor-primary',
         'b-0 m-1 h-6 w-6 cursor-pointer rounded p-0 outline-none',
-        'serlo-tooltip-trigger'
+        'serlo-tooltip-trigger',
+        `qa-plugin-toolbar-button-${
+          text ? text.toLowerCase().trim().replace(/ /g, '-') : ''
+        }`
       )}
       onMouseDown={onMouseDown}
     >
       <EditorTooltip
-        text={textParts?.[0]}
-        hotkeys={textParts?.[1]?.slice(0, -1)}
+        text={text}
+        hotkeys={hotkeyWithClosingBracket?.slice(0, -1)}
       />
       {children}
     </button>

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-control-button.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-control-button.tsx
@@ -28,11 +28,11 @@ export function PluginToolbarTextControlButton({
           ? 'bg-editor-primary-200 text-almost-black shadow-menu hover:text-black'
           : '#b6b6b6 hover:text-editor-primary',
         'b-0 m-1 h-6 w-6 cursor-pointer rounded p-0 outline-none',
-        'serlo-tooltip-trigger',
-        `qa-plugin-toolbar-button-${
-          text ? text.toLowerCase().trim().replace(/ /g, '-') : ''
-        }`
+        'serlo-tooltip-trigger'
       )}
+      data-qa={`plugin-toolbar-button-${
+        text ? text.toLowerCase().trim().replace(/ /g, '-') : ''
+      }`}
       onMouseDown={onMouseDown}
     >
       <EditorTooltip

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-controls.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-controls.tsx
@@ -12,7 +12,7 @@ export interface PluginToolbarTextControlsProps {
 function isNestedControlButton(
   control: ControlButton
 ): control is NestedControlButton {
-  return Object.hasOwn(control, 'children')
+  return Object.hasOwn(control, 'subMenuButtons')
 }
 
 export function PluginToolbarTextControls({
@@ -68,7 +68,7 @@ export function PluginToolbarTextControls({
     },
     title: activeControl.closeMenuTitle,
   }
-  const subMenuControls = [...activeControl.children, closeSubMenuControl]
+  const subMenuControls = [...activeControl.subMenuButtons, closeSubMenuControl]
 
   return (
     <>

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/types.ts
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/types.ts
@@ -25,7 +25,7 @@ interface ActionControlButton {
 export interface NestedControlButton {
   title: string
   closeMenuTitle: string
-  children: ActionControlButton[]
+  subMenuButtons: ActionControlButton[]
   isActive(editor: SlateEditor): boolean
   renderIcon(editor: SlateEditor): React.ReactNode
   renderCloseMenuIcon(): React.ReactNode

--- a/src/serlo-editor/plugins/rows/components/add-row-button.tsx
+++ b/src/serlo-editor/plugins/rows/components/add-row-button.tsx
@@ -21,7 +21,7 @@ export function AddRowButton({
   if (visuallyEmphasized)
     return (
       <button
-        className="serlo-button-editor-secondary"
+        className="qa-add-new-plugin-row-button serlo-button-editor-secondary"
         onClick={onClick}
         title={rowsStrings.addAnElement}
       >
@@ -39,7 +39,8 @@ export function AddRowButton({
           hover:cursor-pointer hover:text-editor-primary hover:opacity-100
           group-hover:opacity-60
           `,
-          focused ? 'opacity-60' : 'opacity-0'
+          focused ? 'opacity-60' : 'opacity-0',
+          'qa-add-new-plugin-row-button'
         )}
         title={rowsStrings.addAnElement}
         onClick={onClick}

--- a/src/serlo-editor/plugins/rows/components/add-row-button.tsx
+++ b/src/serlo-editor/plugins/rows/components/add-row-button.tsx
@@ -21,7 +21,8 @@ export function AddRowButton({
   if (visuallyEmphasized)
     return (
       <button
-        className="qa-add-new-plugin-row-button serlo-button-editor-secondary"
+        className="serlo-button-editor-secondary"
+        data-qa="add-new-plugin-row-button"
         onClick={onClick}
         title={rowsStrings.addAnElement}
       >
@@ -39,11 +40,11 @@ export function AddRowButton({
           hover:cursor-pointer hover:text-editor-primary hover:opacity-100
           group-hover:opacity-60
           `,
-          focused ? 'opacity-60' : 'opacity-0',
-          'qa-add-new-plugin-row-button'
+          focused ? 'opacity-60' : 'opacity-0'
         )}
         title={rowsStrings.addAnElement}
         onClick={onClick}
+        data-qa="add-new-plugin-row-button"
       >
         <FaIcon icon={faCirclePlus} className="text-xl" />
       </button>

--- a/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
+++ b/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
@@ -24,7 +24,8 @@ export function EditModeResultEntry({
       className={clsx(
         'serlo-link flex cursor-pointer bg-white px-side py-2',
         index === selectedIndex && 'bg-editor-primary-100 group-hover:bg-white',
-        'hover:!bg-editor-primary-100 hover:!no-underline'
+        'hover:!bg-editor-primary-100 hover:!no-underline',
+        `qa-link-suggestion-${index}`
       )}
       onClick={() => {
         chooseEntry(index)

--- a/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
+++ b/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
@@ -24,9 +24,9 @@ export function EditModeResultEntry({
       className={clsx(
         'serlo-link flex cursor-pointer bg-white px-side py-2',
         index === selectedIndex && 'bg-editor-primary-100 group-hover:bg-white',
-        'hover:!bg-editor-primary-100 hover:!no-underline',
-        `qa-link-suggestion-${index}`
+        'hover:!bg-editor-primary-100 hover:!no-underline'
       )}
+      data-qa={`link-suggestion-${index}`}
       onClick={() => {
         chooseEntry(index)
       }}

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -426,7 +426,8 @@ export function TextEditor(props: TextEditorProps) {
               <TextLeafRenderer {...props} />
             </span>
           )}
-          className="qa-plugin:text-editor [&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
+          className="[&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
+          data-qa="plugin-text-editor"
         />
         {editable && focused && (
           <LinkControls

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -426,7 +426,7 @@ export function TextEditor(props: TextEditorProps) {
               <TextLeafRenderer {...props} />
             </span>
           )}
-          className="[&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
+          className="qa-plugin:text-editor [&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
         />
         {editable && focused && (
           <LinkControls


### PR DESCRIPTION
Small changes to the frontend as discussed with Botho and outlined here https://github.com/serlo/documentation/wiki/Best-Practices#testing-1 to add qa classNames to certain elements that we are clicking on in the serlo-editor tests. 

Depends on https://github.com/serlo/frontend-e2e-tests/pull/54. Please merge both at the same time, or we'll have some failing tests. 