### PR TITLE
fix(plugin-text): display suggestions on add plugin button

### DIFF
--- a/src/serlo-editor/editor-ui/hover-overlay.tsx
+++ b/src/serlo-editor/editor-ui/hover-overlay.tsx
@@ -1,13 +1,15 @@
 import { createRef, useEffect, useState, ReactNode, RefObject } from 'react'
+import { BaseSelection } from 'slate'
 
 import { tw } from '@/helper/tw'
 
 export type HoverPosition = 'above' | 'below'
 
-interface HoverOverlayProps {
+export interface HoverOverlayProps {
   children: ReactNode
   position: HoverPosition
   anchor?: RefObject<HTMLElement>
+  selection?: BaseSelection
 }
 
 export function HoverOverlay(props: HoverOverlayProps) {
@@ -16,7 +18,7 @@ export function HoverOverlay(props: HoverOverlayProps) {
 
   const windowSelection = window.getSelection()
 
-  const { anchor, children } = props
+  const { anchor, children, selection } = props
 
   useEffect(() => {
     if (!overlay.current) return
@@ -53,7 +55,7 @@ export function HoverOverlay(props: HoverOverlayProps) {
       ),
       0
     )}px`
-  }, [overlay, anchor, positionAbove, windowSelection])
+  }, [overlay, anchor, positionAbove, windowSelection, selection])
 
   return (
     <div

--- a/src/serlo-editor/editor-ui/slate-hover-overlay.tsx
+++ b/src/serlo-editor/editor-ui/slate-hover-overlay.tsx
@@ -1,0 +1,15 @@
+import { useSlate } from 'slate-react'
+
+import { HoverOverlay, type HoverOverlayProps } from './hover-overlay'
+
+/**
+ * The vanilla `HoverOverlay` component relies on `window.getSelection()` for positioning.
+ * When Slate changes this selection, `HoverOverlay` doesn't re-render. This component is
+ * a wrapper that makes sure that `HoverOverlay` re-renders on every Slate selection change.
+ * Can't use `useSlate` in `HoverOverlay`, because `HoverOverlay` is also used outside of Slate.
+ */
+export function SlateHoverOverlay(props: HoverOverlayProps) {
+  const { selection } = useSlate()
+
+  return <HoverOverlay {...props} selection={selection} />
+}

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -21,9 +21,9 @@ import {
 import { isSelectionAtEnd, isSelectionAtStart } from '../utils/selection'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { showToastNotice } from '@/helper/show-toast-notice'
-import { HoverOverlay } from '@/serlo-editor/editor-ui'
 import { useFormattingOptions } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options'
 import { isSelectionWithinList } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/list'
+import { SlateHoverOverlay } from '@/serlo-editor/editor-ui/slate-hover-overlay'
 import type { EditorPluginProps } from '@/serlo-editor/plugin'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
 import {
@@ -418,9 +418,9 @@ export function TextEditor(props: TextEditorProps) {
       <LinkControls serloLinkSearch={config.serloLinkSearch} />
 
       {showSuggestions && (
-        <HoverOverlay position="below">
+        <SlateHoverOverlay position="below">
           <Suggestions {...suggestionsProps} />
-        </HoverOverlay>
+        </SlateHoverOverlay>
       )}
     </Slate>
   )


### PR DESCRIPTION
Bug: When creating a new plugin, suggestions don't appear.

This was probably introduced by this PR: https://github.com/serlo/frontend/pull/2696

Fix: A wrapper component for `HoverOverlay`, that makes sure it re-renders on Slate selection change.