### PR TITLE
fix(serlo-table): restore switch image cell to text cell button

### DIFF
--- a/src/serlo-editor/plugins/image/index.ts
+++ b/src/serlo-editor/plugins/image/index.ts
@@ -71,8 +71,7 @@ export function createImagePlugin(
       return (
         (!serializedState.src.value || isTempFile(serializedState.src.value)) &&
         (!serializedState.link.defined || !serializedState.link.href.value) &&
-        (!serializedState.alt.defined || !serializedState.alt.value) &&
-        (!serializedState.caption.defined || !serializedState.caption.get())
+        (!serializedState.alt.defined || !serializedState.alt.value)
       )
     },
   }

--- a/src/serlo-editor/plugins/serlo-table/cell-switch-button.tsx
+++ b/src/serlo-editor/plugins/serlo-table/cell-switch-button.tsx
@@ -1,0 +1,54 @@
+import { faImages, faParagraph } from '@fortawesome/free-solid-svg-icons'
+
+import { FaIcon } from '@/components/fa-icon'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { ChildStateType } from '@/serlo-editor/plugin/child'
+import {
+  selectDocument,
+  selectIsFocused,
+  useAppSelector,
+} from '@/serlo-editor/store'
+import { StateTypesReturnType } from '@/serlo-editor/types/internal__plugin-state'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
+
+interface CellSwitchButtonProps {
+  cell: StateTypesReturnType<{
+    content: ChildStateType<string, unknown>
+  }>
+  isHead: boolean
+  isClear: boolean
+}
+
+export function CellSwitchButton({
+  cell,
+  isHead,
+  isClear,
+}: CellSwitchButtonProps) {
+  const tableStrings = useEditorStrings().plugins.serloTable
+
+  const isFocused = useAppSelector((state) =>
+    selectIsFocused(state, cell.content.id)
+  )
+  const document = useAppSelector((state) =>
+    selectDocument(state, cell.content.id)
+  )
+
+  if (!document || isHead || !isFocused || !isClear) return null
+
+  const isImage = document.plugin === EditorPluginType.Image
+
+  return (
+    <button
+      onMouseDown={(e) => e.stopPropagation()} // hack to stop editor from stealing events
+      onClick={() => {
+        cell.content.replace(
+          isImage ? EditorPluginType.Text : EditorPluginType.Image
+        )
+      }}
+      className="serlo-button-light absolute m-2 block py-0.5 text-sm"
+      title={isImage ? tableStrings.convertToText : tableStrings.convertToImage}
+    >
+      <FaIcon icon={isImage ? faParagraph : faImages} />
+    </button>
+  )
+}

