### PR TITLE
Close math editor through ESC and new button

### DIFF
--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -875,6 +875,7 @@ export const loggedInData = {
             eG: 'e.g.',
             functions: 'Functions',
             displayAsBlock: 'Display as block',
+            closeMathFormulaEditor: "Close math formula editor",
           },
         },
         video: {

--- a/src/serlo-editor/editor-ui/editor-textarea.tsx
+++ b/src/serlo-editor/editor-ui/editor-textarea.tsx
@@ -5,13 +5,14 @@ type EditorTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   onMoveOutRight?(): void
   onMoveOutLeft?(): void
   className?: string
+  dataQa?: string
 }
 
 export const EditorTextarea = forwardRef<
   HTMLTextAreaElement,
   EditorTextareaProps
 >(function EditorTextarea(
-  { onMoveOutLeft, onMoveOutRight, className, ...props },
+  { onMoveOutLeft, onMoveOutRight, className, dataQa, ...props },
   ref
 ) {
   return (
@@ -22,6 +23,7 @@ export const EditorTextarea = forwardRef<
       )}
       {...props}
       ref={ref}
+      data-qa={dataQa}
       onKeyDown={(e) => {
         if (!ref || typeof ref === 'function' || !ref.current) return
 

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -97,7 +97,6 @@ export function MathEditor(props: MathEditorProps) {
     Key.Escape,
     (event) => {
       event.preventDefault()
-      // close overlay
       props.closeMathEditorOverlay()
     },
     {
@@ -297,7 +296,7 @@ export function MathEditor(props: MathEditorProps) {
             {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
           </p>
           <button
-            onClick={() => props.closeMathEditorOverlay()}
+            onClick={props.closeMathEditorOverlay}
             className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
             aria-label="Close math formula editor"
             data-qa="plugin-math-close-formula-editor"

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -51,7 +51,7 @@ const MathEditorTextArea = (props: MathEditorTextAreaProps) => {
   return (
     <EditorTextarea
       className={tw`
-        !m-0.5 h-24 !w-[80vw] !max-w-[600px] rounded-md !border-2
+        mx-0 my-1 h-24 !w-[80vw] !max-w-[600px] rounded-md !border-2
         border-transparent text-black !shadow-none focus:border-editor-primary
       `}
       onChange={parentOnChange}

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -1,5 +1,5 @@
 import { faCheckCircle, faCircle } from '@fortawesome/free-regular-svg-icons'
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import { faQuestionCircle, faXmark } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { useState, useCallback, createRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
@@ -77,8 +77,8 @@ export interface MathEditorProps {
   onEditorChange(visual: boolean): void
   onInlineChange?(inline: boolean): void
   onChange(state: string): void
-
-  onMoveOutRight: (options?: { closeThroughModal?: boolean }) => void
+  closeMathEditorOverlay: () => void
+  onMoveOutRight: () => void
   onMoveOutLeft(): void
   onDeleteOutRight?(): void
   onDeleteOutLeft?(): void
@@ -98,7 +98,7 @@ export function MathEditor(props: MathEditorProps) {
     (event) => {
       event.preventDefault()
       // close overlay
-      props.onMoveOutRight()
+      props.closeMathEditorOverlay()
     },
     {
       enableOnFormTags: true,
@@ -297,11 +297,12 @@ export function MathEditor(props: MathEditorProps) {
             {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
           </p>
           <button
-            onClick={() => props.onMoveOutRight({ closeThroughModal: true })}
-            className="mr-0.5 mt-1 text-sm font-bold text-gray-600"
+            onClick={() => props.closeMathEditorOverlay()}
+            className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
+            aria-label="Close math formula editor"
             data-qa="plugin-math-close-formula-editor"
           >
-            x
+            <FaIcon icon={faXmark} />
           </button>
         </div>
         {!isVisualMode && (

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -297,8 +297,8 @@ export function MathEditor(props: MathEditorProps) {
           </p>
           <button
             onClick={props.closeMathEditorOverlay}
-            className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
-            aria-label="Close math formula editor"
+            className="serlo-button-editor-secondary py-0"
+            aria-label={mathStrings.closeMathFormulaEditor}
             data-qa="plugin-math-close-formula-editor"
           >
             <FaIcon icon={faXmark} />

--- a/src/serlo-editor/math/renderer.tsx
+++ b/src/serlo-editor/math/renderer.tsx
@@ -32,6 +32,7 @@ export const MathRenderer = React.memo(
               }
         }
         {...additionalContainerProps}
+        data-qa="plugin-math-renderer"
       />
     )
 

--- a/src/serlo-editor/plugins/equations/editor/inline-math.tsx
+++ b/src/serlo-editor/plugins/equations/editor/inline-math.tsx
@@ -49,6 +49,7 @@ export function InlineMath(props: InlineMathProps) {
       onChange={onChange}
       onMoveOutRight={onFocusNext}
       onMoveOutLeft={onFocusPrevious}
+      closeMathEditorOverlay={onFocusNext}
     />
   )
 }

--- a/src/serlo-editor/plugins/text/components/math-element.tsx
+++ b/src/serlo-editor/plugins/text/components/math-element.tsx
@@ -49,13 +49,6 @@ export function MathElement({
     Range.isCollapsed(editor.selection)
 
   if (!shouldShowMathEditor) {
-    console.log('Should not show math editor. Rendering math formula', {
-      focused,
-      selected,
-      editorSelection: editor.selection,
-      isCollapsed: editor.selection && Range.isCollapsed(editor?.selection),
-    })
-
     return (
       // Slate void elements need to set attributes and contentEditable={false}
       // See: https://docs.slatejs.org/api/nodes/element#rendering-void-elements
@@ -67,12 +60,6 @@ export function MathElement({
   }
 
   const VoidWrapper = element.inline ? 'span' : 'div'
-  console.log('Rendering math editor', {
-    focused,
-    selected,
-    editorSelection: editor.selection,
-    isCollapsed: editor.selection && Range.isCollapsed(editor?.selection),
-  })
   return (
     // Slate void elements need to set attributes and contentEditable={false}
     // See: https://docs.slatejs.org/api/nodes/element#rendering-void-elements
@@ -211,49 +198,12 @@ export function MathElement({
       Transforms.delete(editor, { unit, reverse })
     }
 
-    // if (editor.selection) {
-    //   console.log('Setting selection to the end: ', { editor })
-    //   // move cursor to the end of line
-    //   // setTimeout(() => {
-    //   const endOfNode = Editor.end(editor, editor.selection.focus.path)
-    //   // const endOfNode = Editor.end(editor, editor.selection)
-
-    //   Transforms.setSelection(editor, { anchor: endOfNode, focus: endOfNode })
-
-    //   Transforms.move(editor, {
-    //     edge: 'end',
-    //     unit: 'line',
-    //   })
-    //   // ReactEditor.focus(editor)
-
-    //   // Transforms.setSelection(editor, {
-    //   //   anchor: endOfNode,
-    //   //   focus: endOfNode,
-    //   // })
-    //   // })
-    //   // setTimeout(() => {
-    //   //   // Transforms.setSelection(editor, { anchor: end, focus: end })
-    //   //   ReactEditor.focus(editor)
-    //   // })
-    // } else {
-    //   console.log(
-    //   'We have no selection, simply ensure that the editor is focused.'
-    // )
-    // setTimeout(() => {
-    // })
-    // }
-
-    // When calling this function from within the 'x' button to close the
-    // popup-modal, a small timeout is needed to reset the selection.
-    // Transforms.deselect() was not needed
+    // When calling this function when the 'x' button of the modal is clicked,
+    // a small timeout is needed to reset the selection. Transforms.deselect()
+    // was not needed
     if (closeThroughModal) {
       setTimeout(() => {
         ReactEditor.focus(editor)
-        // move cursor to the end
-        // Transforms.move(editor, {
-        //   edge: 'end',
-        //   unit: 'line',
-        // })
       })
     } else {
       ReactEditor.focus(editor)

--- a/src/serlo-editor/plugins/text/components/math-element.tsx
+++ b/src/serlo-editor/plugins/text/components/math-element.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { Editor, Node, Path, Range, Transforms } from 'slate'
 import {
   ReactEditor,
@@ -31,12 +31,7 @@ export function MathElement({
   const editor = useSlate()
   const selected = useSelected()
   const preferences = useContext(PreferenceContext)
-  const visualModePreferences = !!preferences.getKey(visualEditorPreferenceKey)
-  const [isVisualMode, setIsVisualMode] = useState(visualModePreferences)
-
-  useEffect(() => {
-    setIsVisualMode(visualModePreferences)
-  }, [visualModePreferences])
+  const isVisualMode = !!preferences.getKey(visualEditorPreferenceKey)
 
   const isInsideListElement = useMemo(() => {
     return isElementWithinList(element, editor)
@@ -73,6 +68,7 @@ export function MathElement({
         disableBlock={isInsideListElement}
         onInlineChange={handleInlineChange}
         onChange={(src) => updateElement({ src })}
+        closeMathEditorOverlay={transformOutOfElement}
         onMoveOutRight={transformOutOfElement}
         onMoveOutLeft={() => {
           transformOutOfElement({ reverse: true })
@@ -185,11 +181,9 @@ export function MathElement({
   function transformOutOfElement({
     reverse = false,
     shouldDelete = false,
-    closeThroughModal,
   }: {
     reverse?: boolean
     shouldDelete?: boolean
-    closeThroughModal?: boolean
   } = {}) {
     const unit = 'character'
 
@@ -198,15 +192,6 @@ export function MathElement({
       Transforms.delete(editor, { unit, reverse })
     }
 
-    // When calling this function when the 'x' button of the modal is clicked,
-    // a small timeout is needed to reset the selection. Transforms.deselect()
-    // was not needed
-    if (closeThroughModal) {
-      setTimeout(() => {
-        ReactEditor.focus(editor)
-      })
-    } else {
-      ReactEditor.focus(editor)
-    }
+    ReactEditor.focus(editor)
   }
 }


### PR DESCRIPTION
Trying to understand slate transformations. I don't get how I can move the cursor, or why the X button needs a small timeout around `Editor.focus(editor)` for the selection to be reset, and therefore, the modal with the LaTeX formula to be closed. :face_with_spiral_eyes: 

- [x] Clean up code
- [x] Test more edge cases
- [x] Create a card in Trello for it 
- [x] Remove 2px margin with !important of the texarea
- [x] Maybe in follow-up PR: Move components to separate files and renderFns to distinct components
- [x] Figure out why the Redo test is failing for me locally (might be unrelated to my changes here) :crying_cat_face: 