### PR TITLE
Check that ref and latex function exist

### DIFF
--- a/src/serlo-editor/math/visual-editor.tsx
+++ b/src/serlo-editor/math/visual-editor.tsx
@@ -91,8 +91,11 @@ export function VisualEditor(props: VisualEditorProps) {
   return (
     <MQ.EditableMathField
       latex={props.state}
-      onChange={(ref) => {
-        props.onChange(ref.latex())
+      onChange={(mathFieldRef) => {
+        // Should always be defined after first render cycle!
+        if (mathFieldRef?.latex) {
+          props.onChange(mathFieldRef.latex())
+        }
       }}
       onCopy={(event: React.ClipboardEvent) => {
         event.stopPropagation()


### PR DESCRIPTION
Fixes #2691 rendering the equations inside the visual editor

I don't think this is caused by us, but by the library itself. https://github.com/viktorstrate/react-mathquill/blob/8cf664f1023d4afa7a7f785c2919befdf0b1cc00/src/EditableMathField.js#L54 here the function gets written, but if their ref is not yet attached to the DOM node, it can be undefined. I don't know how this can happen, because the effect should run after the ref is attached to the DOM.
If the library was written in TypeScript, we probably would have caught it at compile time. :crying_cat_face: 

I just saw that we're actually using https://github.com/Entkenntnis/tmp-react-mathquill, but the underlying code of mathquill probably looks similar.  