### PR TITLE
Remove nested anchor/link tags

### DIFF
--- a/src/components/content/link.tsx
+++ b/src/components/content/link.tsx
@@ -14,6 +14,7 @@ export interface LinkProps {
   forceNoCSR?: boolean //
   unreviewed?: boolean // e.g. user profiles or comments
   title?: string
+  onClick?: () => void
 }
 
 // imported from cf worker redirects.ts
@@ -52,6 +53,7 @@ function InternalLink({
   className,
   noExternalIcon,
   forceNoCSR,
+  onClick,
   unreviewed,
   ref,
   title,
@@ -101,7 +103,7 @@ function InternalLink({
 
   function renderEmptyLink() {
     return (
-      <a className={className} ref={ref} title={title}>
+      <a className={className} ref={ref} title={title} onClick={onClick}>
         {children}
       </a>
     )
@@ -117,6 +119,7 @@ function InternalLink({
         rel={openBlank ? 'ugc nofollow noreferrer' : undefined}
         target={openBlank || isContentOnly ? '_blank' : undefined}
         title={title}
+        onClick={onClick}
       >
         {children}
         {isExternal && !noExternalIcon && (
@@ -136,6 +139,7 @@ function InternalLink({
         href={_href}
         className={clsx(className, 'serlo-link')}
         title={title}
+        onClick={onClick}
       >
         {children}
       </NextLink>

--- a/src/components/user-tools/edit-or-invite/invite-modal.tsx
+++ b/src/components/user-tools/edit-or-invite/invite-modal.tsx
@@ -39,15 +39,12 @@ export function InviteModal({ isOpen, onClose, type }: InviteModalProps) {
       <p className="serlo-p mb-0 mt-24 border-t-[1px] pt-8 text-base">
         {replacePlaceholders(modalStrings.psText, {
           link: (
-            <a onClick={onClose}>
-              <Link
-                href={
-                  lang === 'de' ? '/community' : footerData.participationHref
-                }
-              >
-                {modalStrings.psLinkText}
-              </Link>
-            </a>
+            <Link
+              href={lang === 'de' ? '/community' : footerData.participationHref}
+              onClick={onClose}
+            >
+              {modalStrings.psLinkText}
+            </Link>
           ),
         })}
       </p>
@@ -57,27 +54,26 @@ export function InviteModal({ isOpen, onClose, type }: InviteModalProps) {
   function renderButtons() {
     return (
       <>
-        {' '}
-        <a
+        <Link
+          className="serlo-button-blue"
+          href={loginUrl}
           onClick={() => {
             submitEvent('invite2edit-click-login-' + type)
             onClose()
           }}
         >
-          <Link className="serlo-button-blue" href={loginUrl}>
-            {modalStrings.loginButton}
-          </Link>
-        </a>
-        <a
+          {modalStrings.loginButton}
+        </Link>
+        <Link
+          className="serlo-button-green ml-4"
+          href={registrationUrl}
           onClick={() => {
             submitEvent('invite2edit-click-register-' + type)
             onClose()
           }}
         >
-          <Link className="serlo-button-green ml-4" href={registrationUrl}>
-            {modalStrings.registerButton}
-          </Link>
-        </a>
+          {modalStrings.registerButton}
+        </Link>
       </>
     )
   }


### PR DESCRIPTION
I was receiving a really cryptic warning in development

```
client.js:1 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    at a
    at LinkComponent (webpack-internal:///./node_modules/next/dist/client/link.js:105:19)
    at _c (webpack-internal:///./src/components/content/link.tsx:45:12)
    at a
    at p
    at div
    at div
    at ModalPortal (webpack-internal:///./node_modules/react-modal/lib/components/ModalPortal.js:79:5)
    at Modal (webpack-internal:///./node_modules/react-modal/lib/components/Modal.js:73:5)
    at ModalWithCloseButton (webpack-internal:///./src/components/modal-with-close-button.tsx:51:11)
    at InviteModal (webpack-internal:///./src/components/user-tools/edit-or-invite/invite-modal.tsx:27:11)
    at LoadableComponent (webpack-internal:///./node_modules/next/dist/shared/lib/loadable.js:113:9)
    at EditOrInvite (webpack-internal:///./src/components/user-tools/edit-or-invite/edit-or-invite.tsx:44:11)
    at LoadableComponent (webpack-internal:///./node_modules/next/dist/shared/lib/loadable.js:113:9)
```

I found the invite-modal.tsx to be the culprit. Please test that I didn't break any behavior 