### PR TITLE
refactor(editor): move add row button to SubDocumentEditor

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -175,7 +175,8 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           'outline-none',
           isInlineChildEditor || isTemplatePlugin
             ? ''
-            : 'plugin-wrapper-container relative -ml-[7px] mb-6 min-h-[10px] pl-[5px]'
+            : 'plugin-wrapper-container relative -ml-[7px] mb-6 min-h-[10px] pl-[5px]',
+          isLastRowInRootRowsPlugin ? '!mb-28' : ''
         )}
         tabIndex={-1} // removing this makes selecting e.g. images impossible somehow
         onMouseDown={handleFocus}

--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -18,14 +18,26 @@ import {
   selectIsFocused,
   useAppSelector,
   useAppDispatch,
+  insertPluginChildAfter,
+  selectParent,
+  store,
+  selectMayManipulateSiblings,
+  selectIsLastRowInRootRowsPlugin,
 } from '../../store'
 import type { StateUpdater } from '../../types/internal__plugin-state'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
+import { RowSeparator } from '@/serlo-editor/plugins/rows/components/row-separator'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
   const dispatch = useAppDispatch()
   const document = useAppSelector((state) => selectDocument(state, id))
+  const mayManipulateSiblings = useAppSelector((state) =>
+    selectMayManipulateSiblings(state, id)
+  )
+  const isLastRowInRootRowsPlugin = useAppSelector((state) =>
+    selectIsLastRowInRootRowsPlugin(state, id)
+  )
 
   const focused = useAppSelector((state) => selectIsFocused(state, id))
   const [domFocus, setDomFocus] = useState<
@@ -99,7 +111,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     const overrideConfig = (pluginProps && pluginProps.config) || {}
     const config = R.mergeDeepRight(defaultConfig, overrideConfig)
 
-    const onChange = (
+    function handleChange(
       initial: StateUpdater<unknown>,
       additional: {
         executor?: ReturnType<
@@ -107,7 +119,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
         >['payload']['state']['executor']
         reverse?: ReturnType<typeof runChangeDocumentSaga>['payload']['reverse']
       } = {}
-    ) => {
+    ) {
       dispatch(
         runChangeDocumentSaga({
           id,
@@ -120,9 +132,30 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
       )
     }
 
-    // Take the default state for this plugin (set in serlo-editor/plugins/[plugin_type]/index.tsx) and add the individual plugin state obtained from the redux state.
+    function handleAddButtonClick() {
+      const textPluginWithSuggestions = {
+        plugin: EditorPluginType.Text,
+        state: [{ type: 'p', children: [{ text: '/' }] }],
+      }
+
+      const parent = selectParent(store.getState(), id)
+      if (!parent) return null
+
+      setTimeout(() => {
+        dispatch(
+          insertPluginChildAfter({
+            parent: parent.id,
+            sibling: id,
+            document: textPluginWithSuggestions,
+          })
+        )
+      })
+    }
+
+    // Take the default state for this plugin (set in serlo-editor/plugins/[plugin_type]/index.tsx)
+    // and add the individual plugin state obtained from the redux state.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const state = plugin.state.init(document.state, onChange)
+    const state = plugin.state.init(document.state, handleChange)
 
     const isInlineChildEditor =
       Object.hasOwn(config, 'isInlineChildEditor') &&
@@ -167,6 +200,16 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           state={state}
           autofocusRef={autofocusRef}
         />
+        {mayManipulateSiblings ? (
+          <RowSeparator
+            focused={domFocus === 'focus'}
+            onClick={(event: React.MouseEvent) => {
+              event.preventDefault()
+              handleAddButtonClick()
+            }}
+            visuallyEmphasizeAddButton={isLastRowInRootRowsPlugin}
+          />
+        ) : null}
       </div>
     )
   }, [
@@ -177,6 +220,8 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     handleDomFocus,
     id,
     domFocus,
+    mayManipulateSiblings,
+    isLastRowInRootRowsPlugin,
     dispatch,
   ])
 }

