### PR TITLE
fix(plugin-text): avoid TextEditor re-render when Slate re-renders

### DIFF
--- a/src/serlo-editor/plugins/text/README.md
+++ b/src/serlo-editor/plugins/text/README.md
@@ -11,7 +11,6 @@
     - [Text formatting options](#text-formatting-options)
     - [Suggestions (`serlo-editor` plugins)](#suggestions-serlo-editor-plugins)
     - [Saving state to `Redux` store](#saving-state-to-redux-store)
-      - [`LinkControls` workaround](#linkcontrols-workaround)
 
 ## Usage
 
@@ -76,10 +75,3 @@ In order to enable global undo/redo behavior (TODO: and maybe other things?), an
 If a portion of the content is selected and then replaced with some text, undo will restore the replaced content and the selection. Slate `Editor`'s `value` prop is used only as an initial value and changing the bound value will not result in a rerender. Therefore, we have to manually assign the value to `editor.children` ([as recommended by the Slate team](https://github.com/ianstormtaylor/slate/releases/tag/slate-react%400.67.0)).
 
 Simple selection changes are not saved to the store, because we don't want to undo pure selection changes.
-
-#### `LinkControls` workaround
-
-The `LinkControls` component should only be shown if the selection is currently on a link inline. But, since we don't save pure selection changes to the store, `LinkControls` doesn't rerender on selection changes. To work around this problem, a simple `useState` hook is used:
-
-1. `hasSelectionChanged` is passed to `LinkControls`, where it's used a dependency in a `useEffect` hook which takes care of showing `LinkControls`
-2. `setHasSelectionChanged` is called whenever selection changes, which increments `hasSelectionChanged` and makes sure `LinkControls` visibility will be updated

--- a/src/serlo-editor/plugins/text/components/link/link-controls.tsx
+++ b/src/serlo-editor/plugins/text/components/link/link-controls.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Editor as SlateEditor, Range, Transforms } from 'slate'
-import { ReactEditor } from 'slate-react'
+import { Range, Transforms } from 'slate'
+import { ReactEditor, useSlate } from 'slate-react'
 
 import { LinkOverlayEditMode } from './edit-mode/link-overlay-edit-mode'
 import { LinkOverlay } from './link-overlay'
@@ -16,21 +16,16 @@ import {
 } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/link'
 
 interface LinkControlsProps {
-  isSelectionChanged: number
-  editor: SlateEditor
   serloLinkSearch: boolean
 }
 
-export function LinkControls({
-  isSelectionChanged,
-  editor,
-  serloLinkSearch,
-}: LinkControlsProps) {
+export function LinkControls({ serloLinkSearch }: LinkControlsProps) {
   const [element, setElement] = useState<Link | null>(null)
   const [value, setValue] = useState('')
   const [isEditMode, setIsEditMode] = useState(value.length === 0)
   const [quickbarData, setQuickbarData] = useState<QuickbarData | null>(null)
 
+  const editor = useSlate()
   const { selection } = editor
 
   useEffect(() => {
@@ -45,7 +40,7 @@ export function LinkControls({
     } else {
       setElement(null)
     }
-  }, [isSelectionChanged, selection, editor])
+  }, [selection, editor])
 
   useEffect(() => {
     if (!serloLinkSearch) return

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -1,5 +1,5 @@
 import isHotkey from 'is-hotkey'
-import React, { useMemo, useState, useEffect, useCallback } from 'react'
+import React, { useMemo, useEffect, useCallback } from 'react'
 import { createEditor, Node, Transforms, Range } from 'slate'
 import { Editable, ReactEditor, Slate, withReact } from 'slate-react'
 
@@ -48,7 +48,6 @@ export type TextEditorProps = EditorPluginProps<
 export function TextEditor(props: TextEditorProps) {
   const { state, id, editable, focused, containerRef } = props
 
-  const [isSelectionChanged, setIsSelectionChanged] = useState(0)
   const dispatch = useAppDispatch()
 
   const textStrings = useEditorStrings().plugins.text
@@ -69,7 +68,6 @@ export function TextEditor(props: TextEditorProps) {
   const { previousSelection, handleEditorChange } = useEditorChange({
     editor,
     state,
-    onChange: setIsSelectionChanged,
   })
 
   // Workaround for setting selection when adding a new editor:
@@ -384,49 +382,40 @@ export function TextEditor(props: TextEditorProps) {
   )
 
   return (
-    <>
+    <Slate
+      editor={editor}
+      value={state.value.value}
+      onChange={handleEditorChange}
+    >
       {focused && (
         <TextToolbar
           id={id}
           toolbarControls={toolbarControls}
-          editor={editor}
           config={config}
           containerRef={containerRef}
         />
       )}
-      <Slate
-        editor={editor}
-        value={state.value.value}
-        onChange={handleEditorChange}
-      >
-        <Editable
-          readOnly={!editable}
-          placeholder={config.placeholder ?? textStrings.placeholder}
-          onKeyDown={handleEditableKeyDown}
-          onPaste={handleEditablePaste}
-          renderElement={handleRenderElement}
-          renderLeaf={(props) => (
-            <span {...props.attributes}>
-              <TextLeafRenderer {...props} />
-            </span>
-          )}
-          className="[&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
-          data-qa="plugin-text-editor"
-        />
-        {editable && focused && (
-          <LinkControls
-            isSelectionChanged={isSelectionChanged}
-            editor={editor}
-            serloLinkSearch={config.serloLinkSearch}
-          />
+      <Editable
+        readOnly={!editable}
+        placeholder={config.placeholder ?? textStrings.placeholder}
+        onKeyDown={handleEditableKeyDown}
+        onPaste={handleEditablePaste}
+        renderElement={handleRenderElement}
+        renderLeaf={(props) => (
+          <span {...props.attributes}>
+            <TextLeafRenderer {...props} />
+          </span>
         )}
-      </Slate>
+        className="[&>[data-slate-node]]:mx-side [&_[data-slate-placeholder]]:top-0" // fixes placeholder position in safari
+        data-qa="plugin-text-editor"
+      />
+      <LinkControls serloLinkSearch={config.serloLinkSearch} />
 
       {showSuggestions && (
         <HoverOverlay position="below">
           <Suggestions {...suggestionsProps} />
         </HoverOverlay>
       )}
-    </>
+    </Slate>
   )
 }

--- a/src/serlo-editor/plugins/text/components/text-toolbar.tsx
+++ b/src/serlo-editor/plugins/text/components/text-toolbar.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { Editor as SlateEditor } from 'slate'
+import { useSlate } from 'slate-react'
 
 import { TextEditorConfig } from '../types'
 import { PluginToolbar } from '@/serlo-editor/editor-ui/plugin-toolbar'
@@ -11,7 +11,6 @@ import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin
 interface TextToolbarProps {
   id: string
   toolbarControls: ControlButton[]
-  editor: SlateEditor
   config: TextEditorConfig
   containerRef?: React.RefObject<HTMLDivElement> // The rendered toolbar buttons
 }
@@ -19,10 +18,11 @@ interface TextToolbarProps {
 export function TextToolbar({
   id,
   toolbarControls,
-  editor,
   config,
   containerRef,
 }: TextToolbarProps) {
+  const editor = useSlate()
+
   if (config.isInlineChildEditor) {
     if (!containerRef || !containerRef.current) return null
     const target = containerRef.current

--- a/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { Descendant, Editor, Transforms } from 'slate'
 
 import { TextEditorProps } from '../components/text-editor'
@@ -6,11 +6,10 @@ import { TextEditorProps } from '../components/text-editor'
 interface UseEditorChangeArgs {
   editor: Editor
   state: TextEditorProps['state']
-  onChange: Dispatch<SetStateAction<number>>
 }
 
 export const useEditorChange = (args: UseEditorChangeArgs) => {
-  const { editor, state, onChange } = args
+  const { editor, state } = args
 
   const previousValue = useRef(state.value.value)
   const previousSelection = useRef(state.value.selection)
@@ -41,10 +40,9 @@ export const useEditorChange = (args: UseEditorChangeArgs) => {
           ({ value }) => ({ value, selection: previousSelection.current })
         )
       }
-      onChange((count: number) => count + 1)
       previousSelection.current = editor.selection
     },
-    [editor.operations, editor.selection, state, onChange]
+    [editor.operations, editor.selection, state]
   )
 
   return {


### PR DESCRIPTION
Please see the removed README section for why a workaround was implemented.

When working on https://github.com/serlo/frontend/pull/2695, I got inspired again to try and find a better solution for that problem.
Turns out that we can use `useSlate` hook in all `Slate` component's children safely*, and avoid passing down the `editor` object as props. This way the `LinkControls` component renders based on `Slate` renders, meaning that we can remove the `isSelectionChanged` workaround, which forces the `TextEditor` component to render when its `Slate` child renders. 

End result: less code and less renders.

\* The `useSlate` hook uses React Context, so it will use the nearest Context Provider, which will always be its parent `Slate`'s context.