### PR TITLE
fix(editor-math): reduce content jumps on block math

### DIFF
--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -86,7 +86,7 @@ export function MathEditor(props: MathEditorProps) {
             className={clsx(
               props.inline
                 ? 'inline-block'
-                : 'my-[0.9em] flex flex-col items-center'
+                : 'my-[1.45em] flex flex-col items-center'
             )}
           >
             <VisualEditor

--- a/src/serlo-editor/math/renderer.tsx
+++ b/src/serlo-editor/math/renderer.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import KaTeX from 'katex'
 import React, { forwardRef } from 'react'
 
@@ -22,15 +23,7 @@ export const MathRenderer = React.memo(
       <span
         ref={ref}
         dangerouslySetInnerHTML={{ __html: html }}
-        style={
-          inline
-            ? undefined
-            : {
-                display: 'block',
-                margin: '1em 0',
-                textAlign: 'center',
-              }
-        }
+        className={clsx(inline ? '' : 'my-6 block text-center')}
         {...additionalContainerProps}
         data-qa="plugin-math-renderer"
       />

--- a/src/serlo-editor/plugins/text/components/math-formula.tsx
+++ b/src/serlo-editor/plugins/text/components/math-formula.tsx
@@ -19,7 +19,7 @@ export const MathFormula = memo(function MathFormula({
   return (
     <span
       dangerouslySetInnerHTML={{ __html: html }}
-      className={element.inline ? undefined : 'mx-0 my-4 block text-center'}
+      className={element.inline ? undefined : 'mx-0 block text-center'}
     />
   )
 })


### PR DESCRIPTION
for https://github.com/serlo/backlog/issues/269