### PR TITLE
refactor(editor): use `onFocus` instead of `onMouseDown`

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -54,7 +54,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
   }, [focused, plugin])
 
   const handleFocus = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: React.FocusEvent) => {
       // Find closest document
       const target = (e.target as HTMLDivElement).closest('[data-document]')
       if (!focused && target === containerRef.current) {
@@ -127,7 +127,7 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
             ? ''
             : 'plugin-wrapper-container relative -ml-[7px] mb-6 min-h-[10px] pl-[5px]'
         )}
-        onMouseDown={handleFocus}
+        onFocus={handleFocus}
         ref={containerRef}
         data-document
         tabIndex={-1}


### PR DESCRIPTION
Works surprisingly well,I could not find problems so far (makes me suspicious :D).

(for https://github.com/serlo/backlog/issues/111)



---

follow up:
- try to remove `onMouseDown={(e) => e.stopPropagation()} // hack to stop edtr from stealing events` to see if it is still needed in those places