### PR TITLE
feat(editor): move global toolbar tools to the sides on larger screens

### DIFF
--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -121,7 +121,7 @@ export function AddRevision({
       </Head>
       {renderBacklink()}
       <div className="controls-portal sticky top-0 z-[90] bg-white md:bg-transparent" />
-      <div className="edtr-io serlo-editor-hacks mx-auto mb-24 max-w-[816px]">
+      <div className="serlo-editor-hacks mx-auto mb-24 max-w-[816px]">
         <SerloEditor
           entityNeedsReview={entityNeedsReview}
           onSave={onSave}

--- a/src/components/pages/add-revision.tsx
+++ b/src/components/pages/add-revision.tsx
@@ -120,7 +120,7 @@ export function AddRevision({
         )}${id ? ` (${id})` : ''}`}</title>
       </Head>
       {renderBacklink()}
-      <div className="controls-portal sticky top-0 z-[90] bg-white" />
+      <div className="controls-portal sticky top-0 z-[90] bg-white md:bg-transparent" />
       <div className="edtr-io serlo-editor-hacks mx-auto mb-24 max-w-[816px]">
         <SerloEditor
           entityNeedsReview={entityNeedsReview}

--- a/src/components/user/profile-description-editor.tsx
+++ b/src/components/user/profile-description-editor.tsx
@@ -31,8 +31,8 @@ export function ProfileDescriptionEditor({
 
   return (
     <>
-      <div className="controls-portal sticky top-0 z-[100] bg-white" />
-      <div className="edtr-io serlo-editor-hacks">
+      <div className="controls-portal sticky top-0 z-[100] bg-white md:bg-transparent" />
+      <div className="serlo-editor-hacks [&>div.relative]:mt-12">
         <SerloEditor
           entityNeedsReview={false}
           onSave={onSave}

--- a/src/serlo-editor-integration/components/local-storage-notice.tsx
+++ b/src/serlo-editor-integration/components/local-storage-notice.tsx
@@ -21,7 +21,7 @@ export function LocalStorageNotice({
   if (!stored) return null
 
   return (
-    <div className="m-side mt-12 rounded-2xl bg-editor-primary-50 p-side">
+    <div className="m-side mt-12 rounded-2xl bg-editor-primary-50 p-side md:-mt-9">
       <>
         {storageStrings[useStored ? 'restoreInitial' : 'found']}
         <br />

--- a/src/serlo-editor/plugins/serlo-template-plugins/toolbar-main/toolbar-main.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/toolbar-main/toolbar-main.tsx
@@ -8,6 +8,7 @@ import { FaIcon, type FaIconProps } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { showToastNotice } from '@/helper/show-toast-notice'
 import { useLeaveConfirm } from '@/helper/use-leave-confirm'
+import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
 import type { StateTypeReturnType } from '@/serlo-editor/plugin'
 import {
   redo,
@@ -44,12 +45,12 @@ export function ToolbarMain({
   return (
     <>
       <ClientOnlyPortal selector=".controls-portal">
-        <nav className="flex h-12 w-full justify-between pl-5 pr-3 pt-4">
-          <div>
+        <nav className="flex h-14 w-full justify-between pl-5 pr-3 pt-6">
+          <div className="md:-ml-28 lg:-ml-52">
             {renderHistoryButton('Undo', faUndo, undo, !undoable)}
             {renderHistoryButton('Redo', faRedo, redo, !redoable)}
           </div>
-          <div>{renderSaveButton()}</div>
+          {renderSaveButton()}
         </nav>
       </ClientOnlyPortal>
       <SaveModal
@@ -71,15 +72,13 @@ export function ToolbarMain({
     return (
       <button
         className={clsx(
-          'serlo-button',
+          'serlo-button serlo-tooltip-trigger',
           disabled ? 'cursor-default text-gray-300' : 'serlo-button-light'
         )}
-        onClick={() => {
-          void dispatch(action())
-        }}
+        onClick={() => dispatch(action())}
         disabled={disabled}
-        title={title}
       >
+        <EditorTooltip text={title} className="top-8 !-ml-3" />
         <FaIcon icon={icon} />
       </button>
     )
@@ -88,12 +87,11 @@ export function ToolbarMain({
   function renderSaveButton() {
     return (
       <button
-        className="serlo-button-green ml-2"
+        className="serlo-button-green ml-2 md:mr-[-11.5vw] lg:-mr-52 xl:-mr-64"
         onClick={() => {
           if (isChanged) setSaveModalOpen(true)
           else showToastNotice('👀 ' + editorStrings.noChangesWarning)
         }}
-        title="Save"
       >
         <FaIcon icon={faSave} /> {editorStrings.edtrIo.save}
       </button>


### PR DESCRIPTION
<img width="1302" alt="image" src="https://github.com/serlo/frontend/assets/1258870/929a4d7d-46df-4cbe-9ec7-551d505384fe">
Should make some overlapping issues a lot easier and avoids "double-toolbar-feeling".

### 👉 [Demo](https://frontend-git-move-global-editor-tools-serlo.vercel.app/entity/repository/add-revision/277232)

todo: check user profile description toolbar
