### PR TITLE
refactor(editor): Split richText formatting into 2 options

### DIFF
--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
@@ -73,12 +73,12 @@ const isRegisteredTextPlugin = (
 const registeredHotkeys = [
   {
     hotkey: 'mod+b',
-    option: TextEditorFormattingOption.richText,
+    option: TextEditorFormattingOption.richTextBold,
     handler: toggleBoldMark,
   },
   {
     hotkey: 'mod+i',
-    option: TextEditorFormattingOption.richText,
+    option: TextEditorFormattingOption.richTextItalic,
     handler: toggleItalicMark,
   },
   {
@@ -221,7 +221,7 @@ function createToolbarControls(
   const allFormattingOptions = [
     // Bold
     {
-      name: TextEditorFormattingOption.richText,
+      name: TextEditorFormattingOption.richTextBold,
       title: textStrings.bold,
       isActive: isBoldActive,
       onClick: toggleBoldMark,
@@ -229,7 +229,7 @@ function createToolbarControls(
     },
     // Italic
     {
-      name: TextEditorFormattingOption.richText,
+      name: TextEditorFormattingOption.richTextItalic,
       title: textStrings.italic,
       isActive: isItalicActive,
       onClick: toggleItalicMark,

--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/types.ts
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/types.ts
@@ -9,7 +9,8 @@ export enum TextEditorFormattingOption {
   lists = 'lists',
   math = 'math',
   paragraphs = 'paragraphs',
-  richText = 'richText',
+  richTextBold = 'richTextBold',
+  richTextItalic = 'richTextItalic',
 }
 
 export type ControlButton = ActionControlButton | NestedControlButton

--- a/src/serlo-editor/plugins/box/index.tsx
+++ b/src/serlo-editor/plugins/box/index.tsx
@@ -14,7 +14,6 @@ function createBoxState(allowedPlugins: (EditorPluginType | string)[]) {
     title: child({
       plugin: EditorPluginType.Text,
       config: {
-        formattingOptions: ['code', 'katex', 'math'],
         noLinebreaks: true,
       },
     }),

--- a/src/serlo-editor/plugins/image/editor.tsx
+++ b/src/serlo-editor/plugins/image/editor.tsx
@@ -14,7 +14,7 @@ import { selectHasFocusedChild, useAppSelector } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 const captionFormattingOptions = [
-  TextEditorFormattingOption.richText,
+  TextEditorFormattingOption.richTextBold,
   TextEditorFormattingOption.links,
   TextEditorFormattingOption.math,
   TextEditorFormattingOption.code,

--- a/src/serlo-editor/plugins/image/index.ts
+++ b/src/serlo-editor/plugins/image/index.ts
@@ -23,7 +23,6 @@ const imageState = object({
     child({
       plugin: EditorPluginType.Text,
       config: {
-        formattingOptions: ['code', 'katex', 'links', 'math', 'richText'],
         noLinebreaks: true,
       },
     })

--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -11,6 +11,7 @@ import { getTableType } from './utils/get-table-type'
 import { TextEditorConfig } from '../text'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { TextEditorFormattingOption } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/types'
 import {
   store,
   selectFocused,
@@ -21,16 +22,21 @@ import {
 } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-const headerTextFormattingOptions = ['code', 'katex', 'links', 'math']
+const headerTextFormattingOptions = [
+  TextEditorFormattingOption.code,
+  TextEditorFormattingOption.katex,
+  TextEditorFormattingOption.links,
+  TextEditorFormattingOption.math,
+]
 const cellTextFormattingOptions = [
-  'code',
-  'colors',
-  'katex',
-  'links',
-  'lists',
-  'math',
-  'richTextBold',
-  'richTextItalic',
+  TextEditorFormattingOption.code,
+  TextEditorFormattingOption.colors,
+  TextEditorFormattingOption.katex,
+  TextEditorFormattingOption.links,
+  TextEditorFormattingOption.lists,
+  TextEditorFormattingOption.math,
+  TextEditorFormattingOption.richTextBold,
+  TextEditorFormattingOption.richTextItalic,
 ]
 
 const newCell = { content: { plugin: EditorPluginType.Text } }

--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -29,7 +29,8 @@ const cellTextFormattingOptions = [
   'links',
   'lists',
   'math',
-  'richText',
+  'richTextBold',
+  'richTextItalic',
 ]
 
 const newCell = { content: { plugin: EditorPluginType.Text } }

--- a/src/serlo-editor/plugins/text/hooks/use-text-config.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-text-config.tsx
@@ -8,7 +8,8 @@ const defaultFormattingOptions: TextEditorFormattingOption[] = [
   TextEditorFormattingOption.links,
   TextEditorFormattingOption.lists,
   TextEditorFormattingOption.math,
-  TextEditorFormattingOption.richText,
+  TextEditorFormattingOption.richTextBold,
+  TextEditorFormattingOption.richTextItalic,
 ]
 
 export const useTextConfig = (config: TextEditorConfig) => ({


### PR DESCRIPTION
Previously, the richText formatting option included both bold and italic.
Since we would like to keep the default italic formatting of image captions, only the bold button should show up in the toolbar.
Now italic and bold formatting can be accessed separately through richTextBold and richTextItalic.