### PR TITLE
feat(plugin-input-exercise): Mark the first answer as correct by default

### DIFF
--- a/src/serlo-editor/plugins/input-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/input-exercise/editor.tsx
@@ -15,6 +15,8 @@ import {
   useAppDispatch,
 } from '../../store'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { boolean } from '@/serlo-editor/plugin/scalar'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export function InputExerciseEditor(props: InputExerciseProps) {
   const { editable, state, id } = props
@@ -86,7 +88,12 @@ export function InputExerciseEditor(props: InputExerciseProps) {
           })}
           <AddButton
             onClick={() => {
-              state.answers.insert()
+              const wrongAnswer = {
+                value: '',
+                isCorrect: false,
+                feedback: { plugin: EditorPluginType.Text },
+              }
+              state.answers.insert(undefined, wrongAnswer)
               setTimeout(() => {
                 dispatch(focus(id))
                 newestAnswerRef.current?.focus()

--- a/src/serlo-editor/plugins/input-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/input-exercise/editor.tsx
@@ -15,7 +15,6 @@ import {
   useAppDispatch,
 } from '../../store'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
-import { boolean } from '@/serlo-editor/plugin/scalar'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export function InputExerciseEditor(props: InputExerciseProps) {

--- a/src/serlo-editor/plugins/input-exercise/index.ts
+++ b/src/serlo-editor/plugins/input-exercise/index.ts
@@ -17,14 +17,14 @@ function createInputExerciseState(
 ) {
   const answerObject = object({
     value: string(''),
-    isCorrect: boolean(),
+    isCorrect: boolean(true),
     feedback: child(feedback),
   })
 
   return object({
     type: string(InputExerciseType.NumberExact),
     unit: string(''),
-    answers: list(answerObject),
+    answers: list(answerObject, 1),
   })
 }
 


### PR DESCRIPTION
By default, first answer to an input exercise will be marked as being correct, as suggested in [this issue](https://github.com/serlo/frontend/issues/2916)