### PR TITLE
Add `PluginToolMenuCustomizationContext` for edu-sharing integration

### DIFF
--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -1,8 +1,9 @@
 import { faClone, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 
 import { AnchorLinkCopyTool } from './anchor-link-copy-tool'
 import { DropdownButton } from './dropdown-button'
+import { PluginToolMenuCustomizationContext } from './plugin-tool-menu-customization-context'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import {
   insertPluginChildAfter,
@@ -22,6 +23,9 @@ interface PluginDefaultToolsProps {
 export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
   const dispatch = useAppDispatch()
   const pluginStrings = useEditorStrings().plugins
+  const { hideAnchorLinkButton } = useContext(
+    PluginToolMenuCustomizationContext
+  )
 
   const handleDuplicatePlugin = useCallback(() => {
     const parent = selectParent(store.getState(), pluginId)
@@ -81,7 +85,7 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         icon={faTrashAlt}
         dataQa="remove-plugin-button"
       />
-      <AnchorLinkCopyTool pluginId={pluginId} />
+      {hideAnchorLinkButton ? null : <AnchorLinkCopyTool pluginId={pluginId} />}
     </>
   )
 }

--- a/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-tool-menu-customization-context.ts
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-tool-menu-customization-context.ts
@@ -1,0 +1,7 @@
+// Introduced for edu-sharing integration to hide the `copy anchor link` button in plugin toolbar. Anchor links did not work in edu-sharing because we did not have a entityId there.
+
+import { createContext } from 'react'
+
+export const PluginToolMenuCustomizationContext = createContext<{
+  hideAnchorLinkButton: boolean
+}>({ hideAnchorLinkButton: false })


### PR DESCRIPTION
Small pull request that enables the edu-sharing integration to hide this button from the plugin toolbar menu: 
![image](https://github.com/serlo/frontend/assets/59921805/825633a9-dd77-4154-8b13-6dcee3e25ca8)

Reason: Anchor links contain an entityId which we do not have in the edu-sharing integration. 

Also: Running `yarn` added a (apparently) missing file to the yarn cache directory