### PR TITLE
editor(template plugins): remove side toolbar tools

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -135,6 +135,8 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
       Object.hasOwn(config, 'isInlineChildEditor') &&
       (config.isInlineChildEditor as boolean)
 
+    const isTemplatePlugin = document.plugin.startsWith('type-')
+
     return (
       <div
         className="outline-none"
@@ -147,7 +149,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           hasSideToolbar={hasSideToolbar}
           focused={focused}
           renderSideToolbar={pluginProps && pluginProps.renderSideToolbar}
-          isInlineChildEditor={isInlineChildEditor}
+          noSidebar={isInlineChildEditor || isTemplatePlugin}
           sideToolbarRef={sideToolbarRef}
         >
           <plugin.Component

--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -1,6 +1,5 @@
 import * as R from 'ramda'
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
-import { createPortal } from 'react-dom'
+import { useRef, useEffect, useMemo, useCallback } from 'react'
 
 import { SubDocumentProps } from '.'
 import { useEnableEditorHotkeys } from './use-enable-editor-hotkeys'
@@ -19,7 +18,6 @@ import { SideToolbarAndWrapper } from '@/serlo-editor/editor-ui/side-toolbar-and
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
 
 export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
-  const [hasSideToolbar, setHasSideToolbar] = useState(false)
   const dispatch = useAppDispatch()
   const document = useAppSelector((state) => selectDocument(state, id))
 
@@ -72,20 +70,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
       }
     },
     [focused, id, dispatch, document]
-  )
-
-  const renderIntoSideToolbar = useCallback(
-    (children: React.ReactNode) => {
-      return (
-        <RenderIntoSideToolbar
-          setHasSideToolbar={setHasSideToolbar}
-          sideToolbarRef={sideToolbarRef}
-        >
-          {children}
-        </RenderIntoSideToolbar>
-      )
-    },
-    [sideToolbarRef]
   )
 
   return useMemo(() => {
@@ -146,14 +130,12 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
         tabIndex={-1}
       >
         <SideToolbarAndWrapper
-          hasSideToolbar={hasSideToolbar}
           focused={focused}
           renderSideToolbar={pluginProps && pluginProps.renderSideToolbar}
           noSidebar={isInlineChildEditor || isTemplatePlugin}
           sideToolbarRef={sideToolbarRef}
         >
           <plugin.Component
-            renderIntoSideToolbar={renderIntoSideToolbar}
             containerRef={containerRef}
             id={id}
             editable
@@ -166,31 +148,5 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
         </SideToolbarAndWrapper>
       </div>
     )
-  }, [
-    document,
-    plugin,
-    pluginProps,
-    handleFocus,
-    hasSideToolbar,
-    focused,
-    renderIntoSideToolbar,
-    id,
-    dispatch,
-  ])
-}
-
-function RenderIntoSideToolbar({
-  children,
-  setHasSideToolbar,
-  sideToolbarRef,
-}: {
-  children: React.ReactNode
-  setHasSideToolbar: (value: boolean) => void
-  sideToolbarRef: React.MutableRefObject<HTMLDivElement>
-}) {
-  useEffect(() => {
-    setHasSideToolbar(true)
-  })
-  if (!sideToolbarRef.current) return null
-  return createPortal(children, sideToolbarRef.current)
+  }, [document, plugin, pluginProps, handleFocus, focused, id, dispatch])
 }

--- a/src/serlo-editor/core/sub-document/renderer.tsx
+++ b/src/serlo-editor/core/sub-document/renderer.tsx
@@ -35,7 +35,6 @@ export function SubDocumentRenderer({ id, pluginProps }: SubDocumentProps) {
       editable={false}
       focused={false}
       autofocusRef={focusRef}
-      renderIntoSideToolbar={() => null}
     />
   )
 }

--- a/src/serlo-editor/editor-ui/exercises/add-button.tsx
+++ b/src/serlo-editor/editor-ui/exercises/add-button.tsx
@@ -1,4 +1,5 @@
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import clsx from 'clsx'
 
 import { FaIcon } from '@/components/fa-icon'
 
@@ -6,14 +7,25 @@ interface AddButtonProps {
   onClick: () => void
   children: string
   title?: string
+  secondary?: boolean
 }
 
