### PR TITLE
feat(text-plugin): also search for pluginType in suggestion search

### DIFF
--- a/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
@@ -230,13 +230,24 @@ function filterPlugins(
   const search = text.replace('/', '').toLowerCase()
   if (!search.length) return plugins
 
-  const startingWithSearchString = plugins.filter(({ title }) => {
-    return title.toLowerCase()?.startsWith(search)
-  })
-  const containingSearchString = plugins.filter(({ title }) => {
-    const value = title?.toLowerCase()
-    return value?.includes(search) && !value?.startsWith(search)
+  const filterResults = new Set<SuggestionOption>()
+
+  // title or pluginType start with search string
+  plugins.forEach((entry) => {
+    if (
+      entry.title.toLowerCase()?.startsWith(search) ||
+      entry.pluginType.startsWith(search)
+    ) {
+      filterResults.add(entry)
+    }
   })
 
-  return [...startingWithSearchString, ...containingSearchString]
+  // title includes search string
+  plugins.forEach((entry) => {
+    if (entry.title.toLowerCase()?.includes(search)) {
+      filterResults.add(entry)
+    }
+  })
+
+  return [...filterResults]
 }

--- a/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-suggestions.tsx
@@ -235,7 +235,7 @@ function filterPlugins(
   // title or pluginType start with search string
   plugins.forEach((entry) => {
     if (
-      entry.title.toLowerCase()?.startsWith(search) ||
+      entry.title.toLowerCase().startsWith(search) ||
       entry.pluginType.startsWith(search)
     ) {
       filterResults.add(entry)
@@ -244,7 +244,7 @@ function filterPlugins(
 
   // title includes search string
   plugins.forEach((entry) => {
-    if (entry.title.toLowerCase()?.includes(search)) {
+    if (entry.title.toLowerCase().includes(search)) {
       filterResults.add(entry)
     }
   })


### PR DESCRIPTION
not functional any more, but I always wanted to try the new js [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) 😉.

why?
mostly so devs can type "injection" and actually find something 😸