### PR TITLE
Prevent opening plugin suggestions in unwanted places

### DIFF
--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -14,7 +14,10 @@ import { useInstanceData } from '@/contexts/instance-context'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 import { TextEditorFormattingOption } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/types'
-import { selectIsEmptyRows } from '@/serlo-editor/plugins/rows'
+import {
+  AllowedChildPlugins,
+  selectIsEmptyRows,
+} from '@/serlo-editor/plugins/rows'
 import { selectIsFocused, useAppSelector } from '@/serlo-editor/store'
 
 const titleFormattingOptions = [
@@ -82,13 +85,15 @@ export function BoxEditor(props: BoxProps) {
           boxType={typedValue}
           title={
             <div className="-ml-1 inline-block max-h-6 min-w-[15rem] font-bold">
-              {title.render({
-                config: {
-                  placeholder: editorStrings.plugins.box.titlePlaceholder,
-                  formattingOptions: titleFormattingOptions,
-                  isInlineChildEditor: true,
-                },
-              })}
+              <AllowedChildPlugins.Provider value={[]}>
+                {title.render({
+                  config: {
+                    placeholder: editorStrings.plugins.box.titlePlaceholder,
+                    formattingOptions: titleFormattingOptions,
+                    isInlineChildEditor: true,
+                  },
+                })}
+              </AllowedChildPlugins.Provider>
             </div>
           }
           anchorId={anchorId.value}

--- a/src/serlo-editor/plugins/equations/editor/editor.tsx
+++ b/src/serlo-editor/plugins/equations/editor/editor.tsx
@@ -12,6 +12,7 @@ import { useGridFocus } from './grid-focus'
 import { StepEditor } from './step-editor'
 import { StepSegment } from './step-segment'
 import type { EquationsProps } from '..'
+import { AllowedChildPlugins } from '../../rows'
 import {
   EquationsRenderer,
   type EquationsRendererStep,
@@ -215,73 +216,77 @@ export function EquationsEditor(props: EquationsProps) {
       : false
 
   return (
-    <div ref={pluginFocusWrapper} className="outline-none" tabIndex={-1}>
-      {props.focused || hasFocusWithin ? <EquationsToolbar {...props} /> : null}
-      <div className="mx-side py-2.5">
-        <table className="whitespace-nowrap">
-          {renderFirstExplanation()}
-          {state.steps.map((step, row) => {
-            return (
-              <tbody key={step.explanation.id}>
-                <tr>
-                  <StepEditor
-                    gridFocus={gridFocus}
-                    resetFocus={resetFocus}
-                    row={row}
-                    state={step}
-                    transformationTarget={transformationTarget}
-                  />
-                  <td>{renderButtons(row)}</td>
-                </tr>
-                {renderExplantionTr()}
-              </tbody>
-            )
-
-            function renderExplantionTr() {
-              if (row === state.steps.length - 1) return null
-
+    <AllowedChildPlugins.Provider value={[]}>
+      <div ref={pluginFocusWrapper} className="outline-none" tabIndex={-1}>
+        {props.focused || hasFocusWithin ? (
+          <EquationsToolbar {...props} />
+        ) : null}
+        <div className="mx-side py-2.5">
+          <table className="whitespace-nowrap">
+            {renderFirstExplanation()}
+            {state.steps.map((step, row) => {
               return (
-                <tr
-                  className="[&_div]:m-0"
-                  onFocus={() =>
-                    gridFocus.setFocus({
-                      row,
-                      column: StepSegment.Explanation,
-                    })
-                  }
-                >
-                  {transformationTarget === TransformationTarget.Equation && (
-                    <td />
-                  )}
-                  {!selectIsDocumentEmpty(
-                    store.getState(),
-                    step.explanation.id
-                  ) ? (
-                    renderDownArrow()
-                  ) : (
-                    <td />
-                  )}
-                  <td colSpan={2} className="min-w-[10rem]">
-                    {step.explanation.render({
-                      config: {
-                        isInlineChildEditor: true,
-                        placeholder:
-                          row === 0 &&
-                          transformationTarget === TransformationTarget.Term
-                            ? equationsStrings.combineLikeTerms
-                            : equationsStrings.explanation,
-                      },
-                    })}
-                  </td>
-                </tr>
+                <tbody key={step.explanation.id}>
+                  <tr>
+                    <StepEditor
+                      gridFocus={gridFocus}
+                      resetFocus={resetFocus}
+                      row={row}
+                      state={step}
+                      transformationTarget={transformationTarget}
+                    />
+                    <td>{renderButtons(row)}</td>
+                  </tr>
+                  {renderExplantionTr()}
+                </tbody>
               )
-            }
-          })}
-        </table>
 
-        {renderAddButton()}
+              function renderExplantionTr() {
+                if (row === state.steps.length - 1) return null
+
+                return (
+                  <tr
+                    className="[&_div]:m-0"
+                    onFocus={() =>
+                      gridFocus.setFocus({
+                        row,
+                        column: StepSegment.Explanation,
+                      })
+                    }
+                  >
+                    {transformationTarget === TransformationTarget.Equation && (
+                      <td />
+                    )}
+                    {!selectIsDocumentEmpty(
+                      store.getState(),
+                      step.explanation.id
+                    ) ? (
+                      renderDownArrow()
+                    ) : (
+                      <td />
+                    )}
+                    <td colSpan={2} className="min-w-[10rem]">
+                      {step.explanation.render({
+                        config: {
+                          isInlineChildEditor: true,
+                          placeholder:
+                            row === 0 &&
+                            transformationTarget === TransformationTarget.Term
+                              ? equationsStrings.combineLikeTerms
+                              : equationsStrings.explanation,
+                        },
+                      })}
+                    </td>
+                  </tr>
+                )
+              }
+            })}
+          </table>
+
+          {renderAddButton()}
+        </div>
       </div>
-    </div>
+    </AllowedChildPlugins.Provider>
   )
 
   function renderFirstExplanation() {

--- a/src/serlo-editor/plugins/image/editor.tsx
+++ b/src/serlo-editor/plugins/image/editor.tsx
@@ -5,6 +5,7 @@ import type { ImageProps } from '.'
 import { InlineSrcControls } from './controls/inline-src-controls'
 import { ImageRenderer } from './renderer'
 import { ImageToolbar } from './toolbar'
+import { AllowedChildPlugins } from '../rows'
 import { TextEditorConfig } from '../text'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
@@ -103,12 +104,18 @@ export function ImageEditor(props: ImageProps) {
   function renderCaption() {
     if (!state.caption.defined) return null
 
-    return state.caption.render({
-      config: {
-        placeholder: imageStrings.captionPlaceholder,
-        formattingOptions: captionFormattingOptions,
-        isInlineChildEditor: true,
-      } as TextEditorConfig,
-    })
+    return (
+      <>
+        <AllowedChildPlugins.Provider value={[]}>
+          {state.caption.render({
+            config: {
+              placeholder: imageStrings.captionPlaceholder,
+              formattingOptions: captionFormattingOptions,
+              isInlineChildEditor: true,
+            } as TextEditorConfig,
+          })}
+        </AllowedChildPlugins.Provider>
+      </>
+    )
   }
 }

--- a/src/serlo-editor/plugins/input-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/input-exercise/editor.tsx
@@ -10,6 +10,7 @@ import {
   store,
   useAppSelector,
 } from '../../store'
+import { AllowedChildPlugins } from '../rows'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 
 export function InputExerciseEditor(props: InputExerciseProps) {
@@ -51,32 +52,34 @@ export function InputExerciseEditor(props: InputExerciseProps) {
       </PreviewOverlay>
       {nestedFocus && !previewActive && (
         <>
-          {state.answers.map((answer, index: number) => {
-            return (
-              <InteractiveAnswer
-                key={answer.feedback.id}
-                answer={
-                  <input
-                    className="width-full border-none outline-none"
-                    value={answer.value.value}
-                    placeholder={inputExStrings.enterTheValue}
-                    type="text"
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      answer.value.set(e.target.value)
-                    }}
-                  />
-                }
-                feedback={answer.feedback.render()}
-                feedbackID={answer.feedback.id}
-                isActive={answer.isCorrect.value}
-                handleChange={() =>
-                  answer.isCorrect.set(!answer.isCorrect.value)
-                }
-                remove={() => state.answers.remove(index)}
-                focusedElement={focusedElement || undefined}
-              />
-            )
-          })}
+          <AllowedChildPlugins.Provider value={[]}>
+            {state.answers.map((answer, index: number) => {
+              return (
+                <InteractiveAnswer
+                  key={answer.feedback.id}
+                  answer={
+                    <input
+                      className="width-full border-none outline-none"
+                      value={answer.value.value}
+                      placeholder={inputExStrings.enterTheValue}
+                      type="text"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        answer.value.set(e.target.value)
+                      }}
+                    />
+                  }
+                  feedback={answer.feedback.render()}
+                  feedbackID={answer.feedback.id}
+                  isActive={answer.isCorrect.value}
+                  handleChange={() =>
+                    answer.isCorrect.set(!answer.isCorrect.value)
+                  }
+                  remove={() => state.answers.remove(index)}
+                  focusedElement={focusedElement || undefined}
+                />
+              )
+            })}
+          </AllowedChildPlugins.Provider>
           <AddButton onClick={() => state.answers.insert()}>
             {inputExStrings.addAnswer}
           </AddButton>

--- a/src/serlo-editor/plugins/sc-mc-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/sc-mc-exercise/editor.tsx
@@ -10,6 +10,7 @@ import {
   selectIsDocumentEmpty,
   useAppSelector,
 } from '../../store'
+import { AllowedChildPlugins } from '../rows'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { EditableContext } from '@/serlo-editor/core/contexts'
 
@@ -75,7 +76,7 @@ export function ScMcExerciseEditor(props: ScMcExerciseProps) {
         {renderer}
       </PreviewOverlay>
       {editable && nestedFocus && !previewActive && (
-        <>
+        <AllowedChildPlugins.Provider value={[]}>
           {state.answers.map((answer, index) => {
             return (
               <InteractiveAnswer
@@ -99,7 +100,7 @@ export function ScMcExerciseEditor(props: ScMcExerciseProps) {
           <AddButton onClick={handleAddButtonClick}>
             {editorStrings.templatePlugins.scMcExercise.addAnswer}
           </AddButton>
-        </>
+        </AllowedChildPlugins.Provider>
       )}
     </div>
   )

--- a/src/serlo-editor/plugins/serlo-table/editor.tsx
+++ b/src/serlo-editor/plugins/serlo-table/editor.tsx
@@ -8,6 +8,7 @@ import { useAreImagesDisabledInTable } from './contexts/are-images-disabled-in-t
 import { SerloTableRenderer, TableType } from './renderer'
 import { SerloTableToolbar } from './toolbar'
 import { getTableType } from './utils/get-table-type'
+import { AllowedChildPlugins } from '../rows'
 import { TextEditorConfig } from '../text'
 import { instanceStateStore } from '../text/utils/instance-state-store'
 import { FaIcon } from '@/components/fa-icon'
@@ -127,22 +128,24 @@ export function SerloTableEditor(props: SerloTableProps) {
               )}
             >
               {renderInlineNav(rowIndex, colIndex)}
-              {cell.content.render({
-                config: {
-                  isInlineChildEditor: true,
-                  placeholder: '',
-                  formattingOptions: isHead
-                    ? headerTextFormattingOptions
-                    : cellTextFormattingOptions,
-                } as TextEditorConfig,
-              })}
-              {props.config.allowImageInTableCells && !areImagesDisabled ? (
-                <CellSwitchButton
-                  cell={cell}
-                  isHead={isHead}
-                  isClear={isClear}
-                />
-              ) : null}
+              <AllowedChildPlugins.Provider value={[]}>
+                {cell.content.render({
+                  config: {
+                    isInlineChildEditor: true,
+                    placeholder: '',
+                    formattingOptions: isHead
+                      ? headerTextFormattingOptions
+                      : cellTextFormattingOptions,
+                  } as TextEditorConfig,
+                })}
+                {props.config.allowImageInTableCells && !areImagesDisabled ? (
+                  <CellSwitchButton
+                    cell={cell}
+                    isHead={isHead}
+                    isClear={isClear}
+                  />
+                ) : null}
+              </AllowedChildPlugins.Provider>
             </div>
           )
         }),

--- a/src/serlo-editor/plugins/text/components/text-toolbar.tsx
+++ b/src/serlo-editor/plugins/text/components/text-toolbar.tsx
@@ -23,6 +23,7 @@ export function TextToolbar({
 }: TextToolbarProps) {
   const editor = useSlate()
 
+  // Text plugins where isInlineChildEditor === true do not have a toolbar displayed directly above them. Example: Table cell. So the toolbar controls are rendered into a parent plugin toolbar.
   if (config.isInlineChildEditor) {
     if (!containerRef || !containerRef.current) return null
     const target = containerRef.current


### PR DESCRIPTION
Quick solution for fixing #2897 

Potential followup: 
Configuring what plugins are allowed where is done multiple ways: 
- `AllowedChildPlugins` context
- Plugin config prop
- Initial plugin state & config

Feels like we might be able to centralize this more. 