-export function AddButton({ title, onClick, children }: AddButtonProps) {
+export function AddButton({
+  title,
+  onClick,
+  children,
+  secondary,
+}: AddButtonProps) {
   return (
     <button
       title={title}
       onMouseDown={onClick}
-      className="serlo-button-editor-primary mr-2"
+      className={clsx(
+        secondary
+          ? 'serlo-button-editor-secondary'
+          : 'serlo-button-editor-primary',
+        'mr-2'
+      )}
     >
       <FaIcon icon={faPlus} /> {children}
     </button>

--- a/src/serlo-editor/editor-ui/side-toolbar-and-wrapper.tsx
+++ b/src/serlo-editor/editor-ui/side-toolbar-and-wrapper.tsx
@@ -5,42 +5,28 @@ import { tw } from '@/helper/tw'
 
 export interface SideToolbarAndWrapperProps {
   children: React.ReactNode // The rendered document
-  sideToolbarRef: React.RefObject<HTMLDivElement> // The rendered toolbar buttons
-  hasSideToolbar: boolean // `true` if the document has rendered any toolbar buttons
   renderSideToolbar?(children: React.ReactNode): React.ReactNode // Render prop to override rendering of toolbar
+  sideToolbarRef: React.RefObject<HTMLDivElement> // The rendered toolbar buttons
   focused: boolean // `true` if the document is focused
   noSidebar: boolean
 }
 
 // Container that includes a plugin and its sideToolbar and handles some hover&focus styling
 export function SideToolbarAndWrapper({
-  focused,
   children,
   renderSideToolbar,
   sideToolbarRef,
-  hasSideToolbar,
+  focused,
   noSidebar,
 }: SideToolbarAndWrapperProps) {
   const [hasHover, setHasHover] = useState(false)
 
-  const showToolbar = hasSideToolbar || renderSideToolbar !== undefined
+  const showToolbar = renderSideToolbar !== undefined
 
   const isFocused = focused && showToolbar
   const isHovered = hasHover && showToolbar
 
   const isAppended = useRef(false)
-  const sideToolbar = (
-    <div
-      ref={(ref) => {
-        // The ref `isAppended` ensures that we only append the content once
-        // so that we don't lose focus on every render
-        if (ref && sideToolbarRef.current && !isAppended.current) {
-          isAppended.current = true
-          ref.appendChild(sideToolbarRef.current)
-        }
-      }}
-    />
-  )
 
   if (noSidebar) return <>{children}</>
 
@@ -78,14 +64,27 @@ export function SideToolbarAndWrapper({
             before:h-full before:w-0.5 before:opacity-100 before:content-[_]`
         )}
       >
-        <div
-          className={clsx(
-            'relative z-[21] mr-0.5 flex flex-col items-end rounded-l-md bg-white pb-2.5 transition-opacity',
-            isFocused ? 'opacity-100' : isHovered ? 'opacity-70' : 'opacity-0'
-          )}
-        >
-          {renderSideToolbar ? renderSideToolbar(sideToolbar) : sideToolbar}
-        </div>
+        {renderSideToolbar ? (
+          <div
+            className={clsx(
+              'relative z-[21] mr-0.5 flex flex-col items-end rounded-l-md bg-white pb-2.5 transition-opacity',
+              isFocused ? 'opacity-100' : isHovered ? 'opacity-70' : 'opacity-0'
+            )}
+          >
+            {renderSideToolbar(
+              <div
+                ref={(ref) => {
+                  // The ref `isAppended` ensures that we only append the content once
+                  // so that we don't lose focus on every render
+                  if (ref && sideToolbarRef.current && !isAppended.current) {
+                    isAppended.current = true
+                    ref.appendChild(sideToolbarRef.current)
+                  }
+                }}
+              />
+            )}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/src/serlo-editor/editor-ui/side-toolbar-and-wrapper.tsx
+++ b/src/serlo-editor/editor-ui/side-toolbar-and-wrapper.tsx
@@ -9,7 +9,7 @@ export interface SideToolbarAndWrapperProps {
   hasSideToolbar: boolean // `true` if the document has rendered any toolbar buttons
   renderSideToolbar?(children: React.ReactNode): React.ReactNode // Render prop to override rendering of toolbar
   focused: boolean // `true` if the document is focused
-  isInlineChildEditor: boolean
+  noSidebar: boolean
 }
 
 // Container that includes a plugin and its sideToolbar and handles some hover&focus styling
@@ -19,7 +19,7 @@ export function SideToolbarAndWrapper({
   renderSideToolbar,
   sideToolbarRef,
   hasSideToolbar,
-  isInlineChildEditor,
+  noSidebar,
 }: SideToolbarAndWrapperProps) {
   const [hasHover, setHasHover] = useState(false)
 
@@ -42,7 +42,7 @@ export function SideToolbarAndWrapper({
     />
   )
 
-  if (isInlineChildEditor) return <>{children}</>
+  if (noSidebar) return <>{children}</>
 
   return (
     <div

--- a/src/serlo-editor/plugins/exercise/editor.tsx
+++ b/src/serlo-editor/plugins/exercise/editor.tsx
@@ -36,6 +36,7 @@ export function ExerciseEditor({ editable, state }: ExerciseProps) {
                 <AddButton
                   key={type}
                   onClick={() => interactive.create({ plugin: type })}
+                  secondary
                 >
                   {exStrings[type]}
                 </AddButton>

--- a/src/serlo-editor/plugins/serlo-template-plugins/applet.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/applet.tsx
@@ -54,12 +54,20 @@ function AppletTypeEditor(props: EditorPluginProps<AppletTypePluginState>) {
 
   return (
     <>
-      <button
-        onClick={() => setShowSettingsModal(true)}
-        className="serlo-button-editor-secondary absolute right-0 -mt-10 mr-side text-base"
-      >
-        Metadata <FaIcon icon={faPencilAlt} />
-      </button>
+      <div className="absolute right-0 -mt-10 mr-side flex">
+        <button
+          onClick={() => setShowSettingsModal(true)}
+          className="serlo-button-editor-secondary mr-2 text-base"
+        >
+          Metadata <FaIcon icon={faPencilAlt} />
+        </button>
+        <ContentLoaders
+          id={id.value}
+          currentRevision={revision.value}
+          onSwitchRevision={replaceOwnState}
+          entityType={UuidType.Applet}
+        />
+      </div>
       <h1 className="serlo-h1 mt-20">
         {props.editable ? (
           <input
@@ -77,14 +85,6 @@ function AppletTypeEditor(props: EditorPluginProps<AppletTypePluginState>) {
       {content.render()}
 
       <ToolbarMain showSubscriptionOptions {...props.state} />
-      {props.renderIntoSideToolbar(
-        <ContentLoaders
-          id={id.value}
-          currentRevision={revision.value}
-          onSwitchRevision={replaceOwnState}
-          entityType={UuidType.Applet}
-        />
-      )}
       {showSettingsModal ? (
         <ModalWithCloseButton
           isOpen={showSettingsModal}

--- a/src/serlo-editor/plugins/serlo-template-plugins/article.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/article.tsx
@@ -42,12 +42,20 @@ function ArticleTypeEditor(props: EditorPluginProps<ArticleTypePluginState>) {
 
   return (
     <>
-      <button
-        onClick={() => setShowSettingsModal(true)}
-        className="serlo-button-editor-secondary absolute right-0 -mt-10 mr-side text-base"
-      >
-        Metadata <FaIcon icon={faPencilAlt} />
-      </button>
+      <div className="absolute right-0 -mt-10 mr-side flex">
+        <button
+          onClick={() => setShowSettingsModal(true)}
+          className="serlo-button-editor-secondary mr-2 text-base"
+        >
+          Metadata <FaIcon icon={faPencilAlt} />
+        </button>
+        <ContentLoaders
+          id={props.state.id.value}
+          currentRevision={props.state.revision.value}
+          onSwitchRevision={props.state.replaceOwnState}
+          entityType={UuidType.Article}
+        />
+      </div>
       <h1 className="serlo-h1 mt-20" itemProp="name">
         {props.editable ? (
           <input
@@ -64,14 +72,6 @@ function ArticleTypeEditor(props: EditorPluginProps<ArticleTypePluginState>) {
       <section itemProp="articleBody">{content.render()}</section>
 
       <ToolbarMain showSubscriptionOptions {...props.state} />
-      {props.renderIntoSideToolbar(
-        <ContentLoaders
-          id={props.state.id.value}
-          currentRevision={props.state.revision.value}
-          onSwitchRevision={props.state.replaceOwnState}
-          entityType={UuidType.Article}
-        />
-      )}
       {showSettingsModal ? (
         <ModalWithCloseButton
           isOpen={showSettingsModal}

--- a/src/serlo-editor/plugins/serlo-template-plugins/course/course-page.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/course/course-page.tsx
@@ -47,7 +47,15 @@ function CoursePageTypeEditor(
 
   return (
     <article>
-      <h1 className="serlo-h1">
+      <div className="absolute right-0 -mt-10 mr-side flex">
+        <ContentLoaders
+          id={props.state.id.value}
+          currentRevision={props.state.revision.value}
+          onSwitchRevision={props.state.replaceOwnState}
+          entityType={UuidType.CoursePage}
+        />
+      </div>
+      <h1 className="serlo-h1 mt-20">
         {props.editable ? (
           <input
             className={headerInputClasses}
@@ -64,14 +72,6 @@ function CoursePageTypeEditor(
 
       {props.config.skipControls ? null : (
         <ToolbarMain showSubscriptionOptions {...props.state} />
-      )}
-      {props.renderIntoSideToolbar(
-        <ContentLoaders
-          id={props.state.id.value}
-          currentRevision={props.state.revision.value}
-          onSwitchRevision={props.state.replaceOwnState}
-          entityType={UuidType.CoursePage}
-        />
       )}
     </article>
   )

--- a/src/serlo-editor/plugins/serlo-template-plugins/course/course.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/course/course.tsx
@@ -64,12 +64,19 @@ function CourseTypeEditor(props: EditorPluginProps<CourseTypePluginState>) {
 
   return (
     <>
-      <button
-        onClick={() => setShowSettingsModal(true)}
-        className="serlo-button-editor-secondary absolute right-0 -mt-10 mr-side text-base"
-      >
-        Metadata <FaIcon icon={faPencilAlt} />
-      </button>
+      <div className="absolute right-0 -mt-10 mr-side flex">
+        <button
+          onClick={() => setShowSettingsModal(true)}
+          className="serlo-button-editor-secondary mr-2 text-base"
+        >
+          Metadata <FaIcon icon={faPencilAlt} />
+        </button>
+        <RevisionHistoryLoader
+          id={props.state.id.value}
+          currentRevision={props.state.revision.value}
+          onSwitchRevision={props.state.replaceOwnState}
+        />
+      </div>
       <article className="mt-20">
         {renderCourseNavigation()}
         {children.map((child, index) => {
@@ -89,13 +96,6 @@ function CourseTypeEditor(props: EditorPluginProps<CourseTypePluginState>) {
           </AddButton>
         </div>
         <ToolbarMain showSubscriptionOptions {...props.state} />
-        {props.renderIntoSideToolbar(
-          <RevisionHistoryLoader
-            id={props.state.id.value}
-            currentRevision={props.state.revision.value}
-            onSwitchRevision={props.state.replaceOwnState}
-          />
-        )}
       </article>
       {showSettingsModal ? (
         <ModalWithCloseButton

--- a/src/serlo-editor/plugins/serlo-template-plugins/event.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/event.tsx
@@ -35,7 +35,15 @@ function EventTypeEditor(props: EditorPluginProps<EventTypePluginState>) {
 
   return (
     <>
-      <h1 className="serlo-h1">
+      <div className="absolute right-0 -mt-10 mr-side flex">
+        <ContentLoaders
+          id={id.value}
+          currentRevision={revision.value}
+          onSwitchRevision={replaceOwnState}
+          entityType={UuidType.Event}
+        />
+      </div>
+      <h1 className="serlo-h1 mt-20">
         {props.editable ? (
           <input
             className={headerInputClasses}
@@ -51,14 +59,6 @@ function EventTypeEditor(props: EditorPluginProps<EventTypePluginState>) {
       {content.render()}
 
       <ToolbarMain showSubscriptionOptions {...props.state} />
-      {props.renderIntoSideToolbar(
-        <ContentLoaders
-          id={id.value}
-          currentRevision={revision.value}
-          onSwitchRevision={replaceOwnState}
-          entityType={UuidType.Event}
-        />
-      )}
     </>
   )
 }

--- a/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/content-loaders.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/content-loaders.tsx
@@ -13,16 +13,13 @@ export function ContentLoaders({
   entityType: UuidType
   onSwitchRevision: (data: any) => void
 }) {
-  if (id) {
-    return (
-      <RevisionHistoryLoader
-        id={id}
-        currentRevision={currentRevision}
-        onSwitchRevision={onSwitchRevision}
-      />
-    )
-  }
-  return (
+  return id ? (
+    <RevisionHistoryLoader
+      id={id}
+      currentRevision={currentRevision}
+      onSwitchRevision={onSwitchRevision}
+    />
+  ) : (
     <ExternalRevisionLoader
       entityType={entityType}
       onSwitchRevision={onSwitchRevision}

--- a/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/external-revision-loader.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/external-revision-loader.tsx
@@ -17,8 +17,8 @@ import {
 import { dataQuery } from '@/fetcher/query'
 import { showToastNotice } from '@/helper/show-toast-notice'
 import { triggerSentry } from '@/helper/trigger-sentry'
+import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
 import { SerloAddButton } from '@/serlo-editor/plugin/helpers/serlo-editor-button'
-import { PluginToolbarButton } from '@/serlo-editor/plugin/plugin-toolbar'
 import {
   DeserializeError,
   editorResponseToState,
@@ -45,11 +45,13 @@ export function ExternalRevisionLoader<T>({
   return (
     <div>
       <span onClick={() => setShowRevisions(true)}>
-        <PluginToolbarButton
-          icon={<FaIcon icon={faFileImport} className="text-xl" />}
-          label={editorStrings.edtrIo.importOther}
-          className="p-0.5 pt-2"
-        />
+        <button className="serlo-button-editor-secondary serlo-tooltip-trigger">
+          <EditorTooltip
+            text={editorStrings.edtrIo.importOther}
+            className="-left-40"
+          />
+          <FaIcon icon={faFileImport} className="text-md" />
+        </button>
       </span>
 
       <ModalWithCloseButton

--- a/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/revision-history-loader.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/helpers/content-loaders/revision-history-loader.tsx
@@ -18,7 +18,7 @@ import { revisionQuery } from '@/fetcher/revision/query'
 import { showToastNotice } from '@/helper/show-toast-notice'
 import { triggerSentry } from '@/helper/trigger-sentry'
 import { revisionHistoryQuery } from '@/pages/entity/repository/history/[id]'
-import { PluginToolbarButton } from '@/serlo-editor/plugin/plugin-toolbar'
+import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
 import {
   editorResponseToState,
   isError,
@@ -60,11 +60,13 @@ export function RevisionHistoryLoader<T>({
           if (revisions.length) setShowRevisions(true)
         }}
       >
-        <PluginToolbarButton
-          icon={<FaIcon icon={faHistory} className="text-xl" />}
-          label={editorStrings.edtrIo.switchRevision}
-          className="pr-0.5 pt-1"
-        />
+        <button className="serlo-button-editor-secondary serlo-tooltip-trigger">
+          <EditorTooltip
+            text={editorStrings.edtrIo.switchRevision}
+            className="-left-40"
+          />
+          <FaIcon icon={faHistory} className="text-md" />
+        </button>
       </span>
 
       <ModalWithCloseButton

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise-group.tsx
@@ -55,34 +55,36 @@ function TextExerciseGroupTypeEditor(
   const contentRendered = content.render()
 
   return (
-    <article className="exercisegroup mt-16">
-      <section className="row">{contentRendered}</section>
-      <ol className="mb-2.5 ml-2 bg-white pb-3.5 [counter-reset:exercises] sm:pl-12">
-        {children.map((child, index) => (
-          <li
-            key={child.id}
-            className="[&>div] serlo-exercise-wrapper serlo-grouped-exercise-wrapper mt-12 [&>div]:border-none"
-          >
-            <OptionalChild
-              state={child}
-              removeLabel={exGroupStrings.removeExercise}
-              onRemove={() => children.remove(index)}
-            />
-          </li>
-        ))}
-      </ol>
-      <AddButton onClick={() => children.insert()}>
-        {exGroupStrings.addExercise}
-      </AddButton>
-      <ToolbarMain showSubscriptionOptions {...props.state} />
-      {props.renderIntoSideToolbar(
+    <>
+      <div className="absolute right-0 -mt-20 mr-side flex">
         <ContentLoaders
           id={id.value}
           currentRevision={revision.value}
           onSwitchRevision={replaceOwnState}
           entityType={UuidType.ExerciseGroup}
         />
-      )}
-    </article>
+      </div>
+      <article className="exercisegroup mt-32">
+        <section className="row">{contentRendered}</section>
+        <ol className="mb-2.5 ml-2 bg-white pb-3.5 [counter-reset:exercises] sm:pl-12">
+          {children.map((child, index) => (
+            <li
+              key={child.id}
+              className="[&>div] serlo-exercise-wrapper serlo-grouped-exercise-wrapper mt-12 [&>div]:border-none"
+            >
+              <OptionalChild
+                state={child}
+                removeLabel={exGroupStrings.removeExercise}
+                onRemove={() => children.remove(index)}
+              />
+            </li>
+          ))}
+        </ol>
+        <AddButton onClick={() => children.insert()}>
+          {exGroupStrings.addExercise}
+        </AddButton>
+        <ToolbarMain showSubscriptionOptions {...props.state} />
+      </article>
+    </>
   )
 }

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
@@ -37,38 +37,39 @@ export const textExerciseTypePlugin: EditorPlugin<
 function TextExerciseTypeEditor({
   state,
   config,
-  renderIntoSideToolbar,
 }: EditorPluginProps<TextExerciseTypePluginState, { skipControls: boolean }>) {
   const { content, 'text-solution': textSolution } = state
   const textExStrings = useEditorStrings().templatePlugins.textExercise
 
   return (
-    <article className="text-exercise mt-16">
-      {content.render()}
-      {textSolution.id ? (
-        <OptionalChild
-          state={textSolution}
-          removeLabel={textExStrings.removeSolution}
-          onRemove={() => textSolution.remove()}
-        />
-      ) : (
-        <div className="-ml-1.5 max-w-[50%]">
-          <AddButton onClick={() => textSolution.create()}>
-            {textExStrings.createSolution}
-          </AddButton>
-        </div>
-      )}
-      {config.skipControls ? null : (
-        <ToolbarMain showSubscriptionOptions {...state} />
-      )}
-      {renderIntoSideToolbar(
+    <>
+      <div className="absolute right-0 -mt-20 mr-side">
         <ContentLoaders
           id={state.id.value}
           currentRevision={state.revision.value}
           onSwitchRevision={state.replaceOwnState}
           entityType={UuidType.Exercise}
         />
-      )}
-    </article>
+      </div>
+      <article className="text-exercise mt-32">
+        {content.render()}
+        {textSolution.id ? (
+          <OptionalChild
+            state={textSolution}
+            removeLabel={textExStrings.removeSolution}
+            onRemove={() => textSolution.remove()}
+          />
+        ) : (
+          <div className="-ml-1.5 max-w-[50%]">
+            <AddButton onClick={() => textSolution.create()}>
+              {textExStrings.createSolution}
+            </AddButton>
+          </div>
+        )}
+        {config.skipControls ? null : (
+          <ToolbarMain showSubscriptionOptions {...state} />
+        )}
+      </article>
+    </>
   )
 }

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-solution.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-solution.tsx
@@ -30,20 +30,22 @@ export const textSolutionTypePlugin: EditorPlugin<
 
 function TextSolutionTypeEditor(props: TextSolutionTypeProps) {
   return (
-    <div className="mt-12">
-      {props.state.content.render()}
-
-      {props.config.skipControls ? null : (
-        <ToolbarMain showSubscriptionOptions {...props.state} />
-      )}
-      {props.renderIntoSideToolbar(
+    <>
+      <div className="absolute right-0 -mt-10 mr-side">
         <ContentLoaders
           id={props.state.id.value}
           currentRevision={props.state.revision.value}
           onSwitchRevision={props.state.replaceOwnState}
           entityType={UuidType.Solution}
         />
-      )}
-    </div>
+      </div>
+      <div className="mt-12">
+        {props.state.content.render()}
+
+        {props.config.skipControls ? null : (
+          <ToolbarMain showSubscriptionOptions {...props.state} />
+        )}
+      </div>
+    </>
   )
 }

--- a/src/serlo-editor/plugins/serlo-template-plugins/video.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/video.tsx
@@ -36,15 +36,15 @@ function VideoTypeEditor(props: EditorPluginProps<VideoTypePluginState>) {
 
   return (
     <>
-      {props.renderIntoSideToolbar(
+      <div className="absolute right-0 -mt-20 mr-side">
         <ContentLoaders
           id={id.value}
           currentRevision={revision.value}
           onSwitchRevision={replaceOwnState}
           entityType={UuidType.Video}
         />
-      )}
-      <h1 className="serlo-h1">
+      </div>
+      <h1 className="serlo-h1 mt-32">
         {props.editable ? (
           <input
             className={headerInputClasses}

--- a/src/serlo-editor/types/internal__plugin.ts
+++ b/src/serlo-editor/types/internal__plugin.ts
@@ -128,7 +128,4 @@ export interface EditorPluginProps<
 
   // Ref for the wrapping SubDocument div
   containerRef?: React.RefObject<HTMLDivElement>
-
-  // Allows the plugin to render buttons into the side toolbar (where the drag is)
-  renderIntoSideToolbar(children: React.ReactNode): React.ReactNode
 }


### PR DESCRIPTION
Adds revision loader button on top and removes old side toolbar button (and also the long line next to all editor content).

<img width="836" alt="image" src="https://github.com/serlo/frontend/assets/1258870/f8beeecc-f9db-4aec-b451-37a0ee2c55f1">
