### PR TITLE
fix(editor): correct focus after modal close

### DIFF
--- a/src/components/modal-with-close-button.tsx
+++ b/src/components/modal-with-close-button.tsx
@@ -37,7 +37,6 @@ export function ModalWithCloseButton({
     <BaseModal
       isOpen={isOpen}
       onRequestClose={onCloseClick}
-      shouldReturnFocusAfterClose={false}
       className={clsx(ModalClsx, 'top-[40%] w-[500px] pb-10', className)}
     >
       {title && <h2 className="serlo-h2">{title}</h2>}


### PR DESCRIPTION
for https://github.com/serlo/frontend/issues/2906

this works fine. we probably introduced this setting for some styling reasons (ugly focus border around opening button) but since this increases a11y/keyboard nav we should tackle the styling issues another way 😸