### PR TITLE
fix(plugin-text): remove unnecessary double selection change

### DIFF
--- a/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -118,14 +118,20 @@ export const useEditableKeydownHandler = (
           const direction = isBackspaceAtStart ? 'previous' : 'next'
 
           // Merge plugins within Slate and get the merge value
-          const newValue = mergePlugins(direction, editor, id)
+          const newEditorState = mergePlugins(direction, editor, id)
 
           // Update Redux document state with the new value
-          if (newValue) {
-            state.set({ value: newValue, selection }, ({ value }) => ({
-              value,
-              selection: instanceStateStore[id].selection,
-            }))
+          if (newEditorState) {
+            state.set(
+              {
+                value: newEditorState.value,
+                selection: newEditorState.selection,
+              },
+              ({ value }) => ({
+                value,
+                selection: instanceStateStore[id].selection,
+              })
+            )
           }
         }
 

--- a/src/serlo-editor/plugins/text/utils/document.ts
+++ b/src/serlo-editor/plugins/text/utils/document.ts
@@ -1,4 +1,10 @@
-import { Descendant, Node, Editor as SlateEditor, Transforms } from 'slate'
+import {
+  BaseSelection,
+  Descendant,
+  Node,
+  Editor as SlateEditor,
+  Transforms,
+} from 'slate'
 
 import { isSelectionAtEnd } from './selection'
 import type { TextEditorState } from '../types/config'
@@ -111,16 +117,23 @@ export function mergePlugins(
         })
       )
 
-      // Set selection to where it was before the merge
-      setTimeout(() => {
-        Transforms.select(editor, {
+      // New selection should start at the point where the plugins merged
+      const newSelection: BaseSelection = {
+        anchor: {
           offset: 0,
           path: [previousDocumentChildrenCount, 0],
-        })
-      })
+        },
+        focus: {
+          offset: 0,
+          path: [previousDocumentChildrenCount, 0],
+        },
+      }
 
       // Return the merge value
-      return newValue
+      return {
+        value: newValue,
+        selection: newSelection,
+      }
     }
   } else {
     // Exit if text plugin is the last child of its parent
@@ -144,7 +157,10 @@ export function mergePlugins(
       )
 
       // Return the merge value
-      return newValue
+      return {
+        value: newValue,
+        selection: editor.selection,
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes the [issue](https://github.com/serlo/frontend/issues/2798) that triggers an error when attempting to merge 2 text plugins with backspace when the first one starts with a list.
It turns out the problem was caused by an invalid selection after the 2 plugins merged.

@hejtful thanks again for the help!