### PR TITLE
make slate work with fast refresh

### DIFF
--- a/src/serlo-editor/plugins/text/components/text-editor.tsx
+++ b/src/serlo-editor/plugins/text/components/text-editor.tsx
@@ -43,20 +43,21 @@ export function TextEditor(props: TextEditorProps) {
 
   const textFormattingOptions = useFormattingOptions(config.formattingOptions)
   const { createTextEditor, toolbarControls } = textFormattingOptions
-  const editor = useMemo(() => {
-    return createTextEditor(
-      withReact(
-        withEmptyLinesRestriction(withCorrectVoidBehavior(createEditor()))
-      )
-    )
-  }, [createTextEditor])
 
-  // Fast Refresh will rerun useMemo and create a new editor instance,
-  // but <Slate /> is confused by it.
-  // Generate a unique key per editor instance and set it on the component
-  // to syncronize rerendering
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const editorKey = useMemo(() => v4(), [createTextEditor])
+  const { editor, editorKey } = useMemo(() => {
+    return {
+      editor: createTextEditor(
+        withReact(
+          withEmptyLinesRestriction(withCorrectVoidBehavior(createEditor()))
+        )
+      ),
+      // Fast Refresh will rerun useMemo and create a new editor instance,
+      // but <Slate /> is confused by it
+      // Generate a unique key per editor instance and set it on the component
+      // to syncronize rerendering
+      editorKey: v4(),
+    }
+  }, [createTextEditor])
 
   const suggestions = useSuggestions({ editor, id, editable, focused })
   const { showSuggestions, suggestionsProps } = suggestions

--- a/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editor-change.tsx
@@ -15,7 +15,7 @@ interface UseEditorChangeArgs {
 export const useEditorChange = (args: UseEditorChangeArgs) => {
   const { editor, state, id, focused } = args
 
-  // setup store on first render
+  // Setup store on first render
   if (!instanceStateStore[id]) {
     instanceStateStore[id] = {
       value: state.value.value,
@@ -62,12 +62,6 @@ export const useEditorChange = (args: UseEditorChangeArgs) => {
   useEffect(() => {
     const storeEntry = instanceStateStore[id]
     if (focused && storeEntry.needRefocus > 0) {
-      // Fix crash in fast refresh: if this component is updated, slate needs a moment
-      // to sync with dom. Don't try accessing slate in these situations
-      if (editor.children.length === 0) {
-        return
-      }
-
       const selection = storeEntry.selection ?? Editor.start(editor, [])
 
       withoutNormalizing(editor, () => {
@@ -84,9 +78,6 @@ export const useEditorChange = (args: UseEditorChangeArgs) => {
     if (focused) {
       instanceStateStore[id].needRefocus = 2
 
-      if (editor.children.length === 0) {
-        return
-      }
       instanceStateStore[id].selection = {
         anchor: Editor.start(editor, []),
         focus: Editor.start(editor, []),


### PR DESCRIPTION
@elbotho found a better and more consistent fix for it

This was a good reference: https://reactnative.dev/docs/fast-refresh#fast-refresh-and-hooks