### PR TITLE
chore(next): activate fallbackNodePolyfills

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -44,9 +44,7 @@ module.exports = withBundleAnalyzer({
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
   transpilePackages: ['ramda'], // context: https://github.com/vercel/next.js/issues/40183
-  /*experimental: {
-    fallbackNodePolyfills: false,
-  },*/ // breaks styled-components unfortunately, see https://github.com/serlo/frontend/issues/2010
+  experimental: { fallbackNodePolyfills: false },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Now that we do not use styled-components any more this might work.
(And I think we don't use [tmp-serlo-legacy-editor-to-editor](https://github.com/Entkenntnis/tmp-serlo-legacy-editor-to-editor) and more)

What is fallbackNodePolyfills: https://nextjs.org/blog/next-12-3#other-improvements
Old issue on why we could not use it: https://github.com/serlo/frontend/issues/2010


(edit: oh wow, bundle size difference is quite underwhelming this time around…)