### PR TITLE
Fix/arrow keys in link suggestion overlay

### DIFF
--- a/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
+++ b/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
@@ -24,7 +24,7 @@ export function EditModeResultEntry({
       className={clsx(
         'serlo-link flex cursor-pointer bg-white px-side py-2',
         'hover:!bg-editor-primary-100 hover:!no-underline',
-        index === selectedIndex && 'bg-editor-primary-100'
+        index === selectedIndex && '!bg-editor-primary-100'
       )}
       onClick={() => {
         chooseEntry(index)

--- a/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
+++ b/src/serlo-editor/plugins/text/components/link/edit-mode/edit-mode-result-entry.tsx
@@ -23,8 +23,8 @@ export function EditModeResultEntry({
       key={index}
       className={clsx(
         'serlo-link flex cursor-pointer bg-white px-side py-2',
-        index === selectedIndex && 'bg-editor-primary-100 group-hover:bg-white',
-        'hover:!bg-editor-primary-100 hover:!no-underline'
+        'hover:!bg-editor-primary-100 hover:!no-underline',
+        index === selectedIndex && 'bg-editor-primary-100'
       )}
       onClick={() => {
         chooseEntry(index)

--- a/src/serlo-editor/plugins/text/components/link/edit-mode/link-overlay-edit-mode.tsx
+++ b/src/serlo-editor/plugins/text/components/link/edit-mode/link-overlay-edit-mode.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { useEffect, useState, KeyboardEvent } from 'react'
+import { useHotkeysContext } from 'react-hotkeys-hook'
 
 import { EditModeInput } from './edit-mode-input'
 import { EditModeResultEntry } from './edit-mode-result-entry'
@@ -36,12 +37,18 @@ export function LinkOverlayEditMode({
     setQuery(value)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value])
+  const { enableScope, disableScope } = useHotkeysContext()
 
   useEffect(() => {
     if (serloLinkSearch) setSelectedIndex(0)
   }, [query, quickbarData, value, serloLinkSearch])
 
   const results = quickbarData ? findResults(quickbarData, query) : []
+  useEffect(() => {
+    disableScope('root-up-down-enter')
+
+    return () => enableScope('root-up-down-enter')
+  }, [enableScope, disableScope])
 
   function chooseEntry(index?: number) {
     const activeIndex = index ?? selectedIndex


### PR DESCRIPTION
Fixes https://github.com/serlo/frontend/issues/2670 

There were actually two small issues. I broke it by not disabling the global arrow keys (thinking of finding a better solution for this), but also: the highlighting didn't work with the arrow keys, making it seem like nothing is selected.  

I also want to add an e2e test for this. 