### PR TITLE
chore(fetcher): add sentry error when using legacy format

### DIFF
--- a/src/fetcher/convert-state.ts
+++ b/src/fetcher/convert-state.ts
@@ -1,5 +1,6 @@
 import { render } from '../../external/legacy_render'
 import { FrontendContentNode, FrontendNodeType } from '@/frontend-node-types'
+import { triggerSentry } from '@/helper/trigger-sentry'
 import { ConvertNode, convert } from '@/schema/convert-edtr-io-state'
 import { convertLegacyState } from '@/schema/convert-legacy-state'
 
@@ -8,6 +9,12 @@ export function convertState(raw: string | undefined): FrontendContentNode[] {
 
   // legacy editor state
   if (raw?.startsWith('[')) {
+    const message = 'using legacy format'
+    // eslint-disable-next-line no-console
+    console.error(message)
+    // eslint-disable-next-line no-console
+    console.log(raw)
+    triggerSentry({ message })
     const legacyHTML = render(raw)
     return convertLegacyState(legacyHTML).children
   }

--- a/src/fetcher/user/request.ts
+++ b/src/fetcher/user/request.ts
@@ -20,38 +20,33 @@ export async function requestUser(
     instance,
   })
 
-  if (!uuid) {
+  if (!uuid || uuid.__typename !== UuidType.User) {
     return { kind: 'not-found' }
   }
 
-  if (uuid.__typename === UuidType.User) {
-    return {
-      kind: 'user/profile',
-      newsletterPopup: false,
-      userData: {
-        ...uuid,
-        motivation: uuid.motivation ?? undefined,
-        chatUrl: uuid.chatUrl ?? undefined,
-        description: getDescription(uuid),
-        roles: uuid.roles.nodes.map((role) => {
-          return {
-            role: role.role,
-            instance:
-              !role.scope || role.scope === Scope.Serlo
-                ? null
-                : (role.scope.substring('serlo.org:'.length) as Instance),
-          }
-        }),
-      },
-      authorization,
-    }
-  } else {
-    return { kind: 'not-found' }
-  }
-}
+  const description =
+    !uuid.description || uuid.description === 'NULL'
+      ? undefined
+      : convertState(uuid.description)
 
-function getDescription(uuid: User) {
-  return uuid.description === null || uuid.description === 'NULL'
-    ? undefined
-    : convertState(uuid.description)
+  return {
+    kind: 'user/profile',
+    newsletterPopup: false,
+    userData: {
+      ...uuid,
+      motivation: uuid.motivation ?? undefined,
+      chatUrl: uuid.chatUrl ?? undefined,
+      description,
+      roles: uuid.roles.nodes.map((role) => {
+        return {
+          role: role.role,
+          instance:
+            !role.scope || role.scope === Scope.Serlo
+              ? null
+              : (role.scope.substring('serlo.org:'.length) as Instance),
+        }
+      }),
+    },
+    authorization,
+  }
 }


### PR DESCRIPTION
just in case… 
I'd let this run for a while and then just remove the legacy converter