### PR TITLE
fix(plugin-serlo-table): column nav positioning

### DIFF
--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -208,7 +208,7 @@ export function SerloTableEditor(props: SerloTableProps) {
             </>
           ) : null}
         </nav>
-        <nav className="absolute -mt-12">
+        <nav className="absolute bottom-12">
           {showColButtons ? (
             <>
               {renderInlineAddButton(false)}
@@ -309,7 +309,7 @@ export function SerloTableEditor(props: SerloTableProps) {
       <button
         className={clsx(
           'serlo-button-light',
-          isRow ? 'm-4 -mt-4 w-auto' : 'mb-16'
+          isRow ? 'm-4 mt-0 w-auto' : 'mb-16'
         )}
         title={replaceWithType(tableStrings.addType, isRow)}
         onClick={() => {


### PR DESCRIPTION
https://trello.com/c/9bkKf26X/278-tabellenspalten-lassen-sich-nicht-l%C3%B6schen

Bug: The column nav (add or remove column) used to be above the column header, but it was hidden behind the toolbar.

Quick fix (suggested by @elbotho): Move the column nav below the column.

Note: Static add new row button had to be moved down a bit, to make space for the column nav.