### PR TITLE
Remove placeholder when not editing

### DIFF
--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -397,7 +397,9 @@ export function TextEditor(props: TextEditorProps) {
       )}
       <Editable
         readOnly={!editable}
-        placeholder={config.placeholder ?? textStrings.placeholder}
+        placeholder={
+          editable ? config.placeholder ?? textStrings.placeholder : undefined
+        }
         onKeyDown={handleEditableKeyDown}
         onPaste={handleEditablePaste}
         renderElement={handleRenderElement}


### PR DESCRIPTION
Fixes https://trello.com/c/Uy0Ur13Q/246-rlp-integration-multimedia-plugin once the edusharing repo updates the git submodule.

As it's only my second PR on the frontend related to edusharing, let me know if there is an easier way to fix it. As it doesn't overwrite the `text-plugin` already, this little change directly in the frontend seems like the easiest fix. 