### PR TITLE
refactor(plugin-input-exercise): use enum for type and make `NumberExact` the default type

### DIFF
--- a/src/components/pages/editor/education-plugin-examples.tsx
+++ b/src/components/pages/editor/education-plugin-examples.tsx
@@ -9,6 +9,7 @@ import { renderNested } from '@/schema/article-renderer'
 import { Sign } from '@/serlo-editor/plugins/equations/sign'
 import { HighlightRenderer } from '@/serlo-editor/plugins/highlight/renderer'
 import { InjectionRenderer } from '@/serlo-editor/plugins/injection/renderer'
+import { InputExerciseType } from '@/serlo-editor/plugins/input-exercise/input-exercise-type'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export const boxExample = (
@@ -196,7 +197,7 @@ export const inputExample = (
           interactive: {
             plugin: EditorPluginType.InputExercise,
             state: {
-              type: 'input-string-normalized-match-challenge',
+              type: InputExerciseType.StringNormalized,
               unit: '',
               answers: [
                 {

--- a/src/frontend-node-types.ts
+++ b/src/frontend-node-types.ts
@@ -1,6 +1,7 @@
 import type { LicenseData } from './data-types'
 import type { BoxType } from './serlo-editor/plugins/box/renderer'
 import { Sign } from './serlo-editor/plugins/equations/sign'
+import { InputExerciseType } from './serlo-editor/plugins/input-exercise/input-exercise-type'
 import type { PageTeamRendererProps } from './serlo-editor/plugins/page-team/renderer'
 import { TableType } from './serlo-editor/plugins/serlo-table/renderer'
 import type { CustomText } from './serlo-editor/plugins/text'
@@ -331,10 +332,7 @@ export interface EditorPluginScMcExercise {
 export interface EditorPluginInputExercise {
   plugin: EditorPluginType.InputExercise // editor plugin
   state: {
-    type:
-      | 'input-number-exact-match-challenge'
-      | 'input-string-normalized-match-challenge'
-      | 'input-expression-equal-match-challenge'
+    type: InputExerciseType
     answers: {
       value: string
       isCorrect: boolean

--- a/src/serlo-editor/plugins/input-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/input-exercise/editor.tsx
@@ -90,6 +90,10 @@ export function InputExerciseEditor(props: InputExerciseProps) {
               setTimeout(() => {
                 dispatch(focus(id))
                 newestAnswerRef.current?.focus()
+                // this needs to wait for the editor focus to finish
+                // and then overwrite it. It's definitely a hack.
+                // 50 is arbitrary value that seems to work nicely.
+                // 10 was to low for firefox in my testing
               }, 50)
             }}
           >

--- a/src/serlo-editor/plugins/input-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/input-exercise/editor.tsx
@@ -90,7 +90,7 @@ export function InputExerciseEditor(props: InputExerciseProps) {
               setTimeout(() => {
                 dispatch(focus(id))
                 newestAnswerRef.current?.focus()
-              }, 10)
+              }, 50)
             }}
           >
             {inputExStrings.addAnswer}

--- a/src/serlo-editor/plugins/input-exercise/index.ts
+++ b/src/serlo-editor/plugins/input-exercise/index.ts
@@ -1,4 +1,5 @@
 import { InputExerciseEditor } from './editor'
+import { InputExerciseType } from './input-exercise-type'
 import {
   type ChildStateTypeConfig,
   type EditorPlugin,
@@ -21,7 +22,7 @@ function createInputExerciseState(
   })
 
   return object({
-    type: string('input-string-normalized-match-challenge'),
+    type: string(InputExerciseType.StringNormalized),
     unit: string(''),
     answers: list(answerObject),
   })

--- a/src/serlo-editor/plugins/input-exercise/index.ts
+++ b/src/serlo-editor/plugins/input-exercise/index.ts
@@ -22,7 +22,7 @@ function createInputExerciseState(
   })
 
   return object({
-    type: string(InputExerciseType.StringNormalized),
+    type: string(InputExerciseType.NumberExact),
     unit: string(''),
     answers: list(answerObject),
   })

--- a/src/serlo-editor/plugins/input-exercise/input-exercise-type.ts
+++ b/src/serlo-editor/plugins/input-exercise/input-exercise-type.ts
@@ -1,5 +1,5 @@
 export enum InputExerciseType {
-  InputStringNormalizedMatchChallenge = 'input-string-normalized-match-challenge',
-  InputNumberExactMatchChallenge = 'input-number-exact-match-challenge',
-  InputExpressionEqualMatchChallenge = 'input-expression-equal-match-challenge',
+  NumberExact = 'input-number-exact-match-challenge',
+  ExpressionEqual = 'input-expression-equal-match-challenge',
+  StringNormalized = 'input-string-normalized-match-challenge',
 }

--- a/src/serlo-editor/plugins/input-exercise/renderer.tsx
+++ b/src/serlo-editor/plugins/input-exercise/renderer.tsx
@@ -2,6 +2,7 @@ import type A from 'algebra.js'
 import clsx from 'clsx'
 import { useState, useEffect } from 'react'
 
+import { InputExerciseType } from './input-exercise-type'
 import { Feedback } from '@/components/content/exercises/feedback'
 import { useInstanceData } from '@/contexts/instance-context'
 import { tw } from '@/helper/tw'
@@ -112,11 +113,11 @@ export function InputExerciseRenderer({
   function normalize(value: string) {
     const _value = collapseWhitespace(value)
     switch (type) {
-      case 'input-number-exact-match-challenge':
+      case InputExerciseType.NumberExact:
         return normalizeNumber(_value).replace(/\s/g, '')
-      case 'input-expression-equal-match-challenge':
+      case InputExerciseType.ExpressionEqual:
         return A ? A.parse(normalizeNumber(_value)) : undefined
-      case 'input-string-normalized-match-challenge':
+      case InputExerciseType.StringNormalized:
         return _value.toUpperCase()
     }
   }


### PR DESCRIPTION
### [(preview)](https://frontend-git-small-input-ex-improvements-serlo.vercel.app/entity/create/Exercise/60730)

the default type change is a community wish

ping @AsterMiha I hope this does not interfere with your work on https://github.com/serlo/frontend/issues/2916 but I can also solve conflicts if it does.