### PR TITLE
Fix cutoff content (height) of fractions in math formula renderer

### DIFF
--- a/src/components/content/math-span.tsx
+++ b/src/components/content/math-span.tsx
@@ -32,7 +32,7 @@ export function MathSpan({ formula }: MathSpanProps) {
     <>
       <KaTeXStyles />
       <span
-        className="[page-break-inside:avoid]"
+        className="inline-block py-1 [page-break-inside:avoid]"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </>


### PR DESCRIPTION
This bug is somewhat hard to reproduce. Tried it in Firefox and chrome. On article https://de.serlo.org/mathe/261500/261500 I was able to see the box being cutoff, locally it didn't in Chrome and at least the box seemed fine.
In Firefox, everything worked fine for me but broke for Anne (see picture).
Meanwhile, for me the `g` at the bottom of a fraction was cutoff a little bit. 

The fix was to add a tiny bit of padding, and more importantly, change the display type of the span from inline to inline block (so that it autogrows with content).


![image](https://github.com/serlo/frontend/assets/28842311/80769ee5-987b-4ebd-8b10-81c1fbdf23d6)
