### PR TITLE
feat(editor): add autoFocus attribute to modal inputs

### DIFF
--- a/src/serlo-editor-integration/components/save-modal.tsx
+++ b/src/serlo-editor-integration/components/save-modal.tsx
@@ -185,6 +185,7 @@ export function SaveModal({
         {edtrIoStrings.changes}{' '}
         <span className="font-bold text-red-500">*</span>
         <textarea
+          autoFocus
           value={changesText}
           onChange={(e) => {
             const { value } = e.target as HTMLTextAreaElement

--- a/src/serlo-editor/editor-ui/editor-input.tsx
+++ b/src/serlo-editor/editor-ui/editor-input.tsx
@@ -10,10 +10,11 @@ interface EditorInputProps
   label?: string
   inputWidth?: string
   width?: string
+  autoFocus?: boolean
 }
 
 export const EditorInput = forwardRef<HTMLInputElement, EditorInputProps>(
-  function EditorInput({ label, ...props }, ref) {
+  function EditorInput({ label, autoFocus, ...props }, ref) {
     const inputProps = { ...props }
     delete inputProps.inputWidth
 
@@ -21,6 +22,7 @@ export const EditorInput = forwardRef<HTMLInputElement, EditorInputProps>(
       <label className="text-almost-black" style={{ width: props.width }}>
         {label ?? ''}
         <input
+          autoFocus={autoFocus}
           {...inputProps}
           ref={ref}
           className={tw`

--- a/src/serlo-editor/plugins/audio/toolbar.tsx
+++ b/src/serlo-editor/plugins/audio/toolbar.tsx
@@ -68,6 +68,7 @@ export const AudioToolbar = ({
 
               <div className="mx-side mb-3">
                 <EditorInput
+                  autoFocus
                   label={`${audioStrings.audioUrl}: `}
                   value={state.src.value}
                   onChange={(e) => {

--- a/src/serlo-editor/plugins/geogebra/toolbar.tsx
+++ b/src/serlo-editor/plugins/geogebra/toolbar.tsx
@@ -46,6 +46,7 @@ export const GeogebraToolbar = ({
 
               <div className="mx-side mb-3">
                 <EditorInput
+                  autoFocus
                   label={`${geogebraStrings.urlOrId}: `}
                   placeholder="z.B. N5ktHvtW"
                   value={state.value}

--- a/src/serlo-editor/plugins/highlight/editor.tsx
+++ b/src/serlo-editor/plugins/highlight/editor.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { HighlightProps } from '.'
 import { HighlightToolbar } from './toolbar'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { tw } from '@/helper/tw'
 
 export function HighlightEditor(props: HighlightProps) {
   const { config, state, focused, editable } = props
@@ -10,8 +11,17 @@ export function HighlightEditor(props: HighlightProps) {
 
   const edit = focused && editable
   const [throttledEdit, setEditThrottled] = useState(edit)
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
   const editorStrings = useEditorStrings()
+
+  useEffect(() => {
+    if (edit) {
+      setTimeout(() => {
+        textAreaRef.current?.focus()
+      })
+    }
+  }, [edit])
 
   if (edit !== throttledEdit) {
     if (edit) {
@@ -23,8 +33,18 @@ export function HighlightEditor(props: HighlightProps) {
 
   const numberOflines = state.code.value.split(/\r\n|\r|\n/).length
 
-  return throttledEdit || edit ? (
-    <>
+  if (!throttledEdit && !edit) {
+    return (
+      <Renderer
+        language={state.language.value}
+        showLineNumbers={state.showLineNumbers.value}
+        code={state.code.value}
+      />
+    )
+  }
+
+  return (
+    <div className="mx-side">
       {focused && <HighlightToolbar {...props} />}
       <textarea
         value={state.code.value}
@@ -34,19 +54,18 @@ export function HighlightEditor(props: HighlightProps) {
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           state.code.set(e.target.value)
         }}
+        ref={textAreaRef}
         // make sure editor does not create new plugin on enter etc
         onKeyDown={(e) => e.stopPropagation()}
-        className="m-auto h-32 w-full border-none p-side font-mono shadow-menu"
-        style={{ height: `${40 + numberOflines * 24}px` }} // simple autogrow
+        className={tw`
+            m-auto w-full items-center rounded-xl border-3 border-editor-primary-200 p-side
+            pt-6 font-mono
+            focus-within:border-editor-primary-200 focus-within:outline-none
+          `}
+        style={{ height: `${50 + numberOflines * 26}px` }} // simple autogrow
       >
         {state.code.value}
       </textarea>
-    </>
-  ) : (
-    <Renderer
-      language={state.language.value}
-      showLineNumbers={state.showLineNumbers.value}
-      code={state.code.value}
-    />
+    </div>
   )
 }

--- a/src/serlo-editor/plugins/image/controls/overlay-input.tsx
+++ b/src/serlo-editor/plugins/image/controls/overlay-input.tsx
@@ -8,14 +8,16 @@ export interface OverlayInputProps
     HTMLInputElement
   > {
   label: string
+  autoFocus?: boolean
 }
 
 export const OverlayInput = forwardRef<HTMLInputElement, OverlayInputProps>(
-  function OverlayInput({ label, ...props }, ref) {
+  function OverlayInput({ label, autoFocus, ...props }, ref) {
     return (
       <label className="mx-auto mb-0 mt-5 flex items-center justify-between text-almost-black">
         <span className="w-1/5">{label}</span>
         <input
+          autoFocus={autoFocus}
           {...props}
           ref={ref}
           className={tw`

--- a/src/serlo-editor/plugins/image/controls/settings-modal-controls.tsx
+++ b/src/serlo-editor/plugins/image/controls/settings-modal-controls.tsx
@@ -15,6 +15,7 @@ export function SettingsModalControls({ state }: Pick<ImageProps, 'state'>) {
     <>
       <OverlayInput
         label={imageStrings.imageUrl}
+        autoFocus
         placeholder={
           !isTemp
             ? imageStrings.placeholderEmpty

--- a/src/serlo-editor/plugins/injection/toolbar.tsx
+++ b/src/serlo-editor/plugins/injection/toolbar.tsx
@@ -43,6 +43,7 @@ export const InjectionToolbar = ({
 
               <div className="mx-side mb-3">
                 <EditorInput
+                  autoFocus
                   label={`${injectionStrings.serloId}: `}
                   placeholder={injectionStrings.placeholder}
                   inputMode="numeric"

--- a/src/serlo-editor/plugins/paste-hack/editor.tsx
+++ b/src/serlo-editor/plugins/paste-hack/editor.tsx
@@ -132,6 +132,7 @@ export const PasteHackEditor: React.FunctionComponent<PasteHackPluginProps> = (
           </a>
         </p>
         <textarea
+          autoFocus
           ref={textareaRef}
           className={tw`
             mb-7 mt-1 flex w-full items-center rounded-2xl

--- a/src/serlo-editor/plugins/serlo-template-plugins/applet.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/applet.tsx
@@ -97,6 +97,7 @@ function AppletTypeEditor(props: EditorPluginProps<AppletTypePluginState>) {
         >
           <div className="mx-side mb-3 mt-12">
             <SettingsTextarea
+              autoFocus
               label={appletStrings.seoTitle}
               state={meta_title}
             />

--- a/src/serlo-editor/plugins/serlo-template-plugins/article.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/article.tsx
@@ -87,6 +87,7 @@ function ArticleTypeEditor(props: EditorPluginProps<ArticleTypePluginState>) {
             <SettingsTextarea
               label={articleStrings.seoTitle}
               state={meta_title}
+              autoFocus
             />
             <SettingsTextarea
               label={articleStrings.seoDesc}

--- a/src/serlo-editor/plugins/serlo-template-plugins/course/course.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/course/course.tsx
@@ -126,6 +126,7 @@ function CourseTypeEditor(props: EditorPluginProps<CourseTypePluginState>) {
         >
           <div className="mx-side mb-3 mt-12">
             <SettingsTextarea
+              autoFocus
               label={courseStrings.seoDesc}
               state={meta_description}
             />

--- a/src/serlo-editor/plugins/serlo-template-plugins/helpers/settings-textarea.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/helpers/settings-textarea.tsx
@@ -4,14 +4,17 @@ import { StateTypeReturnType, string } from '@/serlo-editor/plugin'
 export function SettingsTextarea({
   label,
   state,
+  autoFocus,
 }: {
   label: string
   state: StateTypeReturnType<ReturnType<typeof string>>
+  autoFocus?: boolean
 }) {
   return (
     <label className="font-bold">
       {label}
       <textarea
+        autoFocus={autoFocus}
         value={state.value}
         onChange={(e) => state.set(e.target.value)}
         className={tw`

--- a/src/serlo-editor/plugins/video/editor.tsx
+++ b/src/serlo-editor/plugins/video/editor.tsx
@@ -7,9 +7,12 @@ import { FaIcon } from '@/components/fa-icon'
 import { entityIconMapping } from '@/helper/icon-by-entity-type'
 import { EmbedWrapper } from '@/serlo-editor/editor-ui/embed-wrapper'
 
+export type SettingsModalState = 'url' | 'description' | false
+
 export const VideoEditor = (props: VideoProps) => {
   const { focused, state } = props
-  const [showSettingsModal, setShowSettingsModal] = useState(false)
+  const [showSettingsModal, setShowSettingsModal] =
+    useState<SettingsModalState>(false)
   const [iframeSrc, type] = parseVideoUrl(state.src.value)
   const couldBeValid = type !== undefined
 
@@ -35,7 +38,7 @@ export const VideoEditor = (props: VideoProps) => {
         <div
           className="mx-side cursor-pointer rounded-lg bg-editor-primary-50 py-32 text-center"
           data-qa="plugin-video-placeholder"
-          onClick={() => setShowSettingsModal(true)}
+          onClick={() => setShowSettingsModal('url')}
         >
           <FaIcon
             icon={entityIconMapping['video']}

--- a/src/serlo-editor/plugins/video/toolbar.tsx
+++ b/src/serlo-editor/plugins/video/toolbar.tsx
@@ -2,6 +2,7 @@ import { faPencilAlt } from '@fortawesome/free-solid-svg-icons'
 import { Dispatch, SetStateAction } from 'react'
 
 import type { VideoProps } from '.'
+import type { SettingsModalState } from './editor'
 import { EditorInput } from '../../editor-ui'
 import { FaIcon } from '@/components/fa-icon'
 import { ModalWithCloseButton } from '@/components/modal-with-close-button'
@@ -16,8 +17,8 @@ export const VideoToolbar = ({
   showSettingsModal,
   setShowSettingsModal,
 }: VideoProps & {
-  showSettingsModal: boolean
-  setShowSettingsModal: Dispatch<SetStateAction<boolean>>
+  showSettingsModal: SettingsModalState
+  setShowSettingsModal: Dispatch<SetStateAction<SettingsModalState>>
 }) => {
   const videoStrings = useEditorStrings().plugins.video
 
@@ -27,13 +28,13 @@ export const VideoToolbar = ({
       pluginSettings={
         <>
           <button
-            onClick={() => setShowSettingsModal(true)}
+            onClick={() => setShowSettingsModal('url')}
             className="mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
           >
             {videoStrings.videoUrl} <FaIcon icon={faPencilAlt} />
           </button>
           <button
-            onClick={() => setShowSettingsModal(true)}
+            onClick={() => setShowSettingsModal('description')}
             className="mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
           >
             {videoStrings.videoDescription} <FaIcon icon={faPencilAlt} />
@@ -41,7 +42,7 @@ export const VideoToolbar = ({
           {/* In the future we want a popovers per setting, but this is faster for now */}
           {showSettingsModal ? (
             <ModalWithCloseButton
-              isOpen={showSettingsModal}
+              isOpen={!!showSettingsModal}
               onCloseClick={() => setShowSettingsModal(false)}
               className="!top-1/3 !max-w-xl"
             >
@@ -49,16 +50,7 @@ export const VideoToolbar = ({
 
               <div className="mx-side mb-3">
                 <EditorInput
-                  label={`${videoStrings.videoDescription}: `}
-                  value={state.alt.value}
-                  onChange={(e) => state.alt.set(e.target.value)}
-                  width="100%"
-                  inputWidth="100%"
-                  className="block"
-                />
-              </div>
-              <div className="mx-side mb-3">
-                <EditorInput
+                  autoFocus={showSettingsModal === 'url'}
                   label={`${videoStrings.videoUrl}: `}
                   value={state.src.value}
                   onChange={(e) => {
@@ -67,6 +59,17 @@ export const VideoToolbar = ({
                   inputWidth="100%"
                   width="100%"
                   placeholder="(YouTube, Wikimedia Commons, Vimeo)"
+                  className="block"
+                />
+              </div>
+              <div className="mx-side mb-3">
+                <EditorInput
+                  autoFocus={showSettingsModal === 'description'}
+                  label={`${videoStrings.videoDescription}: `}
+                  value={state.alt.value}
+                  onChange={(e) => state.alt.set(e.target.value)}
+                  width="100%"
+                  inputWidth="100%"
                   className="block"
                 />
               </div>


### PR DESCRIPTION
works quite nicely in ff, chrome and safari.

[**Demo**](https://frontend-git-autofocus-for-modals-serlo.vercel.app/entity/repository/add-revision/277232)

(based on https://github.com/serlo/frontend/pull/2892)