### PR TITLE
refactor(text-plugin): move callbacks into hooks

### DIFF
--- a/src/data/en/index.ts
+++ b/src/data/en/index.ts
@@ -826,7 +826,8 @@ export const loggedInData = {
         text: {
           title: 'Text',
           description: 'Compose content using rich text and math formulas.',
-          placeholder: 'Write something or add elements with \u2295.',
+          placeholder: 'Write something or add element:',
+          addButtonExplanation: 'Click to insert new element',
           quote: 'Quote',
           setColor: 'Set color',
           resetColor: 'Reset color',

--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -37,10 +37,12 @@ export function TextEditor(props: TextEditorProps) {
   const suggestions = useSuggestions({ editor, id, editable, focused })
   const { showSuggestions, suggestionsProps } = suggestions
 
-  const { handleRenderElement, handleRenderLeaf } = useSlateRenderHandlers(
+  const { handleRenderElement, handleRenderLeaf } = useSlateRenderHandlers({
+    editor,
     focused,
-    config.placeholder
-  )
+    placeholder: config.placeholder,
+    id,
+  })
   const { previousSelection, handleEditorChange } = useEditorChange({
     editor,
     state,

--- a/src/serlo-editor/plugins/text/components/text-leaf-with-placeholder.tsx
+++ b/src/serlo-editor/plugins/text/components/text-leaf-with-placeholder.tsx
@@ -1,16 +1,20 @@
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { RenderLeafProps } from 'slate-react'
 
 import { TextLeafRenderer } from './text-leaf-renderer'
+import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
 
 export function TextLeafWithPlaceholder(
   props: {
     customPlaceholder?: string
+    onAdd?: () => void
   } & RenderLeafProps
 ) {
-  const { attributes, customPlaceholder, leaf } = props
+  const { attributes, customPlaceholder, leaf, onAdd } = props
 
-  const placeholderString = useEditorStrings().plugins.text.placeholder
+  const textStrings = useEditorStrings().plugins.text
 
   const leafElement = (
     <span {...attributes}>
@@ -26,7 +30,20 @@ export function TextLeafWithPlaceholder(
         className="pointer-events-none absolute block w-full text-gray-300 [user-select:none]"
         contentEditable={false}
       >
-        {customPlaceholder ?? placeholderString}
+        {customPlaceholder ?? textStrings.placeholder}{' '}
+        {onAdd ? (
+          <button
+            className="serlo-button-editor-secondary serlo-tooltip-trigger pointer-events-auto z-30 h-8 w-8"
+            onClick={onAdd}
+          >
+            <EditorTooltip
+              text={textStrings.addButtonExplanation}
+              hotkeys="/"
+              className="-left-[200%]"
+            />
+            <FaIcon icon={faPlus} />
+          </button>
+        ) : null}
       </span>
       {leafElement}
     </>

--- a/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -1,0 +1,194 @@
+import isHotkey from 'is-hotkey'
+import { useCallback } from 'react'
+import {
+  Editor as SlateEditor,
+  Range,
+  Node,
+  Transforms,
+  BaseRange,
+} from 'slate'
+
+import { useTextConfig } from './use-text-config'
+import type { TextEditorProps } from '../components/text-editor'
+import {
+  emptyDocumentFactory,
+  mergePlugins,
+  sliceNodesAfterSelection,
+} from '../utils/document'
+import { isSelectionAtEnd, isSelectionAtStart } from '../utils/selection'
+import { useFormattingOptions } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options'
+import { isSelectionWithinList } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/list'
+import {
+  focusNext,
+  focusPrevious,
+  insertPluginChildAfter,
+  selectDocument,
+  selectFocusTree,
+  selectMayManipulateSiblings,
+  selectParent,
+  store,
+  useAppDispatch,
+} from '@/serlo-editor/store'
+
+interface UseEditorChangeArgs {
+  config: ReturnType<typeof useTextConfig>
+  editor: SlateEditor
+  id: string
+  showSuggestions: boolean
+  previousSelection: React.MutableRefObject<BaseRange | null>
+  state: TextEditorProps['state']
+}
+
+export const useEditableKeydownHandler = (args: UseEditorChangeArgs) => {
+  const { showSuggestions, config, editor, id, state, previousSelection } = args
+
+  const dispatch = useAppDispatch()
+  const textFormattingOptions = useFormattingOptions(config.formattingOptions)
+
+  return useCallback(
+    (event: React.KeyboardEvent) => {
+      // If linebreaks are disabled in the config, prevent any enter key handling
+      if (config.noLinebreaks && event.key === 'Enter') {
+        event.preventDefault()
+      }
+
+      // Handle specific keyboard commands
+      // (only if selection is collapsed and suggestions are not shown)
+      const { selection } = editor
+      if (selection && Range.isCollapsed(selection) && !showSuggestions) {
+        const isListActive = isSelectionWithinList(editor)
+
+        // Special handler for links. If you move right and end up at the right edge of a link,
+        // this handler unselects the link, so you can write normal text behind it.
+        if (isHotkey('right', event)) {
+          const { path, offset } = selection.focus
+          const node = Node.get(editor, path)
+          const parent = Node.parent(editor, path)
+
+          if (node && parent) {
+            if (Object.hasOwn(parent, 'type') && parent.type === 'a') {
+              if (
+                Object.hasOwn(node, 'text') &&
+                node.text.length - 1 <= offset
+              ) {
+                Transforms.move(editor)
+                Transforms.move(editor, { unit: 'offset' })
+                event.preventDefault()
+              }
+            }
+          }
+        }
+
+        // Special handler for links. Handle linebreaks while editing a link text
+        if (event.key === 'Enter') {
+          const { path, offset } = selection.focus
+          const node = Node.get(editor, path)
+          const parent = Node.parent(editor, path)
+
+          if (node && parent) {
+            if (
+              Object.hasOwn(parent, 'type') &&
+              parent.type === 'a' &&
+              Object.hasOwn(node, 'text')
+            ) {
+              // cursor is on left of link (but still on link): normal line break
+              if (offset === 0) return
+
+              // cursor is right of link(but still on link): line break without continuing link
+              // normal text in new line
+              event.preventDefault()
+              if (node.text.length === offset) Transforms.move(editor)
+              // cursor is somewhere inside link: no line break, no action
+              else return false
+            }
+          }
+        }
+
+        // Create a new Slate instance on "enter" key
+        if (isHotkey('enter', event) && !isListActive) {
+          const document = selectDocument(store.getState(), id)
+          if (!document) return
+
+          const mayManipulateSiblings = selectMayManipulateSiblings(
+            store.getState(),
+            id
+          )
+          if (!mayManipulateSiblings) return
+
+          const parent = selectParent(store.getState(), id)
+          if (!parent) return
+
+          event.preventDefault()
+
+          const slicedNodes = sliceNodesAfterSelection(editor)
+          setTimeout(() => {
+            dispatch(
+              insertPluginChildAfter({
+                parent: parent.id,
+                sibling: id,
+                document: {
+                  plugin: document.plugin,
+                  state: slicedNodes || emptyDocumentFactory().value,
+                },
+              })
+            )
+          })
+        }
+
+        // Merge with previous Slate instance on "backspace" key,
+        // or merge with next Slate instance on "delete" key
+        const isBackspaceAtStart =
+          isHotkey('backspace', event) && isSelectionAtStart(editor, selection)
+        const isDeleteAtEnd =
+          isHotkey('delete', event) && isSelectionAtEnd(editor, selection)
+        if ((isBackspaceAtStart || isDeleteAtEnd) && !isListActive) {
+          event.preventDefault()
+
+          // Get direction of merge
+          const direction = isBackspaceAtStart ? 'previous' : 'next'
+
+          // Merge plugins within Slate and get the merge value
+          const newValue = mergePlugins(direction, editor, store, id)
+
+          // Update Redux document state with the new value
+          if (newValue) {
+            state.set({ value: newValue, selection }, ({ value }) => ({
+              value,
+              selection: previousSelection.current,
+            }))
+          }
+        }
+
+        // Jump to previous/next plugin on pressing "up"/"down" arrow keys at start/end of text block
+        const isUpArrowAtStart =
+          isHotkey('up', event) && isSelectionAtStart(editor, selection)
+        if (isUpArrowAtStart) {
+          event.preventDefault()
+          const focusTree = selectFocusTree(store.getState())
+          dispatch(focusPrevious(focusTree))
+        }
+        const isDownArrowAtEnd =
+          isHotkey('down', event) && isSelectionAtEnd(editor, selection)
+        if (isDownArrowAtEnd) {
+          event.preventDefault()
+          const focusTree = selectFocusTree(store.getState())
+          dispatch(focusNext(focusTree))
+        }
+      }
+
+      textFormattingOptions.handleHotkeys(event, editor)
+      textFormattingOptions.handleMarkdownShortcuts(event, editor)
+      textFormattingOptions.handleListsShortcuts(event, editor)
+    },
+    [
+      config.noLinebreaks,
+      dispatch,
+      editor,
+      id,
+      previousSelection,
+      showSuggestions,
+      state,
+      textFormattingOptions,
+    ]
+  )
+}

--- a/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -30,7 +30,7 @@ import {
   useAppDispatch,
 } from '@/serlo-editor/store'
 
-interface UseEditorChangeArgs {
+interface UseEditableKeydownHandlerArgs {
   config: ReturnType<typeof useTextConfig>
   editor: SlateEditor
   id: string
@@ -39,7 +39,9 @@ interface UseEditorChangeArgs {
   state: TextEditorProps['state']
 }
 
-export const useEditableKeydownHandler = (args: UseEditorChangeArgs) => {
+export const useEditableKeydownHandler = (
+  args: UseEditableKeydownHandlerArgs
+) => {
   const { showSuggestions, config, editor, id, state, previousSelection } = args
 
   const dispatch = useAppDispatch()

--- a/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -41,8 +41,7 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       // Iterate through all plugins and try to process clipboard data
       const plugins = editorPlugins.getAllWithData()
       let media
-      for (let i = 0; i < plugins.length; i++) {
-        const { plugin, type } = plugins[i]
+      for (const { plugin, type } of plugins) {
         const state = plugin.onFiles?.(files) ?? plugin.onText?.(text)
         if (state?.state) {
           media = { state: state.state as unknown, pluginType: type }

--- a/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -26,9 +26,8 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
 
   return useCallback(
     (event: React.ClipboardEvent) => {
-      const storeState = store.getState()
-
       // Exit if unable to select document data or if not allowed to manipulate siblings
+      const storeState = store.getState()
       const document = selectDocument(storeState, id)
       const mayManipulateSiblings = selectMayManipulateSiblings(storeState, id)
       if (!document || !mayManipulateSiblings) return
@@ -39,9 +38,8 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       if (!files.length && !text) return
 
       // Iterate through all plugins and try to process clipboard data
-      const plugins = editorPlugins.getAllWithData()
       let media
-      for (const { plugin, type } of plugins) {
+      for (const { plugin, type } of editorPlugins.getAllWithData()) {
         const state = plugin.onFiles?.(files) ?? plugin.onText?.(text)
         if (state?.state) {
           media = { state: state.state as unknown, pluginType: type }
@@ -62,8 +60,7 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       }
 
       // Insert the plugin with appropriate type and state
-      const { pluginType, state } = media
-      insertPlugin({ pluginType, editor, id, dispatch, state })
+      insertPlugin({ editor, id, dispatch, ...media })
     },
     [dispatch, editor, id, textStrings]
   )

--- a/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -26,16 +26,16 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
 
   return useCallback(
     (event: React.ClipboardEvent) => {
+      // Exit if no files or text in clipboard data
+      const files = Array.from(event.clipboardData.files)
+      const text = event.clipboardData.getData('text')
+      if (!files.length && !text) return
+
       // Exit if unable to select document data or if not allowed to manipulate siblings
       const storeState = store.getState()
       const document = selectDocument(storeState, id)
       const mayManipulateSiblings = selectMayManipulateSiblings(storeState, id)
       if (!document || !mayManipulateSiblings) return
-
-      // Exit if no files or text in clipboard data
-      const files = Array.from(event.clipboardData.files)
-      const text = event.clipboardData.getData('text')
-      if (!files.length && !text) return
 
       // Iterate through all plugins and try to process clipboard data
       let media
@@ -48,7 +48,7 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       }
 
       // Exit if no media was processed from clipboard data
-      if (media?.state === undefined) return
+      if (!media) return
 
       // Prevent URL being pasted as text in the text plugin
       event.preventDefault()

--- a/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -1,0 +1,143 @@
+import { useCallback } from 'react'
+import { Editor as SlateEditor, Node } from 'slate'
+
+import { sliceNodesAfterSelection } from '../utils/document'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { showToastNotice } from '@/helper/show-toast-notice'
+import { isSelectionWithinList } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/list'
+import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
+import {
+  selectDocument,
+  selectParent,
+  insertPluginChildAfter,
+  selectMayManipulateSiblings,
+  runReplaceDocumentSaga,
+  useAppDispatch,
+  store,
+} from '@/serlo-editor/store'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
+
+interface UseEditablePasteHandlerArgs {
+  editor: SlateEditor
+  id: string
+}
+
+export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
+  const { editor, id } = args
+
+  const dispatch = useAppDispatch()
+  const textStrings = useEditorStrings().plugins.text
+
+  return useCallback(
+    (event: React.ClipboardEvent) => {
+      const isListActive = isSelectionWithinList(editor)
+
+      const document = selectDocument(store.getState(), id)
+      if (!document) return
+
+      const mayManipulateSiblings = selectMayManipulateSiblings(
+        store.getState(),
+        id
+      )
+      if (!mayManipulateSiblings) return
+
+      const parentPluginType = document.plugin
+
+      const files = Array.from(event.clipboardData.files)
+      const text = event.clipboardData.getData('text')
+
+      // Handle pasted images or image URLs
+      if (files?.length > 0 || text) {
+        const imagePlugin = editorPlugins.getByType(EditorPluginType.Image)
+        if (!imagePlugin) return
+
+        const imagePluginState =
+          imagePlugin.onFiles?.(files) ?? imagePlugin.onText?.(text)
+
+        if (imagePluginState !== undefined) {
+          if (isListActive) {
+            showToastNotice(textStrings.noElementPasteInLists, 'warning')
+            return
+          }
+
+          insertPlugin(EditorPluginType.Image, imagePluginState)
+          return
+        }
+      }
+
+      if (text) {
+        // Handle pasted video URLs
+        const videoPluginState = editorPlugins
+          .getByType(EditorPluginType.Video)
+          ?.onText?.(text)
+        if (videoPluginState !== undefined) {
+          event.preventDefault()
+
+          if (isListActive) {
+            showToastNotice(textStrings.noElementPasteInLists, 'warning')
+            return
+          }
+
+          insertPlugin(EditorPluginType.Video, videoPluginState)
+          return
+        }
+
+        // Handle pasted geogebra URLs
+        const geogebraPluginState = editorPlugins
+          .getByType(EditorPluginType.Geogebra)
+          ?.onText?.(text)
+        if (geogebraPluginState !== undefined) {
+          event.preventDefault()
+
+          if (isListActive) {
+            showToastNotice(textStrings.noElementPasteInLists, 'warning')
+            return
+          }
+
+          insertPlugin(EditorPluginType.Geogebra, geogebraPluginState)
+          return
+        }
+      }
+
+      function insertPlugin(
+        pluginType: string,
+        { state }: { state?: unknown }
+      ) {
+        const isEditorEmpty = Node.string(editor) === ''
+
+        if (mayManipulateSiblings && isEditorEmpty) {
+          dispatch(runReplaceDocumentSaga({ id, pluginType, state }))
+          return
+        }
+
+        const parent = selectParent(store.getState(), id)
+        if (!parent) return
+
+        const slicedNodes = sliceNodesAfterSelection(editor)
+
+        setTimeout(() => {
+          if (slicedNodes) {
+            dispatch(
+              insertPluginChildAfter({
+                parent: parent.id,
+                sibling: id,
+                document: {
+                  plugin: parentPluginType,
+                  state: slicedNodes,
+                },
+              })
+            )
+          }
+          dispatch(
+            insertPluginChildAfter({
+              parent: parent.id,
+              sibling: id,
+              document: { plugin: pluginType, state },
+            })
+          )
+        })
+      }
+    },
+    [dispatch, editor, id, textStrings]
+  )
+}

--- a/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -12,7 +12,6 @@ import {
   useAppDispatch,
   store,
 } from '@/serlo-editor/store'
-import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 interface UseEditablePasteHandlerArgs {
   editor: SlateEditor
@@ -27,93 +26,45 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
 
   return useCallback(
     (event: React.ClipboardEvent) => {
-      const isListActive = isSelectionWithinList(editor)
+      const storeState = store.getState()
 
-      const document = selectDocument(store.getState(), id)
-      if (!document) return
+      // Exit if unable to select document data or if not allowed to manipulate siblings
+      const document = selectDocument(storeState, id)
+      const mayManipulateSiblings = selectMayManipulateSiblings(storeState, id)
+      if (!document || !mayManipulateSiblings) return
 
-      const mayManipulateSiblings = selectMayManipulateSiblings(
-        store.getState(),
-        id
-      )
-      if (!mayManipulateSiblings) return
-
+      // Exit if no files or text in clipboard data
       const files = Array.from(event.clipboardData.files)
       const text = event.clipboardData.getData('text')
+      if (!files.length && !text) return
 
-      // Handle pasted images or image URLs
-      if (files?.length > 0 || text) {
-        const imagePlugin = editorPlugins.getByType(EditorPluginType.Image)
-        if (!imagePlugin) return
-
-        const imagePluginState =
-          imagePlugin.onFiles?.(files) ?? imagePlugin.onText?.(text)
-
-        if (imagePluginState !== undefined) {
-          if (isListActive) {
-            showToastNotice(textStrings.noElementPasteInLists, 'warning')
-            return
-          }
-
-          insertPlugin({
-            pluginType: EditorPluginType.Image,
-            editor,
-            store,
-            id,
-            dispatch,
-            state: imagePluginState.state,
-          })
-          return
+      // Iterate through all plugins and try to process clipboard data
+      const plugins = editorPlugins.getAllWithData()
+      let media
+      for (let i = 0; i < plugins.length; i++) {
+        const { plugin, type } = plugins[i]
+        const state = plugin.onFiles?.(files) ?? plugin.onText?.(text)
+        if (state?.state) {
+          media = { state: state.state as unknown, pluginType: type }
+          break
         }
       }
 
-      if (text) {
-        // Handle pasted video URLs
-        const videoPluginState = editorPlugins
-          .getByType(EditorPluginType.Video)
-          ?.onText?.(text)
-        if (videoPluginState !== undefined) {
-          event.preventDefault()
+      // Exit if no media was processed from clipboard data
+      if (media?.state === undefined) return
 
-          if (isListActive) {
-            showToastNotice(textStrings.noElementPasteInLists, 'warning')
-            return
-          }
+      // Prevent URL being pasted as text in the text plugin
+      event.preventDefault()
 
-          insertPlugin({
-            pluginType: EditorPluginType.Video,
-            editor,
-            store,
-            id,
-            dispatch,
-            state: videoPluginState.state,
-          })
-          return
-        }
-
-        // Handle pasted geogebra URLs
-        const geogebraPluginState = editorPlugins
-          .getByType(EditorPluginType.Geogebra)
-          ?.onText?.(text)
-        if (geogebraPluginState !== undefined) {
-          event.preventDefault()
-
-          if (isListActive) {
-            showToastNotice(textStrings.noElementPasteInLists, 'warning')
-            return
-          }
-
-          insertPlugin({
-            pluginType: EditorPluginType.Geogebra,
-            editor,
-            store,
-            id,
-            dispatch,
-            state: geogebraPluginState.state,
-          })
-          return
-        }
+      // Prevent pasting media when selection is within a list
+      if (isSelectionWithinList(editor)) {
+        showToastNotice(textStrings.noElementPasteInLists, 'warning')
+        return
       }
+
+      // Insert the plugin with appropriate type and state
+      const { pluginType, state } = media
+      insertPlugin({ pluginType, editor, id, dispatch, state })
     },
     [dispatch, editor, id, textStrings]
   )

--- a/src/serlo-editor/plugins/text/hooks/use-slate-render-handlers.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-slate-render-handlers.tsx
@@ -1,14 +1,30 @@
-import { createElement, useCallback } from 'react'
-import { RenderElementProps, RenderLeafProps } from 'slate-react'
+import { createElement, useCallback, useMemo } from 'react'
+import { Editor as SlateEditor } from 'slate'
+import { ReactEditor, RenderElementProps, RenderLeafProps } from 'slate-react'
 
 import { MathElement } from '../components/math-element'
 import { TextLeafWithPlaceholder } from '../components/text-leaf-with-placeholder'
 import { ListElementType } from '../types/text-editor'
+import { selectMayManipulateSiblings, store } from '@/serlo-editor/store'
 
-export const useSlateRenderHandlers = (
-  focused: boolean,
+interface UseSlateRenderHandlersArgs {
+  focused: boolean
+  id: string
+  editor: SlateEditor
   placeholder?: string
-) => {
+}
+
+export const useSlateRenderHandlers = ({
+  focused,
+  id,
+  editor,
+  placeholder,
+}: UseSlateRenderHandlersArgs) => {
+  const mayManipulateSiblings = useMemo(
+    () => selectMayManipulateSiblings(store.getState(), id),
+    [id]
+  )
+
   const handleRenderElement = useCallback(
     (props: RenderElementProps) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -71,9 +87,20 @@ export const useSlateRenderHandlers = (
 
   const handleRenderLeaf = useCallback(
     (props: RenderLeafProps) => (
-      <TextLeafWithPlaceholder {...props} customPlaceholder={placeholder} />
+      <TextLeafWithPlaceholder
+        {...props}
+        customPlaceholder={placeholder}
+        onAdd={
+          mayManipulateSiblings
+            ? () => {
+                ReactEditor.focus(editor)
+                editor.insertText('/')
+              }
+            : undefined
+        }
+      />
     ),
-    [placeholder]
+    [editor, mayManipulateSiblings, placeholder]
   )
 
   return { handleRenderElement, handleRenderLeaf }

--- a/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
@@ -160,13 +160,7 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
 
     // split the text-plugin and insert selected new plugin
     setTimeout(() => {
-      insertPlugin({
-        pluginType,
-        editor,
-        store,
-        id,
-        dispatch,
-      })
+      insertPlugin({ pluginType, editor, id, dispatch })
     })
   }
 

--- a/src/serlo-editor/plugins/text/utils/insert-plugin.ts
+++ b/src/serlo-editor/plugins/text/utils/insert-plugin.ts
@@ -3,18 +3,17 @@ import { Editor as SlateEditor, Node } from 'slate'
 
 import { sliceNodesAfterSelection } from './document'
 import {
-  RootStore,
   insertPluginChildAfter,
   runReplaceDocumentSaga,
   selectDocument,
   selectMayManipulateSiblings,
   selectParent,
+  store,
 } from '@/serlo-editor/store'
 
 export interface insertPluginArgs {
   pluginType: string
   editor: SlateEditor
-  store: RootStore
   id: string
   dispatch: ThunkDispatch<unknown, unknown, Action<unknown>>
   state?: unknown
@@ -23,12 +22,11 @@ export interface insertPluginArgs {
 export function insertPlugin({
   pluginType,
   editor,
-  store,
   id,
   dispatch,
   state,
 }: insertPluginArgs) {
-  const storeState = store.getState() as unknown
+  const storeState = store.getState()
 
   const document = selectDocument(storeState, id)
   const mayManipulateSiblings = selectMayManipulateSiblings(storeState, id)


### PR DESCRIPTION
~actually pretty stupid to do this in parallel to https://github.com/serlo/frontend/pull/2733 now that I think of it 😅~

- this also reintroduces the placeholder add button that got lost in some merge
- one follow up issue here already: https://github.com/serlo/frontend/issues/2743