### PR TITLE
editor(math): visual active states

### DIFF
--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -200,7 +200,14 @@ export function MathEditor(props: MathEditorProps) {
             />
           </div>
         ) : (
-          <MathRenderer {...props} ref={anchorRef} />
+          <div
+            className={clsx(
+              props.inline ? 'inline-block' : '',
+              'rounded-md bg-editor-primary-200'
+            )}
+          >
+            <MathRenderer {...props} ref={anchorRef} />
+          </div>
         )}
 
         {renderControlsPortal(

--- a/src/serlo-editor/math/visual-editor.tsx
+++ b/src/serlo-editor/math/visual-editor.tsx
@@ -1,6 +1,7 @@
 import * as MQ from 'react-mathquill'
 
 import { MathEditorProps } from './editor'
+import { tw } from '@/helper/tw'
 
 if (typeof window !== 'undefined') {
   MQ.addStyles()
@@ -89,24 +90,32 @@ export function VisualEditor(props: VisualEditorProps) {
   }
 
   return (
-    <MQ.EditableMathField
-      latex={props.state}
-      onChange={(mathFieldRef) => {
-        // Should always be defined after first render cycle!
-        if (mathFieldRef?.latex) {
-          props.onChange(mathFieldRef.latex())
-        }
-      }}
-      onCopy={(event: React.ClipboardEvent) => {
-        event.stopPropagation()
-      }}
-      onCut={(event: React.ClipboardEvent) => {
-        event.stopPropagation()
-      }}
-      // @ts-expect-error https://github.com/serlo/serlo-editor-issues-and-documentation/issues/67
-      config={mathQuillConfig}
-      mathquillDidMount={onMount}
-    />
+    <div
+      className={tw`
+        rounded-sm focus-within:outline
+        focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-editor-primary
+        [&_.mq-editable-field]:!border-none [&_.mq-editable-field]:!shadow-none
+      `}
+    >
+      <MQ.EditableMathField
+        latex={props.state}
+        onChange={(mathFieldRef) => {
+          // Should always be defined after first render cycle!
+          if (mathFieldRef?.latex) {
+            props.onChange(mathFieldRef.latex())
+          }
+        }}
+        onCopy={(event: React.ClipboardEvent) => {
+          event.stopPropagation()
+        }}
+        onCut={(event: React.ClipboardEvent) => {
+          event.stopPropagation()
+        }}
+        // @ts-expect-error https://github.com/serlo/serlo-editor-issues-and-documentation/issues/67
+        config={mathQuillConfig}
+        mathquillDidMount={onMount}
+      />
+    </div>
   )
 
   function onMount(ref: MathField) {


### PR DESCRIPTION
(fixes https://github.com/serlo/backlog/issues/261)

- overwrite outline style for visual mode
<img width="304" alt="image" src="https://github.com/serlo/frontend/assets/1258870/5ee49dc1-1d09-49a5-8565-ad532287a23a">

- add visual active state for latex editor
<img width="287" alt="image" src="https://github.com/serlo/frontend/assets/1258870/89207f62-f3e3-4f9f-887e-25416c32f2b0">



@CodingDive sorry for messing with the same files, but I want this in the next deployment. I can solve the conflicts with your PR.