### PR TITLE
refactor(focus): focus newly created plugins with focusNext

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -23,6 +23,8 @@ import {
   store,
   selectMayManipulateSiblings,
   selectIsLastRowInRootRowsPlugin,
+  focusNext,
+  selectFocusTree,
 } from '../../store'
 import type { StateUpdater } from '../../types/internal__plugin-state'
 import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
@@ -47,9 +49,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
   )
 
   const focused = useAppSelector((state) => selectIsFocused(state, id))
-  const [domFocusState, setDomFocus] = useState<DomFocus>(
-    focused ? DomFocus.focusWithin : DomFocus.notFocused
-  )
+  const [domFocusState, setDomFocus] = useState<DomFocus>(DomFocus.notFocused)
 
   const plugin = editorPlugins.getByType(document?.plugin ?? '')
 
@@ -156,6 +156,9 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
             document: textPluginWithSuggestions,
           })
         )
+        setTimeout(() => {
+          dispatch(focusNext(selectFocusTree(store.getState())))
+        })
       })
     }
 

--- a/src/serlo-editor/core/sub-document/use-enable-editor-hotkeys.tsx
+++ b/src/serlo-editor/core/sub-document/use-enable-editor-hotkeys.tsx
@@ -91,6 +91,9 @@ export const useEnableEditorHotkeys = (
             sibling: id,
           })
         )
+        setTimeout(() => {
+          dispatch(focusNext(selectFocusTree(store.getState())))
+        })
       })
     },
     {

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -5,8 +5,10 @@ import { AnchorLinkCopyTool } from './anchor-link-copy-tool'
 import { DropdownButton } from './dropdown-button'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import {
+  focusNext,
   insertPluginChildAfter,
   removePluginChild,
+  selectFocusTree,
   selectParent,
   selectSerializedDocumentWithoutIds,
   store,
@@ -24,13 +26,11 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
   const pluginStrings = useEditorStrings().plugins
 
   const handleDuplicatePlugin = useCallback(() => {
-    const parent = selectParent(store.getState(), pluginId)
+    const state = store.getState()
+    const parent = selectParent(state, pluginId)
     if (!parent) return
 
-    const document = selectSerializedDocumentWithoutIds(
-      store.getState(),
-      pluginId
-    )
+    const document = selectSerializedDocumentWithoutIds(state, pluginId)
     if (!document) return
 
     dispatch(
@@ -40,6 +40,9 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         document,
       })
     )
+    setTimeout(() => {
+      dispatch(focusNext(selectFocusTree(state)))
+    })
   }, [dispatch, pluginId])
 
   const handleRemovePlugin = useCallback(() => {
@@ -57,6 +60,9 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
           document: { plugin: EditorPluginType.Text },
         })
       )
+      setTimeout(() => {
+        dispatch(focusNext(selectFocusTree(store.getState())))
+      })
     }
 
     dispatch(

--- a/src/serlo-editor/plugins/text/utils/insert-plugin.ts
+++ b/src/serlo-editor/plugins/text/utils/insert-plugin.ts
@@ -3,9 +3,11 @@ import { Editor as SlateEditor, Node } from 'slate'
 
 import { sliceNodesAfterSelection } from './document'
 import {
+  focusNext,
   insertPluginChildAfter,
   runReplaceDocumentSaga,
   selectDocument,
+  selectFocusTree,
   selectMayManipulateSiblings,
   selectParent,
   store,
@@ -70,4 +72,7 @@ export function insertPlugin({
       document: { plugin: pluginType, state },
     })
   )
+  setTimeout(() => {
+    dispatch(focusNext(selectFocusTree(store.getState())))
+  })
 }


### PR DESCRIPTION
trying simple approach to focus plugins after their creation.
if we could move it into `insertPluginChildAfter` this could be nice, what do you think?

what works:
plugin get's focus

what doesn't:
does not focus the correct part of the plugin (autofocusref or slate)