### PR TITLE
refactor(focus): replace focus next & focus previous

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -53,7 +53,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
 
   const plugin = editorPlugins.getByType(document?.plugin ?? '')
 
-  useEnableEditorHotkeys(id, plugin, domFocusState === DomFocus.focusWithin)
+  useEnableEditorHotkeys(id, plugin, domFocusState === DomFocus.focus)
   const containerRef = useRef<HTMLDivElement>(null)
   const autofocusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
 
@@ -185,6 +185,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
             : 'plugin-wrapper-container relative -ml-[7px] mb-6 min-h-[10px] pl-[5px]',
           isLastRowInRootRowsPlugin ? '!mb-28' : ''
         )}
+        id={id}
         tabIndex={-1} // removing this makes selecting e.g. images impossible somehow
         onMouseDown={handleFocus}
         onFocus={noVisualFocusHandling ? undefined : handleDomFocus}

--- a/src/serlo-editor/store/focus/slice.ts
+++ b/src/serlo-editor/store/focus/slice.ts
@@ -18,13 +18,17 @@ export const focusSlice = createSlice({
       if (!state || !action.payload) return state
       const next = findNextNode(action.payload, state)
       if (!next) return state
+      const nextDomElement = document.getElementById(next) as HTMLDivElement
+      if (nextDomElement) nextDomElement.focus()
       return next
     },
     focusPrevious(state, action: PayloadAction<FocusTreeNode | null>) {
       if (!state || !action.payload) return state
-      const next = findPreviousNode(action.payload, state)
-      if (!next) return state
-      return next
+      const previous = findPreviousNode(action.payload, state)
+      if (!previous) return state
+      const previousDomElement = document.getElementById(previous) as HTMLDivElement
+      if (previousDomElement) previousDomElement.focus()
+      return previous
     },
   },
   extraReducers: (builder) => {

--- a/src/serlo-editor/store/focus/slice.ts
+++ b/src/serlo-editor/store/focus/slice.ts
@@ -16,21 +16,27 @@ export const focusSlice = createSlice({
     },
     focusNext(state, action: PayloadAction<FocusTreeNode | null>) {
       if (!state || !action.payload) return state
-      const next = findNextNode(action.payload, state)
+      const _id = document.activeElement?.closest(
+        '.plugin-wrapper-container'
+      )?.id
+      const next = findNextNode(action.payload, _id ?? state)
       if (!next) return state
       const nextDomElement = document.getElementById(next) as HTMLDivElement
       nextDomElement?.focus()
-      return next
+      return state // make sure we don't use old logic
     },
     focusPrevious(state, action: PayloadAction<FocusTreeNode | null>) {
       if (!state || !action.payload) return state
-      const previous = findPreviousNode(action.payload, state)
+      const _id = document.activeElement?.closest(
+        '.plugin-wrapper-container'
+      )?.id
+      const previous = findPreviousNode(action.payload, _id ?? state)
       if (!previous) return state
       const previousDomElement = document.getElementById(
         previous
       ) as HTMLDivElement
       previousDomElement?.focus()
-      return previous
+      return state // make sure we don't use old logic
     },
   },
   extraReducers: (builder) => {

--- a/src/serlo-editor/store/focus/slice.ts
+++ b/src/serlo-editor/store/focus/slice.ts
@@ -19,15 +19,17 @@ export const focusSlice = createSlice({
       const next = findNextNode(action.payload, state)
       if (!next) return state
       const nextDomElement = document.getElementById(next) as HTMLDivElement
-      if (nextDomElement) nextDomElement.focus()
+      nextDomElement?.focus()
       return next
     },
     focusPrevious(state, action: PayloadAction<FocusTreeNode | null>) {
       if (!state || !action.payload) return state
       const previous = findPreviousNode(action.payload, state)
       if (!previous) return state
-      const previousDomElement = document.getElementById(previous) as HTMLDivElement
-      if (previousDomElement) previousDomElement.focus()
+      const previousDomElement = document.getElementById(
+        previous
+      ) as HTMLDivElement
+      previousDomElement?.focus()
       return previous
     },
   },


### PR DESCRIPTION
@hejtful this seems to work pretty similar like it did before in my first tests.
One inconsistency: I can use arrow keys to move into equations now but can't jump into table cells. 

We should probably move it out of the focus slice at some point, but for now I'm happy with minimal changes that don't break anything 😸