### PR TITLE
Split math code into multiple files

### DIFF
--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -58,6 +58,13 @@ export function MathEditor(props: MathEditorProps) {
       targetRef.current = document.querySelector<HTMLDivElement>(
         '.toolbar-controls-target'
       )
+
+      if (!targetRef.current) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'MathEditor: Could not find toolbar-controls-target to create portal'
+        )
+      }
     }
   }, [])
 

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -1,14 +1,14 @@
 import { faCheckCircle, faCircle } from '@fortawesome/free-regular-svg-icons'
-import { faQuestionCircle, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { useState, createRef, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Key } from 'ts-key-enum'
 
+import { MathEditorOverlay } from './math-editor-overlay'
 import { MathHelpModal } from './math-help-modal'
 import { MathRenderer } from './renderer'
-import { MathEditorTextarea } from './textarea'
 import { VisualEditor } from './visual-editor'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
@@ -166,7 +166,7 @@ export function MathEditor(props: MathEditorProps) {
         )}
 
         {hasError || !isVisualMode ? (
-          <MathEditorOverlayPortal
+          <MathEditorOverlay
             hasError={hasError}
             isVisualMode={isVisualMode}
             {...props}
@@ -180,37 +180,4 @@ export function MathEditor(props: MathEditorProps) {
     if (!targetRef.current) return null
     return createPortal(children, targetRef.current)
   }
-}
-
-function MathEditorOverlayPortal({
-  hasError,
-  isVisualMode,
-  ...props
-}: { hasError: boolean; isVisualMode: boolean } & MathEditorProps) {
-  const mathStrings = useEditorStrings().plugins.text.math
-  const { state } = props
-
-  return (
-    <div
-      className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
-      // Stops double/triple clicks inside the textArea field / modal to close
-      // the overlay (see #2700)
-      onClick={(e) => e.stopPropagation()}
-    >
-      <div className="flex items-center justify-between">
-        <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
-          {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
-        </p>
-        <button
-          onClick={props.closeMathEditorOverlay}
-          className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
-          aria-label="Close math formula editor"
-          data-qa="plugin-math-close-formula-editor"
-        >
-          <FaIcon icon={faXmark} />
-        </button>
-      </div>
-      {!isVisualMode && <MathEditorTextarea {...props} defaultValue={state} />}
-    </div>
-  )
 }

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -54,17 +54,15 @@ export function MathEditor(props: MathEditorProps) {
   )
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      targetRef.current = document.querySelector<HTMLDivElement>(
-        '.toolbar-controls-target'
-      )
+    targetRef.current = document.querySelector<HTMLDivElement>(
+      '.toolbar-controls-target'
+    )
 
-      if (!targetRef.current) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'MathEditor: Could not find toolbar-controls-target to create portal'
-        )
-      }
+    if (!targetRef.current) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'MathEditor: Could not find toolbar-controls-target to create portal'
+      )
     }
   }, [])
 

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -1,70 +1,18 @@
 import { faCheckCircle, faCircle } from '@fortawesome/free-regular-svg-icons'
 import { faQuestionCircle, faXmark } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
-import { useState, useCallback, createRef, useEffect } from 'react'
+import { useState, createRef, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useHotkeys } from 'react-hotkeys-hook'
-import Modal from 'react-modal'
 import { Key } from 'ts-key-enum'
 
+import { MathHelpModal } from './math-help-modal'
 import { MathRenderer } from './renderer'
+import { MathEditorTextarea } from './textarea'
 import { VisualEditor } from './visual-editor'
