### PR TITLE
editor(math): stop latex overlay from closing on double/triple click

### DIFF
--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -263,7 +263,7 @@ export function MathEditor(props: MathEditorProps) {
     const children = (
       <div
         className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()} // double/triple clicks close overlay otherwise (#2700)
       >
         <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
           {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -261,7 +261,10 @@ export function MathEditor(props: MathEditorProps) {
 
   function renderOverlayPortal() {
     const children = (
-      <div className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu">
+      <div
+        className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
+        onClick={(e) => e.stopPropagation()}
+      >
         <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
           {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
         </p>


### PR DESCRIPTION
for #2700
Tbh. I'm not sure what the root cause is here, but this works well for me.

@CodingDive could you confirm that this solved the problem for you as well?