--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -65,6 +65,7 @@ export function SerloTableEditor(props: SerloTableProps) {
             {cell.content.render({
               config: {
                 isInlineChildEditor: true,
+                placeholder: '',
                 updateHack,
               },
             })}

--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -1,13 +1,9 @@
-import {
-  faCirclePlus,
-  faImages,
-  faParagraph,
-  faTrashCan,
-} from '@fortawesome/free-solid-svg-icons'
+import { faCirclePlus, faTrashCan } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
-import { KeyboardEvent } from 'react'
+import { KeyboardEvent, useState } from 'react'
 
 import type { SerloTableProps } from '.'
+import { CellSwitchButton } from './cell-switch-button'
 import { useAreImagesDisabledInTable } from './contexts/are-images-disabled-in-table-context'
 import { SerloTableRenderer, TableType } from './renderer'
 import { SerloTableToolbar } from './toolbar'
@@ -15,18 +11,13 @@ import { getTableType } from './utils/get-table-type'
 import { TextEditorConfig } from '../text'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
-import { ChildStateType, StateTypesReturnType } from '@/serlo-editor/plugin'
 import {
   store,
   selectFocused,
   selectIsDocumentEmpty,
   focus,
-  selectDocument,
-  focusNext,
-  focusPrevious,
   useAppSelector,
   useAppDispatch,
-  selectFocusTree,
 } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
@@ -45,6 +36,8 @@ const newCell = { content: { plugin: EditorPluginType.Text } }
 
 export function SerloTableEditor(props: SerloTableProps) {
   const { rows } = props.state
+
+  const [updateHack, setUpdateHack] = useState(0)
 
   const dispatch = useAppDispatch()
   const focusedElement = useAppSelector(selectFocused)
@@ -69,12 +62,12 @@ export function SerloTableEditor(props: SerloTableProps) {
       return {
         cells: row.columns.map((cell) => (
           <div className="min-h-[2rem] pr-2" key={cell.content.id}>
-            {!selectIsDocumentEmpty(store.getState(), cell.content.id) &&
-              cell.content.render({
-                config: {
-                  isInlineChildEditor: true,
-                },
-              })}
+            {cell.content.render({
+              config: {
+                isInlineChildEditor: true,
+                updateHack,
+              },
+            })}
           </div>
         )),
       }
@@ -108,12 +101,6 @@ export function SerloTableEditor(props: SerloTableProps) {
     )
   }
 
-  function updateHack() {
-    const focusTree = selectFocusTree(store.getState())
-    dispatch(focusNext(focusTree))
-    dispatch(focusPrevious(focusTree))
-  }
-
   function renderActiveCellsIntoObject() {
     return rows.map((row, rowIndex) => {
       return {
@@ -133,9 +120,9 @@ export function SerloTableEditor(props: SerloTableProps) {
           const onKeyUpHandler = (e: KeyboardEvent<HTMLDivElement>) => {
             // hack: redraw when isEmpty changes. (onKeyUp bc. keyDown is captured for some keys)
             if (e.key === 'Delete' || e.key === 'Backspace') {
-              if (!isClear) updateHack()
+              if (!isClear) setUpdateHack((count) => count + 1)
             } else {
-              if (isClear) updateHack()
+              if (isClear) setUpdateHack((count) => count + 1)
             }
           }
           const onKeyDownHandler = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -167,9 +154,13 @@ export function SerloTableEditor(props: SerloTableProps) {
                     : cellTextFormattingOptions,
                 } as TextEditorConfig,
               })}
-              {props.config.allowImageInTableCells && !areImagesDisabled
-                ? renderSwitchButton(cell, isHead, isClear)
-                : null}
+              {props.config.allowImageInTableCells && !areImagesDisabled ? (
+                <CellSwitchButton
+                  cell={cell}
+                  isHead={isHead}
+                  isClear={isClear}
+                />
+              ) : null}
               {/* hack: make sure we capture most clicks in cells */}
               <style jsx global>{`
                 .serlo-td,
@@ -186,38 +177,6 @@ export function SerloTableEditor(props: SerloTableProps) {
         }),
       }
     })
-  }
-
-  function renderSwitchButton(
-    cell: StateTypesReturnType<{
-      content: ChildStateType<string, unknown>
-    }>,
-    isHead: boolean,
-    isClear: boolean
-  ) {
-    const isFocused = cell.content.id === focusedElement
-    const isImage =
-      selectDocument(store.getState(), cell.content.id)?.plugin ===
-      EditorPluginType.Image
-
-    if (isHead || !isFocused || !isClear) return null
-
-    return (
-      <button
-        onMouseDown={(e) => e.stopPropagation()} // hack to stop editor from stealing events
-        onClick={() => {
-          cell.content.replace(
-            isImage ? EditorPluginType.Text : EditorPluginType.Image
-          )
-        }}
-        className="serlo-button-light absolute m-2 block py-0.5 text-sm"
-        title={
-          isImage ? tableStrings.convertToText : tableStrings.convertToImage
-        }
-      >
-        <FaIcon icon={isImage ? faParagraph : faImages} />
-      </button>
-    )
   }
 
   function renderInlineNav(rowIndex: number, colIndex: number) {


### PR DESCRIPTION
Changes:
- Image is now considered empty if it only has caption text and no actual image
- The button for switching the cell between Image and Text plugins extracted into a component file
- The`updateHack` for showing the button on KeyUp changed, so that it doesn't change focus, but instead just re-renders the `SerloTableEditor` component (result: less code, less dependency imports, less re-renders)

Caveats:
- The "switch image cell to text cell" button is not shown when caption is focused, as in that case, the cell is technically not focused (because cell === Image plugin in this case, and caption's Text plugin is focused).