### PR TITLE
chore(editor): remove autofocusRef feature

### DIFF
--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -29,30 +29,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const autofocusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
 
-  useEffect(() => {
-    if (focused) {
-      setTimeout(() => {
-        if (autofocusRef.current) {
-          autofocusRef.current.focus()
-        }
-      })
-    }
-  }, [focused])
-
-  useEffect(() => {
-    if (
-      focused &&
-      containerRef.current &&
-      document &&
-      plugin &&
-      !plugin.state.getFocusableChildren(document.state).length
-    ) {
-      containerRef.current.focus()
-    }
-    // `document` should not be part of the dependencies because we only want to call this once when the document gets focused
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focused, plugin])
-
   const handleFocus = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       // Find closest document

--- a/src/serlo-editor/core/sub-document/editor.tsx
+++ b/src/serlo-editor/core/sub-document/editor.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import * as R from 'ramda'
-import { useRef, useEffect, useMemo, useCallback } from 'react'
+import { useRef, useMemo, useCallback } from 'react'
 
 import type { SubDocumentProps } from '.'
 import { useEnableEditorHotkeys } from './use-enable-editor-hotkeys'
@@ -27,7 +27,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
 
   useEnableEditorHotkeys(id, plugin, focused)
   const containerRef = useRef<HTMLDivElement>(null)
-  const autofocusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
 
   const handleFocus = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -116,7 +115,6 @@ export function SubDocumentEditor({ id, pluginProps }: SubDocumentProps) {
           config={config}
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           state={state}
-          autofocusRef={autofocusRef}
         />
       </div>
     )

--- a/src/serlo-editor/core/sub-document/renderer.tsx
+++ b/src/serlo-editor/core/sub-document/renderer.tsx
@@ -1,5 +1,4 @@
 import * as R from 'ramda'
-import { useRef } from 'react'
 
 import type { SubDocumentProps } from '.'
 import { selectDocument, useAppSelector } from '../../store'
