### PR TITLE
programmatic focus demo

### DIFF
--- a/src/serlo-editor/core/editor.tsx
+++ b/src/serlo-editor/core/editor.tsx
@@ -17,6 +17,7 @@ import {
   useAppDispatch,
   DocumentState,
   selectSerializedDocument,
+  focus,
 } from '../store'
 import { ROOT } from '../store/root/constants'
 
@@ -37,6 +38,14 @@ export function Editor(props: EditorProps) {
   )
 }
 
+const pluginIds = [
+  '2866db2d-6210-4579-a6cf-6e01b282bbbf',
+  '44cf6a69-d925-420a-8b0e-998b152b7200',
+  '649d16bc-6189-43c1-a7c0-ba2effc6fca7',
+  'c6b1f38f-40b6-4aa2-bb75-571945d6fa25',
+  '7d59264e-b2e5-45a9-92a7-dc0a123949a6',
+]
+
 function InnerDocument({
   children,
   editable = true,
@@ -48,6 +57,16 @@ function InnerDocument({
 
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   useBlurOnOutsideClick(wrapperRef)
+
+  const [counter, setCounter] = useState(0)
+
+  useEffect(() => {
+    setTimeout(() => setCounter(counter + 1), 2000)
+    if (counter > 0) {
+      const toFocus = pluginIds[counter % pluginIds.length]
+      dispatch(focus(toFocus))
+    }
+  }, [counter, dispatch])
 
   useEffect(() => {
     if (typeof onChange !== 'function') return

--- a/src/serlo-editor/core/editor.tsx
+++ b/src/serlo-editor/core/editor.tsx
@@ -40,10 +40,12 @@ export function Editor(props: EditorProps) {
 
 const pluginIds = [
   '2866db2d-6210-4579-a6cf-6e01b282bbbf',
-  '44cf6a69-d925-420a-8b0e-998b152b7200',
-  '649d16bc-6189-43c1-a7c0-ba2effc6fca7',
-  'c6b1f38f-40b6-4aa2-bb75-571945d6fa25',
   '7d59264e-b2e5-45a9-92a7-dc0a123949a6',
+  '649d16bc-6189-43c1-a7c0-ba2effc6fca7',
+  '44cf6a69-d925-420a-8b0e-998b152b7200',
+  'c6b1f38f-40b6-4aa2-bb75-571945d6fa25',
+  'bc070871-4e7c-41a9-91d8-8546a4a130a5',
+  '3db8191b-9954-4ce2-b1d2-fb2cf2ee83af',
 ]
 
 function InnerDocument({

--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -29,6 +29,8 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const autofocusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
 
+  console.log('render subdocument editor', id)
+
   useEffect(() => {
     if (focused) {
       setTimeout(() => {
@@ -117,7 +119,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
       (config.isInlineChildEditor as boolean)
 
     const isTemplatePlugin = document.plugin.startsWith('type-')
-
+    console.log('no useMemo in', id)
     return (
       <div
         className={clsx(


### PR DESCRIPTION
demo: https://frontend-git-2864-investigate-focus-serlo.vercel.app/entity/repository/add-revision/277232

Very simple show case: I use `dispatch` and `focus` to programmatically focus some plugins after each other.

I'm pleased to see that this is working in principle. And `memo` is also working and only necessary elements are rendered.

But the demo already reveals some bugs on a fundamental level: 
- Initially, table cells and heading fail to get focused (no cursor, you can't move with arrow keys)
- After some interaction (like clicking into the text), the heading with the text "box" works.
- Table cells don't work, even after interaction.  Sometimes the cell is focused, but loses focus immediately after
- equations plugin will always focus the next plugin (and not the one I specified)