### PR TITLE
fix(plugin-text): Slate deleting void nodes when sibling node deleted

### DIFF
--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -19,6 +19,7 @@ import { useEditorChange } from '../hooks/use-editor-change'
 import { useSlateRenderHandlers } from '../hooks/use-slate-render-handlers'
 import { useSuggestions } from '../hooks/use-suggestions'
 import { useTextConfig } from '../hooks/use-text-config'
+import { withCorrectVoidBehavior } from '../plugins/with-correct-void-behavior'
 import type { TextEditorConfig, TextEditorState } from '../types/config'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { useFormattingOptions } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options'
@@ -39,10 +40,9 @@ export function TextEditor(props: TextEditorProps) {
 
   const textFormattingOptions = useFormattingOptions(config.formattingOptions)
   const { createTextEditor, toolbarControls } = textFormattingOptions
-  const editor = useMemo(
-    () => createTextEditor(withReact(createEditor())),
-    [createTextEditor]
-  )
+  const editor = useMemo(() => {
+    return createTextEditor(withReact(withCorrectVoidBehavior(createEditor())))
+  }, [createTextEditor])
 
   const suggestions = useSuggestions({ editor, id, editable, focused })
   const { showSuggestions, suggestionsProps } = suggestions

--- a/src/serlo-editor/plugins/text/plugins/with-correct-void-behavior.ts
+++ b/src/serlo-editor/plugins/text/plugins/with-correct-void-behavior.ts
@@ -1,0 +1,80 @@
+import { Editor, Node, Path, Range, Transforms } from 'slate'
+
+import { MathElement } from '../types/text-editor'
+
+// Slate is not good with void block elements.
+// https://github.com/ianstormtaylor/slate/issues/3991
+export const withCorrectVoidBehavior = (editor: Editor) => {
+  const { deleteBackward, deleteForward, insertBreak } = editor
+
+  // If current selection is a void node, insert a default node below
+  editor.insertBreak = () => {
+    if (!editor.selection || !Range.isCollapsed(editor.selection)) {
+      return insertBreak()
+    }
+
+    const selectedNodePath = Path.parent(editor.selection.anchor.path)
+    const selectedNode = Node.get(editor, selectedNodePath)
+    if (Editor.isVoid(editor, selectedNode as MathElement)) {
+      Editor.insertNode(editor, {
+        type: 'p',
+        children: [{ text: '' }],
+      })
+      return
+    }
+
+    insertBreak()
+  }
+
+  // If previous node is a void node, remove the current node and select the void node
+  editor.deleteBackward = (unit) => {
+    if (
+      !editor.selection ||
+      !Range.isCollapsed(editor.selection) ||
+      editor.selection.anchor.offset !== 0
+    ) {
+      return deleteBackward(unit)
+    }
+
+    const parentPath = Path.parent(editor.selection.anchor.path)
+    const parentNode = Node.get(editor, parentPath)
+    const parentIsEmpty = Node.string(parentNode).length === 0
+
+    if (parentIsEmpty && Path.hasPrevious(parentPath)) {
+      const prevNodePath = Path.previous(parentPath)
+      const prevNode = Node.get(editor, prevNodePath)
+      if (Editor.isVoid(editor, prevNode as MathElement)) {
+        return Transforms.removeNodes(editor)
+      }
+    }
+
+    deleteBackward(unit)
+  }
+
+  // If next node is a void node, remove the current node and select the void node
+  editor.deleteForward = (unit) => {
+    if (
+      !editor.selection ||
+      !Range.isCollapsed(editor.selection) ||
+      editor.selection.anchor.offset !== 0
+    ) {
+      return deleteForward(unit)
+    }
+
+    const parentPath = Path.parent(editor.selection.anchor.path)
+    const parentNode = Node.get(editor, parentPath)
+    const parentIsEmpty = Node.string(parentNode).length === 0
+
+    if (parentIsEmpty) {
+      const nextNodePath = Path.next(parentPath)
+      const nextNode = Node.get(editor, nextNodePath)
+      if (Editor.isVoid(editor, nextNode as MathElement)) {
+        return Transforms.removeNodes(editor)
+      }
+    }
+
+    deleteForward(unit)
+  }
+
+  return editor
+}

--- a/src/serlo-editor/plugins/text/utils/document.ts
+++ b/src/serlo-editor/plugins/text/utils/document.ts
@@ -69,7 +69,7 @@ export function mergePlugins(
 
   // If the editor is empty, remove the current Slate instance
   // and focus the one it's been merged with
-  if (Node.string(editor) === '') {
+  if (Node.string(editor) === '' && editor.children.length <= 1) {
     const focusTree = selectChildTree(store.getState())
     const focusAction = direction === 'previous' ? focusPrevious : focusNext
     store.dispatch(focusAction(focusTree))


### PR DESCRIPTION
https://trello.com/c/H3eIoRy2/279-ux-zeilenabst%C3%A4nde-und-formelumgebung

Second commit also resolves https://github.com/serlo/frontend/issues/2842