### PR TITLE
fix(editor): first box fixes/improvements

### DIFF
--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -76,7 +76,7 @@ export function BoxEditor(props: BoxProps) {
       <div
         className={clsx(
           showToolbar && '[&>figure]:rounded-t-none',
-          !focusWithin && editable && isEmptyContent ? 'opacity-50' : '',
+          !focusWithin && editable && isEmptyContent ? 'opacity-30' : '',
           editable &&
             tw`
             [&>figure>div]:!mt-8
@@ -104,8 +104,8 @@ export function BoxEditor(props: BoxProps) {
         >
           <div className="-ml-3 px-side">{content.render()}</div>
         </BoxRenderer>
+        {focusWithin ? renderWarning() : null}
       </div>
-      {focusWithin ? renderWarning() : null}
     </>
   )
 
@@ -136,8 +136,8 @@ export function BoxEditor(props: BoxProps) {
 
   function renderWarning() {
     return isEmptyContent && editable ? (
-      <div className="mt-1 text-right">
-        <span className="bg-editor-primary-100 p-0.5 text-sm">
+      <div className="text-side absolute left-10 -mt-[1.65rem]">
+        <span className="bg-editor-primary-100 px-1.5 py-0.5 text-sm">
           ⚠️ {editorStrings.plugins.box.emptyContentWarning}
         </span>
       </div>

--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -15,11 +15,7 @@ import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 import { TextEditorFormattingOption } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/types'
 import { selectIsEmptyRows } from '@/serlo-editor/plugins/rows'
-import {
-  selectHasFocusedChild,
-  selectIsFocused,
-  useAppSelector,
-} from '@/serlo-editor/store'
+import { selectIsFocused, useAppSelector } from '@/serlo-editor/store'
 
 const titleFormattingOptions = [
   TextEditorFormattingOption.math,
@@ -47,12 +43,8 @@ export function BoxEditor(props: BoxProps) {
   const isTitleFocused = useAppSelector((state) =>
     selectIsFocused(state, title.id)
   )
-  const isContentFocused = useAppSelector((state) =>
-    selectHasFocusedChild(state, content.id)
-  )
 
   const showToolbar = focused || isTitleFocused
-  const focusWithin = focused || isContentFocused || isTitleFocused
 
   if (hasNoType) {
     return (
@@ -77,7 +69,7 @@ export function BoxEditor(props: BoxProps) {
       <div
         className={clsx(
           showToolbar && '[&>figure]:rounded-t-none',
-          !focusWithin && editable && isEmptyContent ? 'opacity-30' : '',
+          editable && isEmptyContent && 'opacity-30 focus-within:opacity-100 ',
           // making space for first toolbar, not wysiwyg
           '[&>figure>figcaption]:!mb-9',
           // toolbar finetuning
@@ -107,7 +99,7 @@ export function BoxEditor(props: BoxProps) {
         >
           <div className="-ml-3 px-side">{content.render()}</div>
         </BoxRenderer>
-        {focusWithin ? renderWarning() : null}
+        {renderWarning()}
       </div>
     </>
   )
@@ -139,7 +131,7 @@ export function BoxEditor(props: BoxProps) {
 
   function renderWarning() {
     return isEmptyContent && editable ? (
-      <div className="text-side absolute left-10 -mt-[1.65rem]">
+      <div className="box-warning text-side absolute left-10 -mt-[1.65rem]">
         <span className="bg-editor-primary-100 px-1.5 py-0.5 text-sm">
           ⚠️ {editorStrings.plugins.box.emptyContentWarning}
         </span>

--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -58,12 +58,12 @@ export function BoxEditor(props: BoxProps) {
       <>
         <figure
           className={clsx(
-            'relative rounded-xl border-3 p-4 pt-2',
+            'relative mx-side rounded-xl border-3 p-4 pt-2',
             borderColorClass
           )}
         >
-          <b className="block pb-4">{editorStrings.plugins.box.type}</b>
-          <ul className="unstyled-list pb-8">{renderSettingsListItems()}</ul>
+          <b className="block pb-3">{editorStrings.plugins.box.type}</b>
+          <ul className="unstyled-list">{renderSettingsListItems()}</ul>
         </figure>
       </>
     )
@@ -118,7 +118,7 @@ export function BoxEditor(props: BoxProps) {
         : undefined
 
       return (
-        <li key={typedBoxType} className="inline-block pb-4 pr-4">
+        <li key={typedBoxType} className="inline-block pb-3.5 pr-4">
           <button
             className="serlo-button-editor-secondary"
             onClick={(event) => {

--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -69,7 +69,9 @@ export function BoxEditor(props: BoxProps) {
       <div
         className={clsx(
           showToolbar && '[&>figure]:rounded-t-none',
-          editable && isEmptyContent && 'opacity-30 focus-within:opacity-100 ',
+          'transition-opacity',
+          editable && isEmptyContent && 'opacity-30 focus-within:opacity-100',
+          showToolbar && '!opacity-100 ',
           // making space for first toolbar, not wysiwyg
           '[&>figure>figcaption]:!mb-9',
           // toolbar finetuning

--- a/src/serlo-editor/plugins/box/editor.tsx
+++ b/src/serlo-editor/plugins/box/editor.tsx
@@ -36,6 +36,7 @@ export function BoxEditor(props: BoxProps) {
   const borderColorClass = Object.hasOwn(style, 'borderColorClass')
     ? style.borderColorClass
     : defaultStyle.borderColorClass
+
   const contentId = content.get()
   const isEmptyContent = useAppSelector((state) =>
     selectIsEmptyRows(state, contentId)
@@ -77,9 +78,11 @@ export function BoxEditor(props: BoxProps) {
         className={clsx(
           showToolbar && '[&>figure]:rounded-t-none',
           !focusWithin && editable && isEmptyContent ? 'opacity-30' : '',
+          // making space for first toolbar, not wysiwyg
+          '[&>figure>figcaption]:!mb-9',
+          // toolbar finetuning
           editable &&
             tw`
-            [&>figure>div]:!mt-8
             [&_.plugin-toolbar]:ml-[-2px]
             [&_.plugin-toolbar]:mr-[-16px]
             [&_.plugin-toolbar]:rounded-none

--- a/src/serlo-editor/plugins/box/index.tsx
+++ b/src/serlo-editor/plugins/box/index.tsx
@@ -17,6 +17,7 @@ function createBoxState(allowedPlugins: (EditorPluginType | string)[]) {
         noLinebreaks: true,
       },
     }),
+    // we don't generate new id's any more but keep the old ones for now
     anchorId: string(''),
     content: child({
       plugin: EditorPluginType.Rows,

--- a/src/serlo-editor/plugins/box/renderer.tsx
+++ b/src/serlo-editor/plugins/box/renderer.tsx
@@ -82,14 +82,12 @@ export function BoxRenderer({ boxType, title, anchorId, children }: BoxProps) {
       <figcaption className="px-side pb-2 pt-2.5 text-lg">
         <a className="!no-underline">
           {isBlank ? null : (
-            <>
-              <span
-                className={clsx(title && !isBlank ? 'mr-1.5' : '', colorClass)}
-              >
-                {icon ? <FaIcon className="mr-1" icon={icon} /> : null}
-                {strings.content.boxTypes[boxType]}
-              </span>
-            </>
+            <span
+              className={clsx(title && !isBlank ? 'mr-1.5' : '', colorClass)}
+            >
+              {icon ? <FaIcon className="mr-1" icon={icon} /> : null}
+              {strings.content.boxTypes[boxType]}
+            </span>
           )}
           {title}
         </a>

--- a/src/serlo-editor/plugins/box/renderer.tsx
+++ b/src/serlo-editor/plugins/box/renderer.tsx
@@ -80,7 +80,7 @@ export function BoxRenderer({ boxType, title, anchorId, children }: BoxProps) {
   function renderHeader() {
     return (
       <figcaption className="px-side pb-2 pt-2.5 text-lg">
-        <a className="!no-underline" id={anchorId}>
+        <a className="!no-underline">
           {isBlank ? null : (
             <>
               <span


### PR DESCRIPTION
(for https://trello.com/c/pIaQccPX/326-improve-box-plugin)

### [Preview](https://frontend-git-some-box-improvements-serlo.vercel.app/entity/repository/add-revision/277232)

- does not switch width any more
- less layout jumps (warning pos absolute, type menu similar height as empty state, quote margin fixed)
- low opacity when empty and not focused to indicate it will not be shown to the learners

