### PR TITLE
fix(editor): huge amount of `HoverOverlay` re-renders

### DIFF
--- a/src/serlo-editor/editor-ui/hover-overlay.tsx
+++ b/src/serlo-editor/editor-ui/hover-overlay.tsx
@@ -16,21 +16,6 @@ export function HoverOverlay(props: HoverOverlayProps) {
 
   const windowSelection = window.getSelection()
 
-  const [nativeSelection, setNativeSelection] = useState({
-    anchorOffset: windowSelection?.anchorOffset,
-    focusNode: windowSelection?.focusNode,
-  })
-  const handleSelectionChange = () => {
-    setNativeSelection({
-      anchorOffset: windowSelection?.anchorOffset,
-      focusNode: windowSelection?.focusNode,
-    })
-  }
-  document.addEventListener('selectionchange', handleSelectionChange)
-  useEffect(() => () => {
-    document.removeEventListener('selectionchange', handleSelectionChange)
-  })
-
   const { anchor, children } = props
 
   useEffect(() => {
@@ -68,14 +53,7 @@ export function HoverOverlay(props: HoverOverlayProps) {
       ),
       0
     )}px`
-  }, [
-    overlay,
-    anchor,
-    positionAbove,
-    nativeSelection.focusNode,
-    nativeSelection.anchorOffset,
-    windowSelection,
-  ])
+  }, [overlay, anchor, positionAbove, windowSelection])
 
   return (
     <div


### PR DESCRIPTION
First win of React strict mode: we got a warning about a huge amount of re-renders of the `HoverOverlay` component!

It happened when opening the suggestions overlay, and then typing a bit, like first typing "Text", but then backspacing and typing "Multimedia" instead. With each keystroke, the amount of re-renders would exponentially increase, creating very obvious performance issues.

The removed code was my quick fix for a link settings overlay positioning issue. However, probably due to all the refactors done by @elbotho , we no longer have any positioning issues that require the code removed in this PR.