### PR TITLE
refactor(focus): remove focus from store (wip)

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -13,9 +13,7 @@ import type { SubDocumentProps } from '.'
 import { useEnableEditorHotkeys } from './use-enable-editor-hotkeys'
 import {
   runChangeDocumentSaga,
-  focus,
   selectDocument,
-  selectIsFocused,
   useAppSelector,
   useAppDispatch,
   insertPluginChildAfter,
@@ -46,10 +44,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     selectIsLastRowInRootRowsPlugin(state, id)
   )
 
-  const focused = useAppSelector((state) => selectIsFocused(state, id))
-  const [domFocusState, setDomFocus] = useState<DomFocus>(
-    focused ? DomFocus.focusWithin : DomFocus.notFocused
-  )
+  const [domFocusState, setDomFocus] = useState<DomFocus>(DomFocus.notFocused)
 
   const plugin = editorPlugins.getByType(document?.plugin ?? '')
 
@@ -59,19 +54,9 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
 
   useEffect(() => {
     if (domFocusState !== 'focus') return
-    setTimeout(() => autofocusRef.current?.focus())
+    // TODO: does not work any more (with or without timeout)
+    autofocusRef.current?.focus()
   }, [domFocusState])
-
-  const handleFocus = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      // Find closest document
-      const target = (e.target as HTMLDivElement).closest('[data-document]')
-      if (!focused && target === containerRef.current) {
-        dispatch(focus(id))
-      }
-    },
-    [focused, id, dispatch]
-  )
 
   const handleDomFocus = useCallback((e: FocusEvent<HTMLDivElement>) => {
     const target = containerRef.current
@@ -186,7 +171,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           isLastRowInRootRowsPlugin ? '!mb-28' : ''
         )}
         tabIndex={-1} // removing this makes selecting e.g. images impossible somehow
-        onMouseDown={handleFocus}
         onFocus={noVisualFocusHandling ? undefined : handleDomFocus}
         onBlur={noVisualFocusHandling ? undefined : handleDomFocus}
         ref={containerRef}
@@ -223,7 +207,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     document,
     plugin,
     pluginProps,
-    handleFocus,
     handleDomFocus,
     id,
     domFocusState,

--- a/src/serlo-editor/plugins/equations/editor/editor.tsx
+++ b/src/serlo-editor/plugins/equations/editor/editor.tsx
@@ -23,21 +23,11 @@ import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
 import { MathRenderer } from '@/serlo-editor/math'
-import {
-  store,
-  focus,
-  focusNext,
-  focusPrevious,
-  selectIsDocumentEmpty,
-  useAppDispatch,
-  selectFocusTree,
-} from '@/serlo-editor/store'
+import { store, selectIsDocumentEmpty } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export function EquationsEditor(props: EquationsProps) {
   const { domFocusWithin, state } = props
-
-  const dispatch = useAppDispatch()
 
   const transformationTarget = toTransformationTarget(
     state.transformationTarget.value
@@ -100,24 +90,7 @@ export function EquationsEditor(props: EquationsProps) {
   const gridFocus = useGridFocus({
     rows: state.steps.length,
     columns: 4,
-    focusNext: () => {
-      const focusTree = selectFocusTree(store.getState())
-      dispatch(focusNext(focusTree))
-    },
-    focusPrevious: () => {
-      const focusTree = selectFocusTree(store.getState())
-      dispatch(focusPrevious(focusTree))
-    },
     transformationTarget,
-    onFocusChanged: (state) => {
-      if (state === 'firstExplanation') {
-        dispatch(focus(props.state.firstExplanation.id))
-      } else if (state.column === StepSegment.Explanation) {
-        dispatch(focus(props.state.steps[state.row].explanation.id))
-      } else {
-        dispatch(focus(props.id))
-      }
-    },
   })
 
   useEffect(() => {
@@ -126,7 +99,6 @@ export function EquationsEditor(props: EquationsProps) {
         row: 0,
         column: firstColumn(transformationTarget),
       })
-      dispatch(focus(props.id))
     }
     //prevents loop
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/serlo-editor/plugins/equations/editor/grid-focus.tsx
+++ b/src/serlo-editor/plugins/equations/editor/grid-focus.tsx
@@ -18,24 +18,19 @@ export interface GridFocus {
   moveLeft: () => void
 }
 
+// TODO: can't move out of plugin with tab, it just creates a new line every time
+
 export function useGridFocus({
   rows,
   columns,
-  focusNext,
-  focusPrevious,
-  onFocusChanged,
   transformationTarget,
 }: {
   rows: number
   columns: number
-  focusNext: () => void
-  focusPrevious: () => void
-  onFocusChanged: (args: GridFocusState) => void
   transformationTarget: TransformationTarget
 }): GridFocus {
   const [focus, setFocusState] = useState<GridFocusState | null>(null)
   const setFocus = (state: GridFocusState) => {
-    onFocusChanged(state)
     setFocusState(state)
   }
   const isFocused = (state: GridFocusState) => {
@@ -66,7 +61,7 @@ export function useGridFocus({
         focus.row === rows - 1 &&
         focus.column === lastColumn(transformationTarget)
       ) {
-        focusNext()
+        // do nothing for now
       } else if (transformationTarget === TransformationTarget.Term) {
         if (focus.column === StepSegment.Right) {
           setFocus({ row: focus.row, column: StepSegment.Explanation })
@@ -84,14 +79,11 @@ export function useGridFocus({
     },
     moveLeft() {
       if (focus === null) return
-      if (focus === 'firstExplanation') {
-        focusPrevious()
-        return
-      }
+      if (focus === 'firstExplanation') return
 
       if (transformationTarget === TransformationTarget.Term) {
         if (focus.row === 0 && focus.column === StepSegment.Right) {
-          focusPrevious()
+          // do nothing for now
         } else if (focus.column === StepSegment.Right) {
           setFocus({ row: focus.row - 1, column: StepSegment.Explanation })
         } else {

--- a/src/serlo-editor/store/focus/selectors.ts
+++ b/src/serlo-editor/store/focus/selectors.ts
@@ -13,13 +13,6 @@ import { State } from '../types'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-const selectSelf = (state: State) => state.focus
-
-export const selectIsFocused = createSelector(
-  [selectSelf, (_state, id: string) => id],
-  (focus, id: string) => focus === id
-)
-
 export const selectFocusTree: (
   state: State,
   id?: string


### PR DESCRIPTION
@hejtful as expected there are some bugs, but it's not as bad as I feared.
If you like you can take this over, I'll be back in the afternoon. 

todos:
- write new functions for `focusNext` and `focusPrevious` (could use the "focus"-Tree or just the dom to do so, performance should not really matter here)
- bug: first focus resets slate-curor to first position instead of where the user clicked
- bug: autofocus does not work as expected any more
- more refactoring (remove unused store, move or rename "focus"-Tree stuff, focus hook, …?)