--- a/src/serlo-editor/plugins/rows/components/add-row-button-floating.tsx
+++ b/src/serlo-editor/plugins/rows/components/add-row-button-floating.tsx
@@ -5,31 +5,16 @@ import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 
-interface AddRowButtonProps {
+interface AddRowButtonFloatingProps {
   focused: boolean
   onClick: React.MouseEventHandler<HTMLButtonElement>
-  visuallyEmphasized?: boolean
 }
 
-export function AddRowButton({
+export function AddRowButtonFloating({
   focused,
   onClick,
-  visuallyEmphasized = false,
-}: AddRowButtonProps) {
+}: AddRowButtonFloatingProps) {
   const rowsStrings = useEditorStrings().plugins.rows
-
-  if (visuallyEmphasized)
-    return (
-      <button
-        className="serlo-button-editor-secondary"
-        data-qa="add-new-plugin-row-button"
-        onClick={onClick}
-        title={rowsStrings.addAnElement}
-      >
-        <FaIcon icon={faCirclePlus} className="text-xl" />{' '}
-        <span className="text-almost-black">{rowsStrings.addAnElement}</span>
-      </button>
-    )
 
   return (
     <div className="group flex justify-center">

--- a/src/serlo-editor/plugins/rows/components/add-row-button-large.tsx
+++ b/src/serlo-editor/plugins/rows/components/add-row-button-large.tsx
@@ -1,0 +1,23 @@
+import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
+
+import { FaIcon } from '@/components/fa-icon'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+interface AddRowButtonLargeProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement>
+}
+
+export function AddRowButtonLarge({ onClick }: AddRowButtonLargeProps) {
+  const rowsStrings = useEditorStrings().plugins.rows
+
+  return (
+    <button
+      className="serlo-button-editor-secondary mx-side mt-8"
+      onClick={onClick}
+      data-qa="add-new-plugin-row-button"
+    >
+      <FaIcon icon={faCirclePlus} className="text-xl" />{' '}
+      <span className="text-almost-black">{rowsStrings.addAnElement}</span>
+    </button>
+  )
+}

--- a/src/serlo-editor/plugins/rows/components/row-editor.tsx
+++ b/src/serlo-editor/plugins/rows/components/row-editor.tsx
@@ -1,48 +1,27 @@
-import clsx from 'clsx'
 import { useRef } from 'react'
 
-import { RowSeparator } from './row-separator'
 import type { RowsPluginConfig, RowsPluginState } from '..'
 import { EditorRowRenderer } from '../editor-renderer'
 import { StateTypeReturnType } from '@/serlo-editor/plugin'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
-import { selectIsFocused, useAppSelector } from '@/serlo-editor/store'
 
 interface RowEditorProps {
   config: RowsPluginConfig
-  onAddButtonClick(index: number): void
   index: number
   rows: StateTypeReturnType<RowsPluginState>
   row: StateTypeReturnType<RowsPluginState>[0]
-  visuallyEmphasizeAddButton?: boolean
-  isFirst?: boolean
-  isLast?: boolean
 }
 
-export function RowEditor({
-  config,
-  onAddButtonClick,
-  index,
-  row,
-  rows,
-  visuallyEmphasizeAddButton = false,
-  isFirst = false,
-  isLast = false,
-}: RowEditorProps) {
-  const focused = useAppSelector((state) => selectIsFocused(state, row.id))
+export function RowEditor({ config, index, row, rows }: RowEditorProps) {
   const plugins = editorPlugins.getAllWithData()
   const dropContainer = useRef<HTMLDivElement>(null)
 
   return (
-    // bigger drop zone with padding hack
     <div
       key={row.id}
       ref={dropContainer}
-      className={clsx(
-        'rows-child relative -ml-12 pl-12',
-        isFirst && 'first',
-        isLast && 'last'
-      )}
+      // bigger drop zone with padding hack
+      className="rows-child relative -ml-12 pl-12"
     >
       <EditorRowRenderer
         config={config}
@@ -51,16 +30,6 @@ export function RowEditor({
         index={index}
         plugins={plugins}
         dropContainer={dropContainer}
-      />
-      <RowSeparator
-        config={config}
-        focused={focused}
-        onClick={(event: React.MouseEvent) => {
-          event.preventDefault()
-          onAddButtonClick(index + 1)
-        }}
-        isLast={isLast}
-        visuallyEmphasizeAddButton={visuallyEmphasizeAddButton}
       />
     </div>
   )

--- a/src/serlo-editor/plugins/rows/components/row-separator.tsx
+++ b/src/serlo-editor/plugins/rows/components/row-separator.tsx
@@ -1,41 +1,24 @@
-import clsx from 'clsx'
-
-import { AddRowButton } from './add-row-button'
+import { AddRowButtonFloating } from './add-row-button-floating'
+import { AddRowButtonLarge } from './add-row-button-large'
 
 interface RowSeparatorProps {
-  isFirst?: boolean
-  isLast?: boolean
   visuallyEmphasizeAddButton?: boolean
   focused?: boolean
   onClick: React.MouseEventHandler<HTMLButtonElement>
 }
 
 export function RowSeparator({
-  isFirst,
-  isLast = false,
   visuallyEmphasizeAddButton = false,
   focused,
   onClick,
 }: RowSeparatorProps) {
   return (
-    <div
-      className={clsx(
-        'absolute z-[1] h-auto w-full',
-        isFirst ? 'top-0' : 'bottom-0',
-        isFirst && isLast
-          ? ''
-          : isFirst
-          ? '-translate-y-full'
-          : isLast
-          ? 'translate-y-[170%]'
-          : 'translate-y-full'
+    <div className="absolute bottom-0 z-[1] h-auto w-full translate-y-full">
+      {visuallyEmphasizeAddButton ? (
+        <AddRowButtonLarge onClick={onClick} />
+      ) : (
+        <AddRowButtonFloating focused={focused || false} onClick={onClick} />
       )}
-    >
-      <AddRowButton
-        focused={focused || false}
-        onClick={onClick}
-        visuallyEmphasized={visuallyEmphasizeAddButton}
-      />
     </div>
   )
 }

--- a/src/serlo-editor/plugins/rows/components/row-separator.tsx
+++ b/src/serlo-editor/plugins/rows/components/row-separator.tsx
@@ -1,23 +1,21 @@
 import clsx from 'clsx'
 
 import { AddRowButton } from './add-row-button'
-import type { RowsPluginConfig } from '..'
 
 interface RowSeparatorProps {
-  config: RowsPluginConfig
   isFirst?: boolean
   isLast?: boolean
   visuallyEmphasizeAddButton?: boolean
-  onClick: React.MouseEventHandler<HTMLButtonElement>
   focused?: boolean
+  onClick: React.MouseEventHandler<HTMLButtonElement>
 }
 
 export function RowSeparator({
   isFirst,
   isLast = false,
   visuallyEmphasizeAddButton = false,
-  onClick,
   focused,
+  onClick,
 }: RowSeparatorProps) {
   return (
     <div

--- a/src/serlo-editor/plugins/rows/editor.tsx
+++ b/src/serlo-editor/plugins/rows/editor.tsx
@@ -1,27 +1,8 @@
-import clsx from 'clsx'
-
 import type { RowsProps } from '.'
 import { AllowedChildPlugins } from './allowed-child-plugins-context'
 import { RowEditor } from './components/row-editor'
-import { RowSeparator } from './components/row-separator'
-import { selectAncestorPluginTypes, useAppSelector } from '@/serlo-editor/store'
-import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-export function RowsEditor({ state, config, id, editable }: RowsProps) {
-  const typesOfAncestors = useAppSelector((state) =>
-    selectAncestorPluginTypes(state, id)
-  )
-
-  function insertRowWithSuggestionsOpen(insertIndex: number) {
-    const textPluginWithSuggestions = {
-      plugin: EditorPluginType.Text,
-      state: [{ type: 'p', children: [{ text: '/' }] }],
-    }
-    setTimeout(() => {
-      state.insert(insertIndex, textPluginWithSuggestions)
-    })
-  }
-
+export function RowsEditor({ state, config, editable }: RowsProps) {
   if (!editable) {
     return (
       <>
@@ -34,30 +15,9 @@ export function RowsEditor({ state, config, id, editable }: RowsProps) {
     )
   }
 
-  const isRootRowsEditor =
-    !typesOfAncestors?.some(isPluginWithoutEmphasizedAddButton) &&
-    typesOfAncestors?.[typesOfAncestors.length - 1] !== EditorPluginType.Rows
-
-  const isDocumentEmpty = state.length === 0
-
   return (
     <AllowedChildPlugins.Provider value={config.allowedPlugins}>
-      <div
-        className={clsx(
-          'relative mt-[25px]',
-          isRootRowsEditor ? 'mb-[75px]' : undefined
-        )}
-      >
-        <RowSeparator
-          isFirst
-          isLast={isDocumentEmpty}
-          visuallyEmphasizeAddButton={isRootRowsEditor && isDocumentEmpty}
-          focused={state.length === 0}
-          onClick={(event: React.MouseEvent) => {
-            event.preventDefault()
-            insertRowWithSuggestionsOpen(0)
-          }}
-        />
+      <div className="relative mt-[25px]">
         {state.map((row, index) => (
           <RowEditor
             config={config}
@@ -71,11 +31,3 @@ export function RowsEditor({ state, config, id, editable }: RowsProps) {
     </AllowedChildPlugins.Provider>
   )
 }
-
-const isPluginWithoutEmphasizedAddButton = (pluginType: EditorPluginType) =>
-  [
-    EditorPluginType.Box,
-    EditorPluginType.Spoiler,
-    EditorPluginType.Multimedia,
-    EditorPluginType.Important,
-  ].includes(pluginType)

--- a/src/serlo-editor/store/focus/selectors.ts
+++ b/src/serlo-editor/store/focus/selectors.ts
@@ -10,6 +10,7 @@ import {
 import { selectRoot } from '../root'
 import { State } from '../types'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 const selectSelf = (state: State) => state.focus
 
@@ -80,17 +81,37 @@ export const selectAncestorPluginTypes = createDeepEqualSelector(
     if (!rootNode) return null
 
     let currentId = leafId
-    let pluginTypes: string[] = []
+    let pluginTypes: EditorPluginType[] = []
 
     while (currentId !== rootNode.id) {
       const parentNode = findParent(rootNode, currentId)
       if (!parentNode) return null
       const pluginType = selectDocument(state, parentNode.id)?.plugin
       if (pluginType === undefined) return null
-      pluginTypes = [pluginType, ...pluginTypes]
+      pluginTypes = [pluginType as EditorPluginType, ...pluginTypes]
       currentId = parentNode.id
     }
 
     return pluginTypes
+  }
+)
+
+export const selectIsLastRowInRootRowsPlugin = createSelector(
+  [(state: State) => state, (_state, leafId: string) => leafId],
+  (state, leafId) => {
+    const rootNode = selectFocusTree(state)
+    console.log('rootNode: ', rootNode)
+    if (!rootNode) return false
+
+    const rootRowsPlugin = rootNode.children?.[0]?.children?.[1]
+    console.log('rootRowsPlugin: ', rootRowsPlugin)
+    if (!rootRowsPlugin) return false
+
+    const lastRowInRootRowsPlugin =
+      rootRowsPlugin.children?.[rootRowsPlugin.children.length - 1]
+    console.log('lastRowInRootRowsPlugin: ', lastRowInRootRowsPlugin)
+    if (!lastRowInRootRowsPlugin) return false
+
+    return leafId === lastRowInRootRowsPlugin.id
   }
 )

--- a/src/serlo-editor/store/focus/selectors.ts
+++ b/src/serlo-editor/store/focus/selectors.ts
@@ -100,16 +100,13 @@ export const selectIsLastRowInRootRowsPlugin = createSelector(
   [(state: State) => state, (_state, leafId: string) => leafId],
   (state, leafId) => {
     const rootNode = selectFocusTree(state)
-    console.log('rootNode: ', rootNode)
     if (!rootNode) return false
 
     const rootRowsPlugin = rootNode.children?.[0]?.children?.[1]
-    console.log('rootRowsPlugin: ', rootRowsPlugin)
     if (!rootRowsPlugin) return false
 
     const lastRowInRootRowsPlugin =
       rootRowsPlugin.children?.[rootRowsPlugin.children.length - 1]
-    console.log('lastRowInRootRowsPlugin: ', lastRowInRootRowsPlugin)
     if (!lastRowInRootRowsPlugin) return false
 
     return leafId === lastRowInRootRowsPlugin.id

--- a/src/serlo-editor/store/focus/selectors.ts
+++ b/src/serlo-editor/store/focus/selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit'
+import { last } from 'ramda'
 
 import { findParent } from './helpers'
 import type { FocusTreeNode } from './types'
@@ -97,18 +98,14 @@ export const selectAncestorPluginTypes = createDeepEqualSelector(
 )
 
 export const selectIsLastRowInRootRowsPlugin = createSelector(
-  [(state: State) => state, (_state, leafId: string) => leafId],
-  (state, leafId) => {
+  [(state: State) => state, (_state, id: string) => id],
+  (state, id) => {
     const rootNode = selectFocusTree(state)
     if (!rootNode) return false
 
-    const rootRowsPlugin = rootNode.children?.[0]?.children?.[1]
-    if (!rootRowsPlugin) return false
+    const rootRowsPluginRows = rootNode.children?.[0]?.children?.[1]?.children
+    if (!rootRowsPluginRows) return false
 
-    const lastRowInRootRowsPlugin =
-      rootRowsPlugin.children?.[rootRowsPlugin.children.length - 1]
-    if (!lastRowInRootRowsPlugin) return false
-
-    return leafId === lastRowInRootRowsPlugin.id
+    return id === last(rootRowsPluginRows)?.id
   }
 )


### PR DESCRIPTION
Some code is still duplicated, because of the empty editor case. Any ideas how to clean that up?