-import { EditorTextarea } from '../editor-ui'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
-
-interface MathEditorTextAreaProps
-  extends Pick<
-    MathEditorProps,
-    'onChange' | 'onMoveOutLeft' | 'onMoveOutRight'
-  > {
-  defaultValue: string
-  onChange: (value: string) => void
-}
-
-const MathEditorTextArea = (props: MathEditorTextAreaProps) => {
-  const [latex, setLatex] = useState(props.defaultValue)
-  const { onChange } = props
-  const parentOnChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const value = e.target.value
-      setLatex(value)
-      onChange(value)
-    },
-    [onChange]
-  )
-
-  // Autofocus textarea
-  const textareaRef = createRef<HTMLTextAreaElement>()
-  useEffect(() => {
-    const textarea = textareaRef.current
-    if (textarea)
-      // Timeout is needed because hovering overlay is positioned only after render of this
-      setTimeout(() => {
-        textarea.focus()
-      })
-    // Only run on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  return (
-    <EditorTextarea
-      className={tw`
-        mx-0 my-1 h-24 !w-[80vw] !max-w-[600px] rounded-md !border-2
-        border-transparent text-black !shadow-none focus:border-editor-primary
-      `}
-      onChange={parentOnChange}
-      onCopy={(e) => e.stopPropagation()}
-      onCut={(e) => e.stopPropagation()}
-      onMoveOutRight={props.onMoveOutRight}
-      onMoveOutLeft={props.onMoveOutLeft}
-      value={latex}
-      ref={textareaRef}
-      dataQa="plugin-math-latex-editor"
-    />
-  )
-}
 
 export interface MathEditorProps {
   autofocus?: boolean
@@ -86,8 +34,9 @@ export interface MathEditorProps {
 
 export function MathEditor(props: MathEditorProps) {
   const anchorRef = createRef<HTMLDivElement>()
-  const [helpOpen, setHelpOpen] = useState(false)
+  const [isHelpOpen, setIsHelpOpen] = useState(false)
   const [hasError, setHasError] = useState(false)
+  const targetRef = useRef<HTMLDivElement | null>(null)
 
   const mathStrings = useEditorStrings().plugins.text.math
 
@@ -104,84 +53,22 @@ export function MathEditor(props: MathEditorProps) {
     }
   )
 
-  const isVisualMode = visual && !hasError
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      targetRef.current = document.querySelector<HTMLDivElement>(
+        '.toolbar-controls-target'
+      )
+    }
+  }, [])
+
+  const isVisualMode = (visual && !hasError) || false
 
   return (
     <>
-      <Modal
-        ariaHideApp={false}
-        isOpen={helpOpen}
-        onRequestClose={() => {
-          setHelpOpen(false)
-        }}
-        style={{
-          overlay: {
-            zIndex: 9999,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            backgroundColor: 'rgba(0, 0, 0, 0.1)',
-          },
-          content: {
-            borderRadius: 0,
-            backgroundColor: '#ffffff',
-            width: '90%',
-            maxWidth: '600px',
-            maxHeight: 'calc(100vh - 80px)',
-            top: 'auto',
-            left: 'auto',
-            right: 'auto',
-            bottom: 'auto',
-            margin: '0 auto',
-          },
-        }}
-      >
-        <>
-          {mathStrings.shortcuts}:
-          <br />
-          <br />
-          <p>
-            {mathStrings.fraction}: {renderKey('/')}
-          </p>
-          <p>
-            {mathStrings.superscript}: {renderKey('↑')} {mathStrings.or}{' '}
-            {renderKey('^')}
-          </p>
-          <p>
-            {mathStrings.subscript}: {renderKey('↓')} {mathStrings.or}{' '}
-            {renderKey('_')}
-          </p>
-          <p>
-            π, α, β, γ: {renderKey('pi')}, {renderKey('alpha')},{' '}
-            {renderKey('beta')},{renderKey('gamma')}
-          </p>
-          <p>
-            ≤, ≥: {renderKey('<=')}, {renderKey('>=')}
-          </p>
-          <p>
-            {mathStrings.root}: {renderKey('\\sqrt')}, {renderKey('\\nthroot')}
-          </p>
-          <p>
-            {mathStrings.mathSymbols}: {renderKey('\\<NAME>')}, {mathStrings.eG}{' '}
-            {renderKey('\\neq')} (≠), {renderKey('\\pm')} (±), …
-          </p>
-          <p>
-            {mathStrings.functions}: {renderKey('sin')}, {renderKey('cos')},{' '}
-            {renderKey('ln')}, …
-          </p>
-        </>
-      </Modal>
+      <MathHelpModal isHelpOpen={isHelpOpen} setIsHelpOpen={setIsHelpOpen} />
       {renderChildren()}
     </>
   )
-
-  function renderKey(text: string) {
-    return (
-      <span className="min-w-[20px] rounded-md bg-[#ddd] px-1 py-0.5 text-center text-almost-black">
-        {text}
-      </span>
-    )
-  }
 
   function renderChildren() {
     if (readOnly) {
@@ -262,7 +149,7 @@ export function MathEditor(props: MathEditorProps) {
             )}
             {isVisualMode && (
               <button
-                onMouseDown={() => setHelpOpen(true)}
+                onMouseDown={() => void setIsHelpOpen(true)}
                 className="mx-2 text-almost-black hover:text-editor-primary"
               >
                 <FaIcon icon={faQuestionCircle} />
@@ -271,43 +158,52 @@ export function MathEditor(props: MathEditorProps) {
           </div>
         )}
 
-        {hasError || !isVisualMode ? renderOverlayPortal() : null}
+        {hasError || !isVisualMode ? (
+          <MathEditorOverlayPortal
+            hasError={hasError}
+            isVisualMode={isVisualMode}
+            {...props}
+          />
+        ) : null}
       </>
     )
   }
 
   function renderControlsPortal(children: JSX.Element) {
-    const target =
-      typeof window !== undefined &&
-      document.querySelector('.toolbar-controls-target')
-    if (!target) return null
-
-    return createPortal(children, target)
+    if (!targetRef.current) return null
+    return createPortal(children, targetRef.current)
   }
