### PR TITLE
Fix merging issue between a block starting with a list and another text block

### DIFF
--- a/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useRef } from 'react'
 import { Descendant, Editor, Transforms } from 'slate'
 
 import type { TextEditorProps } from '../components/text-editor'
-import { CustomElement, ListElementType, Paragraph } from '../types/text-editor'
 
 interface UseEditorChangeArgs {
   editor: Editor
@@ -31,33 +30,13 @@ export const useEditorChange = (args: UseEditorChangeArgs) => {
 
   const handleEditorChange = useCallback(
     (newValue: Descendant[]) => {
-      let modifiedValue = []
-      modifiedValue = newValue
-
-      // Add an empty line in front of list elements at th start of the block
-      // This way we avoid list related merging issues
-      if (newValue.length > 0) {
-        const first_child = newValue[0] as CustomElement
-        if (
-          first_child.type === ListElementType.ORDERED_LIST ||
-          first_child.type === ListElementType.UNORDERED_LIST
-        ) {
-          const empty_text_node = {
-            children: [{ text: '' }],
-            type: 'p',
-          } as Paragraph
-          modifiedValue = [empty_text_node, ...modifiedValue]
-          editor.insertNode(empty_text_node, { at: [0] })
-        }
-      }
-
       const isAstChange = editor.operations.some(
         ({ type }) => type !== 'set_selection'
       )
       if (isAstChange) {
-        previousValue.current = modifiedValue
+        previousValue.current = newValue
         state.set(
-          { value: modifiedValue, selection: editor.selection },
+          { value: newValue, selection: editor.selection },
           ({ value }) => ({ value, selection: previousSelection.current })
         )
       }

--- a/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import { Descendant, Editor, Transforms } from 'slate'
 
 import type { TextEditorProps } from '../components/text-editor'
+import { CustomElement, ListElementType, Paragraph } from '../types/text-editor'
 
 interface UseEditorChangeArgs {
   editor: Editor
@@ -30,13 +31,33 @@ export const useEditorChange = (args: UseEditorChangeArgs) => {
 
   const handleEditorChange = useCallback(
     (newValue: Descendant[]) => {
+      let modifiedValue = []
+      modifiedValue = newValue
+
+      // Add an empty line in front of list elements at th start of the block
+      // This way we avoid list related merging issues
+      if (newValue.length > 0) {
+        const first_child = newValue[0] as CustomElement
+        if (
+          first_child.type === ListElementType.ORDERED_LIST ||
+          first_child.type === ListElementType.UNORDERED_LIST
+        ) {
+          const empty_text_node = {
+            children: [{ text: '' }],
+            type: 'p',
+          } as Paragraph
+          modifiedValue = [empty_text_node, ...modifiedValue]
+          editor.insertNode(empty_text_node, { at: [0] })
+        }
+      }
+
       const isAstChange = editor.operations.some(
         ({ type }) => type !== 'set_selection'
       )
       if (isAstChange) {
-        previousValue.current = newValue
+        previousValue.current = modifiedValue
         state.set(
-          { value: newValue, selection: editor.selection },
+          { value: modifiedValue, selection: editor.selection },
           ({ value }) => ({ value, selection: previousSelection.current })
         )
       }

--- a/src/serlo-editor/plugins/text/index.tsx
+++ b/src/serlo-editor/plugins/text/index.tsx
@@ -1,17 +1,18 @@
 import { Node } from 'slate'
 
 import { TextEditor, type TextEditorProps } from './components/text-editor'
+import { createDefaultTextNode, isListNode } from './plugins'
 import type { TextEditorConfig, TextEditorState } from './types/config'
-import type {
-  CustomElement,
-  CustomText,
-  Paragraph,
-  List,
-  ListItem,
-  ListItemText,
-  Heading,
-  Link,
-  MathElement,
+import {
+  type CustomElement,
+  type CustomText,
+  type Paragraph,
+  type List,
+  type ListItem,
+  type ListItemText,
+  type Heading,
+  type Link,
+  type MathElement,
 } from './types/text-editor'
 import { emptyDocumentFactory } from './utils/document'
 import { isEmptyObject } from './utils/object'
@@ -37,6 +38,13 @@ const createTextPlugin = (
       const firstChild = (value[0] as CustomElement).children[0]
       if (isEmptyObject(firstChild)) {
         return emptyDocumentFactory()
+      }
+
+      // Add an empty line in front of list elements at the start of the block
+      // This way we avoid list related merging issues
+      const firstElement = value[0] as CustomElement
+      if (isListNode(firstElement)) {
+        value = [createDefaultTextNode(), ...value]
       }
 
       return { value, selection: null }


### PR DESCRIPTION
A new line will be added at the start of the block to avoid the error the list causes (described [here](https://github.com/serlo/frontend/issues/2798)).

This fixes the issue as long as the block containing the list is interacted with before we attempt to merge with the other block.
To completely avoid the issue, we need to make sure the exercise is loaded together with this extra line to start with.