### PR TITLE
Fix bug that visual/latex mode is sometimes not shown in equations

### DIFF
--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -58,12 +58,31 @@ export function MathEditor(props: MathEditorProps) {
       '.toolbar-controls-target'
     )
 
-    if (!targetRef.current) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'MathEditor: Could not find toolbar-controls-target to create portal'
-      )
+    if (targetRef.current) {
+      return
     }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      'MathEditor: Could not find toolbar-controls-target to create portal'
+    )
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+          const target = document.querySelector<HTMLDivElement>(
+            '.toolbar-controls-target'
+          )
+          if (target) {
+            targetRef.current = target
+            observer.disconnect()
+          }
+        }
+      }
+    })
+
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return () => observer.disconnect()
   }, [])
 
   const isVisualMode = (visual && !hasError) || false
@@ -133,13 +152,21 @@ export function MathEditor(props: MathEditorProps) {
                 hover:bg-editor-primary-200 focus:bg-editor-primary-200 focus:outline-none
                 `}
               value={isVisualMode ? 'visual' : 'latex'}
+              data-qa="editor-plugin-toolbar-math-visual-latex-switch"
               onChange={(e) => {
                 if (hasError) setHasError(false)
                 props.onEditorChange(e.target.value === 'visual')
               }}
             >
-              <option value="visual">{mathStrings.visual}</option>
-              <option value="latex">{mathStrings.latex}</option>
+              <option
+                value="visual"
+                data-qa="editor-plugin-toolbar-math-visual"
+              >
+                {mathStrings.visual}
+              </option>
+              <option value="latex" data-qa="editor-plugin-toolbar-math-latex">
+                {mathStrings.latex}
+              </option>
             </select>
             {!disableBlock && (
               <button


### PR DESCRIPTION
Any idea why the .toolbar-controls-target is not available on first render? 

I don't like my solution of reaching for the big guns (MutationObserver), and I can refactor this within the next few days to have some proper parent-child communication, or even easier, we don't do any document.querySelector selection and instead, just attach a ref to .toolbar-controls-target and put it into React context, that children can just grab from there.
There are other solutions like adding a small timeout.

Will also add some tests and have already prepared for it, by adding some data-qa attributes.

As it's a holiday today, I'd appreciate if we can get this in quickly, so that Peter and the other authors can do their job without being annoyed.

Bug can be seen here https://www.loom.com/share/10aef34a4d2b4a70a933d671322d730d