+}
 
-  function renderOverlayPortal() {
-    return (
-      <div
-        className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
-        onClick={(e) => e.stopPropagation()} // double/triple clicks close overlay otherwise (#2700)
-      >
-        <div className="flex items-center justify-between">
-          <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
-            {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
-          </p>
-          <button
-            onClick={props.closeMathEditorOverlay}
-            className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
-            aria-label="Close math formula editor"
-            data-qa="plugin-math-close-formula-editor"
-          >
-            <FaIcon icon={faXmark} />
-          </button>
-        </div>
-        {!isVisualMode && (
-          <MathEditorTextArea {...props} defaultValue={state} />
-        )}
+function MathEditorOverlayPortal({
+  hasError,
+  isVisualMode,
+  ...props
+}: { hasError: boolean; isVisualMode: boolean } & MathEditorProps) {
+  const mathStrings = useEditorStrings().plugins.text.math
+  const { state } = props
+
+  return (
+    <div
+      className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
+      // Stops double/triple clicks inside the textArea field / modal to close
+      // the overlay (see #2700)
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between">
+        <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
+          {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
+        </p>
+        <button
+          onClick={props.closeMathEditorOverlay}
+          className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
+          aria-label="Close math formula editor"
+          data-qa="plugin-math-close-formula-editor"
+        >
+          <FaIcon icon={faXmark} />
+        </button>
       </div>
-    )
-  }
+      {!isVisualMode && <MathEditorTextarea {...props} defaultValue={state} />}
+    </div>
+  )
 }

--- a/src/serlo-editor/math/math-editor-overlay.tsx
+++ b/src/serlo-editor/math/math-editor-overlay.tsx
@@ -1,0 +1,39 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons'
+
+import { MathEditorProps } from './editor'
+import { MathEditorTextarea } from './textarea'
+import { FaIcon } from '@/components/fa-icon'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+export function MathEditorOverlay({
+  hasError,
+  isVisualMode,
+  ...props
+}: { hasError: boolean; isVisualMode: boolean } & MathEditorProps) {
+  const mathStrings = useEditorStrings().plugins.text.math
+  const { state } = props
+
+  return (
+    <div
+      className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
+      // Stops double/triple clicks inside the textArea field / modal to close
+      // the overlay (see #2700)
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between">
+        <p className="mr-0.5 mt-1 text-right text-sm font-bold text-gray-600">
+          {hasError ? mathStrings.onlyLatex : mathStrings.latexEditorTitle}
+        </p>
+        <button
+          onClick={props.closeMathEditorOverlay}
+          className="mr-0.5 mt-1 text-sm font-bold text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-700"
+          aria-label="Close math formula editor"
+          data-qa="plugin-math-close-formula-editor"
+        >
+          <FaIcon icon={faXmark} />
+        </button>
+      </div>
+      {!isVisualMode && <MathEditorTextarea {...props} defaultValue={state} />}
+    </div>
+  )
+}

--- a/src/serlo-editor/math/math-help-modal.tsx
+++ b/src/serlo-editor/math/math-help-modal.tsx
@@ -1,5 +1,4 @@
-import Modal from 'react-modal'
-
+import { ModalWithCloseButton } from '@/components/modal-with-close-button'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 
 export const MathHelpModal = ({
@@ -11,31 +10,9 @@ export const MathHelpModal = ({
 }) => {
   const mathStrings = useEditorStrings().plugins.text.math
   return (
-    <Modal
-      ariaHideApp={false}
+    <ModalWithCloseButton
       isOpen={isHelpOpen}
-      onRequestClose={() => void setIsHelpOpen(false)}
-      style={{
-        overlay: {
-          zIndex: 9999,
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: 'rgba(0, 0, 0, 0.1)',
-        },
-        content: {
-          borderRadius: 0,
-          backgroundColor: '#ffffff',
-          width: '90%',
-          maxWidth: '600px',
-          maxHeight: 'calc(100vh - 80px)',
-          top: 'auto',
-          left: 'auto',
-          right: 'auto',
-          bottom: 'auto',
-          margin: '0 auto',
-        },
-      }}
+      onCloseClick={() => void setIsHelpOpen(false)}
     >
       <>
         {mathStrings.shortcuts}:
@@ -71,7 +48,7 @@ export const MathHelpModal = ({
           {renderKey('ln')}, …
         </p>
       </>
-    </Modal>
+    </ModalWithCloseButton>
   )
 
   function renderKey(text: string) {

--- a/src/serlo-editor/math/math-help-modal.tsx
+++ b/src/serlo-editor/math/math-help-modal.tsx
@@ -1,0 +1,84 @@
+import Modal from 'react-modal'
+
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+export const MathHelpModal = ({
+  isHelpOpen,
+  setIsHelpOpen,
+}: {
+  isHelpOpen: boolean
+  setIsHelpOpen: (isOpen: boolean) => void
+}) => {
+  const mathStrings = useEditorStrings().plugins.text.math
+  return (
+    <Modal
+      ariaHideApp={false}
+      isOpen={isHelpOpen}
+      onRequestClose={() => void setIsHelpOpen(false)}
+      style={{
+        overlay: {
+          zIndex: 9999,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: 'rgba(0, 0, 0, 0.1)',
+        },
+        content: {
+          borderRadius: 0,
+          backgroundColor: '#ffffff',
+          width: '90%',
+          maxWidth: '600px',
+          maxHeight: 'calc(100vh - 80px)',
+          top: 'auto',
+          left: 'auto',
+          right: 'auto',
+          bottom: 'auto',
+          margin: '0 auto',
+        },
+      }}
+    >
+      <>
+        {mathStrings.shortcuts}:
+        <br />
+        <br />
+        <p>
+          {mathStrings.fraction}: {renderKey('/')}
+        </p>
+        <p>
+          {mathStrings.superscript}: {renderKey('↑')} {mathStrings.or}{' '}
+          {renderKey('^')}
+        </p>
+        <p>
+          {mathStrings.subscript}: {renderKey('↓')} {mathStrings.or}{' '}
+          {renderKey('_')}
+        </p>
+        <p>
+          π, α, β, γ: {renderKey('pi')}, {renderKey('alpha')},{' '}
+          {renderKey('beta')},{renderKey('gamma')}
+        </p>
+        <p>
+          ≤, ≥: {renderKey('<=')}, {renderKey('>=')}
+        </p>
+        <p>
+          {mathStrings.root}: {renderKey('\\sqrt')}, {renderKey('\\nthroot')}
+        </p>
+        <p>
+          {mathStrings.mathSymbols}: {renderKey('\\<NAME>')}, {mathStrings.eG}{' '}
+          {renderKey('\\neq')} (≠), {renderKey('\\pm')} (±), …
+        </p>
+        <p>
+          {mathStrings.functions}: {renderKey('sin')}, {renderKey('cos')},{' '}
+          {renderKey('ln')}, …
+        </p>
+      </>
+    </Modal>
+  )
+
+  function renderKey(text: string) {
+    return (
+      <span className="min-w-[20px] rounded-md bg-[#ddd] px-1 py-0.5 text-center text-almost-black">
+        {text}
+      </span>
+    )
+  }
+}

--- a/src/serlo-editor/math/textarea.tsx
+++ b/src/serlo-editor/math/textarea.tsx
@@ -1,0 +1,57 @@
+import { useState, useCallback, createRef, useEffect } from 'react'
+
+import { MathEditorProps } from './editor'
+import { EditorTextarea } from '../editor-ui'
+import { tw } from '@/helper/tw'
+
+interface MathEditorTextareaProps
+  extends Pick<
+    MathEditorProps,
+    'onChange' | 'onMoveOutLeft' | 'onMoveOutRight'
+  > {
+  defaultValue: string
+  onChange: (value: string) => void
+}
+
+export const MathEditorTextarea = (props: MathEditorTextareaProps) => {
+  const [latex, setLatex] = useState(props.defaultValue)
+  const { onChange } = props
+  const parentOnChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value
+      setLatex(value)
+      onChange(value)
+    },
+    [onChange]
+  )
+
+  // Autofocus textarea
+  const textareaRef = createRef<HTMLTextAreaElement>()
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea)
+      // Timeout is needed because hovering overlay is positioned only after render of this
+      setTimeout(() => {
+        textarea.focus()
+      })
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <EditorTextarea
+      className={tw`
+        mx-0 my-1 h-24 !w-[80vw] !max-w-[600px] rounded-md !border-2
+        border-transparent text-black !shadow-none focus:border-editor-primary
+      `}
+      onChange={parentOnChange}
+      onCopy={(e) => e.stopPropagation()}
+      onCut={(e) => e.stopPropagation()}
+      onMoveOutRight={props.onMoveOutRight}
+      onMoveOutLeft={props.onMoveOutLeft}
+      value={latex}
+      ref={textareaRef}
+      dataQa="plugin-math-latex-editor"
+    />
+  )
+}


### PR DESCRIPTION
Now that we have made some nice bug fixes and visual improvements with the math editor, I just took a few components/render fns and extracted them into their own files/components. 

Also put the DOM element selection into an effect for concurrent mode :tada: 