@@ -9,7 +8,6 @@ export function SubDocumentRenderer({ id, pluginProps }: SubDocumentProps) {
   const document = useAppSelector((state) => selectDocument(state, id))
   const plugin = editorPlugins.getByType(document?.plugin ?? '')
 
-  const focusRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
   if (!document) return null
   if (!plugin) {
     // eslint-disable-next-line no-console
@@ -34,7 +32,6 @@ export function SubDocumentRenderer({ id, pluginProps }: SubDocumentProps) {
       id={id}
       editable={false}
       focused={false}
-      autofocusRef={focusRef}
     />
   )
 }

--- a/src/serlo-editor/math/editor.tsx
+++ b/src/serlo-editor/math/editor.tsx
@@ -15,7 +15,6 @@ import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 
 export interface MathEditorProps {
-  autofocus?: boolean
   state: string
   inline?: boolean
   readOnly?: boolean

--- a/src/serlo-editor/plugins/anchor/editor.tsx
+++ b/src/serlo-editor/plugins/anchor/editor.tsx
@@ -30,11 +30,10 @@ export const AnchorEditor = (props: AnchorProps) => {
                 onChange={(e) => {
                   state.set(e.target.value)
                 }}
-                ref={props.autofocusRef}
                 className={tw`
-                mr-2 cursor-pointer rounded-md !border border-gray-500
-              bg-editor-primary-100 px-1 py-[1px] text-sm transition-all
-              hover:bg-editor-primary-200 focus:bg-editor-primary-200 focus:outline-none
+                  mr-2 cursor-pointer rounded-md !border border-gray-500
+                bg-editor-primary-100 px-1 py-[1px] text-sm transition-all
+                hover:bg-editor-primary-200 focus:bg-editor-primary-200 focus:outline-none
               `}
               />
             </label>

--- a/src/serlo-editor/plugins/audio/toolbar.tsx
+++ b/src/serlo-editor/plugins/audio/toolbar.tsx
@@ -19,7 +19,6 @@ import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin
 export const AudioToolbar = ({
   id,
   state,
-  autofocusRef,
   showSettingsModal,
   setShowSettingsModal,
 }: AudioProps & {
@@ -78,7 +77,6 @@ export const AudioToolbar = ({
                   width="100%"
                   onKeyDown={handleInputEnter}
                   placeholder="voca.ro/audio-id"
-                  ref={autofocusRef}
                   className="block"
                 />
               </div>

--- a/src/serlo-editor/plugins/h5p/index.tsx
+++ b/src/serlo-editor/plugins/h5p/index.tsx
@@ -37,7 +37,7 @@ export const H5pPlugin: EditorPlugin<H5pPluginState> = {
 }
 
 // Note: This plugin will not be translated for now, as i18n work is deprioritized
-function H5pEditor({ state, autofocusRef }: H5pProps) {
+function H5pEditor({ state }: H5pProps) {
   const hasState = !!state.value
 
   const [mode, setMode] = useState<'edit' | 'loading' | 'preview'>(
@@ -151,7 +151,6 @@ function H5pEditor({ state, autofocusRef }: H5pProps) {
             }}
             inputWidth="70%"
             width="100%"
-            ref={autofocusRef}
           />
           <button
             className="serlo-button ml-3 mt-2 bg-brandgreen-300 disabled:cursor-default disabled:bg-gray-300"

--- a/src/serlo-editor/plugins/serlo-template-plugins/video.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/video.tsx
@@ -55,8 +55,6 @@ function VideoTypeEditor(props: EditorPluginProps<VideoTypePluginState>) {
             placeholder={editorStrings.plugins.video.titlePlaceholder}
             value={title.value}
             onChange={(e) => title.set(e.target.value)}
-            // hack to stop faulty autofocus
-            onMouseDown={(e) => e.stopPropagation()}
           />
         ) : (
           <span itemProp="name">{title.value}</span>

--- a/src/serlo-editor/plugins/spoiler/editor.tsx
+++ b/src/serlo-editor/plugins/spoiler/editor.tsx
@@ -9,7 +9,7 @@ import { PluginDefaultTools } from '@/serlo-editor/editor-ui/plugin-toolbar/plug
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export function SpoilerEditor(props: SpoilerProps) {
-  const { state, editable, autofocusRef, id, focused } = props
+  const { state, editable, id, focused } = props
   const editorStrings = useEditorStrings()
 
   const title = editable ? (
@@ -17,7 +17,6 @@ export function SpoilerEditor(props: SpoilerProps) {
       onChange={(e) => state.title.set(e.target.value)}
       value={state.title.value}
       placeholder={editorStrings.plugins.spoiler.enterATitle}
-      ref={autofocusRef}
       className="-my-1 w-full rounded-md bg-transparent p-1 focus:bg-brand-100 focus:outline-none"
     />
   ) : (

--- a/src/serlo-editor/plugins/text/components/math-element.tsx
+++ b/src/serlo-editor/plugins/text/components/math-element.tsx
@@ -63,7 +63,6 @@ export function MathElement({
     // See: https://docs.slatejs.org/api/nodes/element#rendering-void-elements
     <VoidWrapper {...attributes} tabIndex={-1} contentEditable={false}>
       <MathEditor
-        autofocus
         state={element.src}
         inline={element.inline}
         readOnly={false}

--- a/src/serlo-editor/plugins/video/toolbar.tsx
+++ b/src/serlo-editor/plugins/video/toolbar.tsx
@@ -13,7 +13,6 @@ import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin
 export const VideoToolbar = ({
   id,
   state,
-  autofocusRef,
   showSettingsModal,
   setShowSettingsModal,
 }: VideoProps & {
@@ -68,7 +67,6 @@ export const VideoToolbar = ({
                   inputWidth="100%"
                   width="100%"
                   placeholder="(YouTube, Wikimedia Commons, Vimeo)"
-                  ref={autofocusRef}
                   className="block"
                 />
               </div>

--- a/src/serlo-editor/types/internal__plugin.ts
+++ b/src/serlo-editor/types/internal__plugin.ts
@@ -121,11 +121,6 @@ export interface EditorPluginProps<
    */
   focused: boolean
 
-  /**
-   * Ref to use for an input element. The element will receive focus, when the plugin is focused.
-   */
-  autofocusRef: React.RefObject<HTMLInputElement & HTMLTextAreaElement>
-
   // Ref for the wrapping SubDocument div
   containerRef?: React.RefObject<HTMLDivElement>
 }


### PR DESCRIPTION
there is like one case where this was actually helpful. 
I plan to replace this function with a different approach.

First step of new function in https://github.com/serlo/frontend/pull/2894.