### PR TITLE
refactor(editor): remove selectIsFocused selector

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -1,21 +1,12 @@
 import clsx from 'clsx'
 import * as R from 'ramda'
-import {
-  useState,
-  useRef,
-  useEffect,
-  useMemo,
-  useCallback,
-  FocusEvent,
-} from 'react'
+import { useState, useRef, useMemo, useCallback, FocusEvent } from 'react'
 
 import type { SubDocumentProps } from '.'
 import { useEnableEditorHotkeys } from './use-enable-editor-hotkeys'
 import {
   runChangeDocumentSaga,
-  focus,
   selectDocument,
-  selectIsFocused,
   useAppSelector,
   useAppDispatch,
   insertPluginChildAfter,
@@ -46,32 +37,13 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     selectIsLastRowInRootRowsPlugin(state, id)
   )
 
-  const focused = useAppSelector((state) => selectIsFocused(state, id))
-  const [domFocusState, setDomFocus] = useState<DomFocus>(
-    focused ? DomFocus.focusWithin : DomFocus.notFocused
-  )
+  const [domFocusState, setDomFocus] = useState<DomFocus>(DomFocus.notFocused)
 
   const plugin = editorPlugins.getByType(document?.plugin ?? '')
 
   useEnableEditorHotkeys(id, plugin, domFocusState === DomFocus.focusWithin)
   const containerRef = useRef<HTMLDivElement>(null)
   const autofocusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
-
-  useEffect(() => {
-    if (domFocusState !== 'focus') return
-    setTimeout(() => autofocusRef.current?.focus())
-  }, [domFocusState])
-
-  const handleFocus = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      // Find closest document
-      const target = (e.target as HTMLDivElement).closest('[data-document]')
-      if (!focused && target === containerRef.current) {
-        dispatch(focus(id))
-      }
-    },
-    [focused, id, dispatch]
-  )
 
   const handleDomFocus = useCallback((e: FocusEvent<HTMLDivElement>) => {
     const target = containerRef.current
@@ -97,7 +69,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
         : DomFocus.notFocused
     }
 
-    setDomFocus(() => getFocusWithin())
+    setDomFocus(getFocusWithin)
   }, [])
 
   return useMemo(() => {
@@ -186,7 +158,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           isLastRowInRootRowsPlugin ? '!mb-28' : ''
         )}
         tabIndex={-1} // removing this makes selecting e.g. images impossible somehow
-        onMouseDown={handleFocus}
         onFocus={noVisualFocusHandling ? undefined : handleDomFocus}
         onBlur={noVisualFocusHandling ? undefined : handleDomFocus}
         ref={containerRef}
@@ -223,7 +194,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
     document,
     plugin,
     pluginProps,
-    handleFocus,
     handleDomFocus,
     id,
     domFocusState,

--- a/src/serlo-editor/plugins/article/editor.tsx
+++ b/src/serlo-editor/plugins/article/editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ArticleProps } from '.'
 import { ArticleAddModal } from './add-modal/article-add-modal'
@@ -22,8 +22,18 @@ export function ArticleEditor({ editable, state }: ArticleProps) {
 
   const modalStrings = useEditorStrings().templatePlugins.article.addModal
 
+  // Focus the article introduction explanation on page load
+  // TODO: Move this into a focus-dedicated hook
+  const ref = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const explanationTextPlugin = ref.current?.querySelector<HTMLDivElement>(
+      '.explanation-wrapper > .plugin-wrapper-container'
+    )
+    explanationTextPlugin?.focus()
+  }, [])
+
   return (
-    <>
+    <div ref={ref}>
       <ArticleRenderer
         introduction={introduction.render()}
         content={content.render()}
@@ -81,7 +91,7 @@ export function ArticleEditor({ editable, state }: ArticleProps) {
           setModalOpen={setModalOpen}
         />
       )}
-    </>
+    </div>
   )
 
   function renderButton(text: string, noIcon?: boolean) {

--- a/src/serlo-editor/store/focus/selectors.ts
+++ b/src/serlo-editor/store/focus/selectors.ts
@@ -13,13 +13,6 @@ import { State } from '../types'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-const selectSelf = (state: State) => state.focus
-
-export const selectIsFocused = createSelector(
-  [selectSelf, (_state, id: string) => id],
-  (focus, id: string) => focus === id
-)
-
 export const selectFocusTree: (
   state: State,
   id?: string

--- a/src/serlo-editor/store/focus/slice.ts
+++ b/src/serlo-editor/store/focus/slice.ts
@@ -2,7 +2,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { findNextNode, findPreviousNode } from './helpers'
 import { FocusTreeNode } from './types'
-import { isPureInsertDocumentAction } from '../documents'
 import { State } from '../types'
 
 const initialState: State['focus'] = null as State['focus']
@@ -26,13 +25,6 @@ export const focusSlice = createSlice({
       if (!next) return state
       return next
     },
-  },
-  extraReducers: (builder) => {
-    builder.addMatcher(
-      // Always focus the newly inserted document
-      isPureInsertDocumentAction,
-      (_state, action) => action.payload.id
-    )
   },
 })
 


### PR DESCRIPTION
This PR is not to `remove-store-focus` branch, because that branch introduces multiple bugs, and I preferred to introduce and fix bugs one by one.

In `ArticleEditor`, I thought about adding a class instead of a ref, but a class would stay local to the `ArticleEditor`, while a ref can be moved into the focus-dedicated hook and therefore connected to the focus feature.

**Issues:**
- The "table click outside blur" bug does not appear in this branch, but two clicks are needed to focus a table cell. Looking into it.
- Doesn't work for non-article entities, like e.g. [exercise](http://localhost:3000/entity/create/Exercise/60730).
- When creating a new plugin it does not get focused (at all, but also not where it's supposed to get focus via autofocusref).