### PR TITLE
fix(editor): prevent removing last plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tsconfig.tsbuildinfo
 
 # asdf-vm
 .tool-versions
+
+# nvm
+.nvmrc

--- a/src/serlo-editor/plugins/rows/editor-renderer.tsx
+++ b/src/serlo-editor/plugins/rows/editor-renderer.tsx
@@ -15,6 +15,7 @@ import {
   selectSerializedDocument,
   store,
 } from '@/serlo-editor/store'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 interface RowDragObject {
   id: string
@@ -54,10 +55,16 @@ export function EditorRowRenderer({
         id: row.id,
         serialized: selectSerializedDocument(store.getState(), row.id),
         onDrop() {
+          // Remove the dragged plugin from its original rows plugin
           rows.set((list) => {
             const index = list.findIndex((id) => id === row.id)
             return R.remove(index, 1, list)
           })
+
+          // If the dragged plugin was the only plugin in the current rows plugin,
+          // add an empty text plugin to replace it
+          if (rows.length > 1) return
+          rows.insert(0, { plugin: EditorPluginType.Text })
         },
       }
     },
@@ -102,12 +109,12 @@ export function EditorRowRenderer({
         if (!canDrop(item.id)) return
 
         const draggingAbove = isDraggingAbove(monitor)
+        item.onDrop()
         rows.set((list, deserializer) => {
           const index =
             list.findIndex((id) => id === row.id) + (draggingAbove ? 0 : 1)
           return R.insert(index, deserializer(item.serialized), list)
         })
-        item.onDrop()
         return
       }
 

--- a/src/serlo-editor/plugins/rows/editor-renderer.tsx
+++ b/src/serlo-editor/plugins/rows/editor-renderer.tsx
@@ -63,8 +63,9 @@ export function EditorRowRenderer({
 
           // If the dragged plugin was the only plugin in the current rows plugin,
           // add an empty text plugin to replace it
-          if (rows.length > 1) return
-          rows.insert(0, { plugin: EditorPluginType.Text })
+          if (rows.length <= 1) {
+            rows.insert(0, { plugin: EditorPluginType.Text })
+          }
         },
       }
     },

--- a/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -146,7 +146,7 @@ export const useEditableKeydownHandler = (
           const direction = isBackspaceAtStart ? 'previous' : 'next'
 
           // Merge plugins within Slate and get the merge value
-          const newValue = mergePlugins(direction, editor, store, id)
+          const newValue = mergePlugins(direction, editor, id)
 
           // Update Redux document state with the new value
           if (newValue) {


### PR DESCRIPTION
Fixes https://github.com/serlo/frontend/issues/2773 and is a follow-up to https://github.com/serlo/frontend/pull/2791

**Backspace and delete plugin removal:**
We actually already had this check when merging plugins with content, but removing empty plugins happened before this check.
Now, the check is moved up, and refactored a bit.

**Drag'n'drop plugin removal:**
When the only plugin of a rows plugin is dragged and dropped outside its parent rows plugin, replace it with an empty text plugin.
Note: Before, we would first insert the dropped plugin, before removing it from its original position. That meant that, with the new logic, the replacement empty text plugin would be focused, because it was inserted last. Now, we are first removing the dropped plugin from its original position (and replacing it with an empty text plugin, if necessary), and then inserting it in the drop position.