### PR TITLE
feat(editor): simple focus after undo redo for some cases

### DIFF
--- a/src/serlo-editor/store/documents/saga.ts
+++ b/src/serlo-editor/store/documents/saga.ts
@@ -16,6 +16,7 @@ import {
   StateUpdater,
   StoreDeserializeHelpers,
 } from '../../types/internal__plugin-state'
+// eslint-disable-next-line import/no-cycle
 import {
   runCommitActionToHistorySaga,
   runCommitTemporaryActionToHistorySaga,

--- a/src/serlo-editor/store/history/index.ts
+++ b/src/serlo-editor/store/history/index.ts
@@ -1,3 +1,4 @@
 export * from './saga-actions'
 export * from './selectors'
+// eslint-disable-next-line import/no-cycle
 export * from './slice'

--- a/src/serlo-editor/store/history/saga.ts
+++ b/src/serlo-editor/store/history/saga.ts
@@ -10,6 +10,7 @@ import {
   takeEvery,
 } from 'redux-saga/effects'
 
+// eslint-disable-next-line import/no-cycle
 import {
   runCommitActionToHistorySaga,
   pureCommitActionToHistory,

--- a/src/serlo-editor/store/index.ts
+++ b/src/serlo-editor/store/index.ts
@@ -1,5 +1,6 @@
 export * from './documents'
 export * from './focus'
+// eslint-disable-next-line import/no-cycle
 export * from './history'
 export * from './plugin'
 export * from './root'

--- a/src/serlo-editor/store/root/saga.ts
+++ b/src/serlo-editor/store/root/saga.ts
@@ -4,6 +4,7 @@ import { runInitRootSaga } from '.'
 import { ROOT } from './constants'
 import type { ReversibleAction } from '..'
 import { selectDocuments } from '../documents'
+// eslint-disable-next-line import/no-cycle
 import { handleRecursiveInserts } from '../documents/saga'
 import { persistHistory } from '../history'
 

--- a/src/serlo-editor/store/saga.ts
+++ b/src/serlo-editor/store/saga.ts
@@ -1,5 +1,6 @@
 import { all, call } from 'redux-saga/effects'
 
+// eslint-disable-next-line import/no-cycle
 import { documentsSaga } from './documents/saga'
 import { historySaga } from './history/saga'
 import { pluginSaga } from './plugin/saga'

--- a/src/serlo-editor/store/store.ts
+++ b/src/serlo-editor/store/store.ts
@@ -4,6 +4,7 @@ import createSagaMiddleware from 'redux-saga'
 
 import { documentsSlice } from './documents'
 import { focusSlice } from './focus'
+// eslint-disable-next-line import/no-cycle
 import { historySlice } from './history'
 import { saga } from './saga'
 


### PR DESCRIPTION
low hanging fruits for https://github.com/serlo/backlog/issues/257

- It only sets focus to the plugin (not caring about slate cursor etc. but we handle that inside the text plugin anyway I think)
- Does not work when targeting the rows plugin (deleting/changing order) but most other cases work so it's an improvement

Todo: solve dependency cycle madness
