### PR TITLE
chore(editor): cleanup types

### DIFF
--- a/src/components/content/static-entity.tsx
+++ b/src/components/content/static-entity.tsx
@@ -26,7 +26,7 @@ import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
 import { CourseNavigation } from '@/serlo-editor/plugins/serlo-template-plugins/course/course-navigation'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
-import { SupportedEditorPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface EntityProps {
   data: EntityData
@@ -137,7 +137,7 @@ export function StaticEntity({ data }: EntityProps) {
 
   function renderContent(value: FrontendContentNode[]) {
     const content = (
-      <StaticRenderer document={value as unknown as SupportedEditorPlugin} />
+      <StaticRenderer document={value as unknown as SupportedEditorDocument} />
     )
     if (data.schemaData?.setContentAsSection) {
       return <section itemProp="articleBody">{content}</section>

--- a/src/components/content/static-entity.tsx
+++ b/src/components/content/static-entity.tsx
@@ -26,7 +26,7 @@ import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
 import { CourseNavigation } from '@/serlo-editor/plugins/serlo-template-plugins/course/course-navigation'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
-import { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
+import { AnyEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface EntityProps {
   data: EntityData
@@ -137,7 +137,7 @@ export function StaticEntity({ data }: EntityProps) {
 
   function renderContent(value: FrontendContentNode[]) {
     const content = (
-      <StaticRenderer document={value as unknown as SupportedEditorDocument} />
+      <StaticRenderer document={value as unknown as AnyEditorDocument} />
     )
     if (data.schemaData?.setContentAsSection) {
       return <section itemProp="articleBody">{content}</section>

--- a/src/components/taxonomy/static-sub-taxonomy.tsx
+++ b/src/components/taxonomy/static-sub-taxonomy.tsx
@@ -2,7 +2,7 @@ import { TopicCategories } from './topic-categories'
 import { Link } from '@/components/content/link'
 import { TaxonomySubTerm } from '@/data-types'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorRowsDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface SubTopicProps {
   data: TaxonomySubTerm
@@ -25,7 +25,7 @@ export function StaticSubTaxonomy({ data, subid, hideTitle }: SubTopicProps) {
           {' '}
           <div className="mt-6 sm:mb-5">
             <StaticRenderer
-              document={data.description as unknown as SupportedEditorDocument}
+              document={data.description as unknown as EditorRowsDocument}
             />
           </div>
         </div>

--- a/src/components/taxonomy/static-sub-taxonomy.tsx
+++ b/src/components/taxonomy/static-sub-taxonomy.tsx
@@ -2,7 +2,7 @@ import { TopicCategories } from './topic-categories'
 import { Link } from '@/components/content/link'
 import { TaxonomySubTerm } from '@/data-types'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { SupportedEditorPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface SubTopicProps {
   data: TaxonomySubTerm
@@ -25,7 +25,7 @@ export function StaticSubTaxonomy({ data, subid, hideTitle }: SubTopicProps) {
           {' '}
           <div className="mt-6 sm:mb-5">
             <StaticRenderer
-              document={data.description as unknown as SupportedEditorPlugin}
+              document={data.description as unknown as SupportedEditorDocument}
             />
           </div>
         </div>

--- a/src/components/taxonomy/static-taxonomy.tsx
+++ b/src/components/taxonomy/static-taxonomy.tsx
@@ -22,9 +22,9 @@ import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
 import {
-  EditorExercisePlugin,
-  EditorSolutionPlugin,
-  SupportedEditorPlugin,
+  EditorExerciseDocument,
+  EditorSolutionDocument,
+  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface TopicProps {
@@ -69,7 +69,7 @@ export function StaticTaxonomy({ data }: TopicProps) {
       <div className="min-h-1/2">
         <div className="mt-6 sm:mb-5">
           <StaticRenderer
-            document={data.description as unknown as SupportedEditorPlugin}
+            document={data.description as unknown as SupportedEditorDocument}
           />
         </div>
 
@@ -160,8 +160,8 @@ export function StaticTaxonomy({ data }: TopicProps) {
         {data.exercisesContent.map((inExercise, i) => {
           // for static
           const exerciseArray = inExercise as unknown as
-            | [EditorExercisePlugin]
-            | [EditorExercisePlugin, EditorSolutionPlugin]
+            | [EditorExerciseDocument]
+            | [EditorExerciseDocument, EditorSolutionDocument]
 
           const exerciseUuid = exerciseArray[0].serloContext?.uuid
 

--- a/src/components/taxonomy/static-taxonomy.tsx
+++ b/src/components/taxonomy/static-taxonomy.tsx
@@ -23,8 +23,8 @@ import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
 import {
   EditorExerciseDocument,
+  EditorRowsDocument,
   EditorSolutionDocument,
-  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface TopicProps {
@@ -69,7 +69,7 @@ export function StaticTaxonomy({ data }: TopicProps) {
       <div className="min-h-1/2">
         <div className="mt-6 sm:mb-5">
           <StaticRenderer
-            document={data.description as unknown as SupportedEditorDocument}
+            document={data.description as unknown as EditorRowsDocument}
           />
         </div>
 

--- a/src/components/user-tools/foldout-author-menus/author-tools-exercises.tsx
+++ b/src/components/user-tools/foldout-author-menus/author-tools-exercises.tsx
@@ -29,10 +29,10 @@ export function AuthorToolsExercises({ data }: MoreAuthorToolsProps) {
     data.type === ExerciseInlineType.Exercise
       ? UuidType.Exercise
       : data.type === ExerciseInlineType.ExerciseGroup
-      ? UuidType.ExerciseGroup
-      : data.type === ExerciseInlineType.Solution
-      ? UuidType.Solution
-      : UuidType.Exercise
+        ? UuidType.ExerciseGroup
+        : data.type === ExerciseInlineType.Solution
+          ? UuidType.Solution
+          : UuidType.Exercise
   )
 
   return (

--- a/src/components/user-tools/foldout-author-menus/author-tools-exercises.tsx
+++ b/src/components/user-tools/foldout-author-menus/author-tools-exercises.tsx
@@ -29,10 +29,10 @@ export function AuthorToolsExercises({ data }: MoreAuthorToolsProps) {
     data.type === ExerciseInlineType.Exercise
       ? UuidType.Exercise
       : data.type === ExerciseInlineType.ExerciseGroup
-        ? UuidType.ExerciseGroup
-        : data.type === ExerciseInlineType.Solution
-          ? UuidType.Solution
-          : UuidType.Exercise
+      ? UuidType.ExerciseGroup
+      : data.type === ExerciseInlineType.Solution
+      ? UuidType.Solution
+      : UuidType.Exercise
   )
 
   return (

--- a/src/data-types.ts
+++ b/src/data-types.ts
@@ -476,6 +476,7 @@ export interface TaxonomyTermBase {
   applets: TaxonomyLink[]
   exercises: TaxonomyLink[]
   events: TaxonomyLink[]
+  // TODO: should be EditorRowsDocument after
   description?: FrontendContentNode[]
 }
 

--- a/src/fetcher/create-exercises.ts
+++ b/src/fetcher/create-exercises.ts
@@ -17,9 +17,9 @@ import { shuffleArray } from '@/helper/shuffle-array'
 import { convert, ConvertNode } from '@/schema/convert-edtr-io-state'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import {
-  EditorH5PPlugin,
-  EditorInputExercisePlugin,
-  EditorScMcExercisePlugin,
+  EditorH5PDocument,
+  EditorInputExerciseDocument,
+  EditorScMcExerciseDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 type BareExercise = Omit<
@@ -54,9 +54,9 @@ export function createExercise(
 export interface TaskEditorStateInput {
   content: ConvertNode // serlo-editor plugin "exercise"
   interactive?:
-    | EditorScMcExercisePlugin
-    | EditorInputExercisePlugin
-    | EditorH5PPlugin
+    | EditorScMcExerciseDocument
+    | EditorInputExerciseDocument
+    | EditorH5PDocument
 }
 
 function createTaskData(raw?: string): TaskEditorState | undefined {

--- a/src/fetcher/static-create-exercises.ts
+++ b/src/fetcher/static-create-exercises.ts
@@ -1,9 +1,9 @@
 import { MainUuidType } from './query-types'
 import {
-  EditorExercisePlugin,
-  EditorRowsPlugin,
-  EditorSolutionPlugin,
-  EditorTemplateGroupedExercise,
+  EditorExerciseDocument,
+  EditorRowsDocument,
+  EditorSolutionDocument,
+  EditorTemplateGroupedExerciseDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
 
@@ -15,7 +15,10 @@ type BareExercise = Omit<
 export function staticCreateExercise(
   uuid: BareExercise
   // index?: number
-): [] | [EditorExercisePlugin] | [EditorExercisePlugin, EditorSolutionPlugin] {
+):
+  | []
+  | [EditorExerciseDocument]
+  | [EditorExerciseDocument, EditorSolutionDocument] {
   if (!uuid.currentRevision?.content) return []
 
   // compat: shuffle interactive answers with shuffleArray
@@ -24,7 +27,7 @@ export function staticCreateExercise(
   // href: uuid.alias, ??
 
   const exerciseWithContext = {
-    ...(JSON.parse(uuid.currentRevision?.content) as EditorExercisePlugin),
+    ...(JSON.parse(uuid.currentRevision?.content) as EditorExerciseDocument),
     serloContext: {
       uuid: uuid.id,
       revisionId: uuid.currentRevision.id,
@@ -36,7 +39,7 @@ export function staticCreateExercise(
   }
   const solutionRaw = uuid.solution?.currentRevision?.content
   const solution = solutionRaw
-    ? (JSON.parse(solutionRaw) as EditorSolutionPlugin)
+    ? (JSON.parse(solutionRaw) as EditorSolutionDocument)
     : undefined
 
   const solutionContext = solution
@@ -63,7 +66,7 @@ export function createStaticExerciseGroup(
     'date' | 'taxonomyTerms'
   >
   // pageIndex?: number
-): [EditorTemplateGroupedExercise] | [] {
+): [EditorTemplateGroupedExerciseDocument] | [] {
   // const children: FrontendExerciseNode[] = []
   // let groupIndex = 0
   // if (uuid.exercises?.length > 0) {
@@ -91,7 +94,7 @@ export function createStaticExerciseGroup(
       plugin: TemplatePluginType.TextExerciseGroup,
       state: {
         // @ts-expect-error not sure why string is expected here
-        content: JSON.parse(uuid.currentRevision.content) as EditorRowsPlugin,
+        content: JSON.parse(uuid.currentRevision.content) as EditorRowsDocument,
         // solutions are not really part of the state at this point, but cleaner this way
         exercisesWithSolutions: uuid.exercises.map(staticCreateExercise),
       },

--- a/src/fetcher/static-create-exercises.ts
+++ b/src/fetcher/static-create-exercises.ts
@@ -4,6 +4,7 @@ import {
   EditorRowsDocument,
   EditorSolutionDocument,
   EditorTemplateGroupedExerciseDocument,
+  ExerciseWithSolution,
 } from '@/serlo-editor-integration/types/editor-plugins'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
 
@@ -12,22 +13,16 @@ type BareExercise = Omit<
   'exerciseGroup' | '__typename' | 'instance'
 >
 
-export function staticCreateExercise(
+export function staticCreateExerciseAndSolution(
   uuid: BareExercise
-  // index?: number
-):
-  | []
-  | [EditorExerciseDocument]
-  | [EditorExerciseDocument, EditorSolutionDocument] {
-  if (!uuid.currentRevision?.content) return []
+): undefined | ExerciseWithSolution {
+  if (!uuid.currentRevision?.content) return undefined
 
+  // TODO: Check:
   // compat: shuffle interactive answers with shuffleArray
 
-  // positionOnPage: index,
-  // href: uuid.alias, ??
-
-  const exerciseWithContext = {
-    ...(JSON.parse(uuid.currentRevision?.content) as EditorExerciseDocument),
+  const exercise = {
+    ...(JSON.parse(uuid.currentRevision.content) as EditorExerciseDocument),
     serloContext: {
       uuid: uuid.id,
       revisionId: uuid.currentRevision.id,
@@ -37,27 +32,24 @@ export function staticCreateExercise(
       license: uuid.license && !uuid.license.default ? uuid.license : undefined,
     },
   }
+
+  if (!uuid.solution?.currentRevision?.content) return { exercise }
+
   const solutionRaw = uuid.solution?.currentRevision?.content
-  const solution = solutionRaw
-    ? (JSON.parse(solutionRaw) as EditorSolutionDocument)
-    : undefined
 
-  const solutionContext = solution
-    ? {
-        uuid: uuid.solution?.id,
-        exerciseId: uuid.id,
-        trashed: uuid.solution?.trashed,
-        unrevisedRevisions: solution.serloContext?.unrevisedRevisions,
-        license:
-          uuid.solution?.license && !uuid.solution?.license.default
-            ? uuid.solution?.license
-            : undefined,
-      }
-    : undefined
-
-  return solution
-    ? [exerciseWithContext, { ...solution, serloContext: solutionContext }]
-    : [exerciseWithContext]
+  const solution = {
+    ...(JSON.parse(solutionRaw) as EditorSolutionDocument),
+    serloContext: {
+      uuid: uuid.solution?.id,
+      exerciseId: uuid.id,
+      trashed: uuid.solution?.trashed,
+      license:
+        uuid.solution?.license && !uuid.solution?.license.default
+          ? uuid.solution?.license
+          : undefined,
+    },
+  }
+  return { exercise, solution }
 }
 
 export function createStaticExerciseGroup(
@@ -65,44 +57,25 @@ export function createStaticExerciseGroup(
     Extract<MainUuidType, { __typename: 'ExerciseGroup' }>,
     'date' | 'taxonomyTerms'
   >
-  // pageIndex?: number
-): [EditorTemplateGroupedExerciseDocument] | [] {
-  // const children: FrontendExerciseNode[] = []
-  // let groupIndex = 0
-  // if (uuid.exercises?.length > 0) {
-  //   uuid.exercises.forEach((exercise) => {
-  //     if (!exercise.currentRevision) return
-  //     if (exercise.trashed) return
-  //     const exerciseNode = staticCreateExercise(exercise)
-  //     // exerciseNode.grouped = true
-  //     exerciseNode.positionInGroup = groupIndex++
-  //     exerciseNode.positionOnPage = pageIndex // compat: page index also to grouped exercise for id generation
-  //     exerciseNode.context.parent = uuid.id
-  //     exerciseNode.context.revisionId = uuid.currentRevision?.id ?? -1
-  //     children.push(exerciseNode)
-  //   })
-  // }
+): EditorTemplateGroupedExerciseDocument | undefined {
+  if (!uuid.currentRevision?.content) return undefined
 
-  //   positionOnPage: pageIndex,
-  //   license: createInlineLicense(uuid.license),
-  //   href: uuid.alias,
+  const exercisesWithSolutions = uuid.exercises
+    .map(staticCreateExerciseAndSolution)
+    .filter(Boolean) as ExerciseWithSolution[]
 
-  if (!uuid.currentRevision?.content) return []
-
-  return [
-    {
-      plugin: TemplatePluginType.TextExerciseGroup,
-      state: {
-        // @ts-expect-error not sure why string is expected here
-        content: JSON.parse(uuid.currentRevision.content) as EditorRowsDocument,
-        // solutions are not really part of the state at this point, but cleaner this way
-        exercisesWithSolutions: uuid.exercises.map(staticCreateExercise),
-      },
-      serloContext: {
-        uuid: uuid.id,
-        trashed: uuid.trashed,
-        unrevisedRevisions: uuid.revisions.totalCount,
-      },
+  return {
+    plugin: TemplatePluginType.TextExerciseGroup,
+    state: {
+      // @ts-expect-error not sure why string is expected here
+      content: JSON.parse(uuid.currentRevision.content) as EditorRowsDocument,
+      // solutions are not really part of the state at this point, but cleaner this way
+      exercisesWithSolutions,
     },
-  ]
+    serloContext: {
+      uuid: uuid.id,
+      trashed: uuid.trashed,
+      unrevisedRevisions: uuid.revisions.totalCount,
+    },
+  }
 }

--- a/src/fetcher/static-create-taxonomy.ts
+++ b/src/fetcher/static-create-taxonomy.ts
@@ -1,7 +1,7 @@
 import { MainUuidQuery, TaxonomyTermType } from './graphql-types/operations'
 import {
   createStaticExerciseGroup,
-  staticCreateExercise,
+  staticCreateExerciseAndSolution,
 } from './static-create-exercises'
 import {
   TaxonomyData,
@@ -12,9 +12,9 @@ import {
 import { hasSpecialUrlChars } from '@/helper/urls/check-special-url-chars'
 import {
   EditorExerciseDocument,
+  EditorRowsDocument,
   EditorSolutionDocument,
   EditorTemplateGroupedExerciseDocument,
-  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 type TaxonomyTerm = Extract<
@@ -33,7 +33,7 @@ export function staticBuildTaxonomyData(uuid: TaxonomyTerm): TaxonomyData {
   const children = uuid.children.nodes.filter(isActive)
 
   const description = uuid.description
-    ? (JSON.parse(uuid.description) as SupportedEditorDocument)
+    ? (JSON.parse(uuid.description) as EditorRowsDocument)
     : undefined
 
   return {
@@ -75,7 +75,7 @@ function collectExercises(children: TaxonomyTermChildrenLevel1[]) {
   )[] = []
   children.forEach((child) => {
     if (child.__typename === UuidType.Exercise && child.currentRevision) {
-      const exercise = staticCreateExercise({
+      const exercise = staticCreateExerciseAndSolution({
         ...child,
         revisions: { totalCount: 0 },
       })
@@ -155,7 +155,7 @@ function collectNestedTaxonomyTerms(
         url: getAlias(child),
         //@ts-expect-error static
         description: child.description
-          ? (JSON.parse(child.description) as SupportedEditorDocument)
+          ? (JSON.parse(child.description) as EditorRowsDocument)
           : undefined,
         articles: collectType(subChildren, UuidType.Article),
         exercises: collectExerciseFolders(subChildren),

--- a/src/fetcher/static-create-taxonomy.ts
+++ b/src/fetcher/static-create-taxonomy.ts
@@ -68,21 +68,25 @@ function isActive_for_subchildren(child: TaxonomyTermChildrenLevel2) {
 
 function collectExercises(children: TaxonomyTermChildrenLevel1[]) {
   const result: (
-    | []
-    | [EditorExerciseDocument]
-    | [EditorExerciseDocument, EditorSolutionDocument]
-    | [EditorTemplateGroupedExerciseDocument]
+    | EditorExerciseDocument
+    | EditorSolutionDocument
+    | EditorTemplateGroupedExerciseDocument
   )[] = []
   children.forEach((child) => {
     if (child.__typename === UuidType.Exercise && child.currentRevision) {
-      const exercise = staticCreateExerciseAndSolution({
+      const exerciseWithSolution = staticCreateExerciseAndSolution({
         ...child,
         revisions: { totalCount: 0 },
       })
-      result.push(exercise)
+      if (exerciseWithSolution) {
+        result.push(exerciseWithSolution.exercise)
+        if (exerciseWithSolution.solution)
+          result.push(exerciseWithSolution.solution)
+      }
     }
     if (child.__typename === UuidType.ExerciseGroup && child.currentRevision) {
-      result.push(createStaticExerciseGroup(child))
+      const group = createStaticExerciseGroup(child)
+      if (group) result.push(group)
     }
   })
 

--- a/src/fetcher/static-create-taxonomy.ts
+++ b/src/fetcher/static-create-taxonomy.ts
@@ -11,10 +11,10 @@ import {
 } from '@/data-types'
 import { hasSpecialUrlChars } from '@/helper/urls/check-special-url-chars'
 import {
-  EditorExercisePlugin,
-  EditorSolutionPlugin,
-  EditorTemplateGroupedExercise,
-  SupportedEditorPlugin,
+  EditorExerciseDocument,
+  EditorSolutionDocument,
+  EditorTemplateGroupedExerciseDocument,
+  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 type TaxonomyTerm = Extract<
@@ -33,7 +33,7 @@ export function staticBuildTaxonomyData(uuid: TaxonomyTerm): TaxonomyData {
   const children = uuid.children.nodes.filter(isActive)
 
   const description = uuid.description
-    ? (JSON.parse(uuid.description) as SupportedEditorPlugin)
+    ? (JSON.parse(uuid.description) as SupportedEditorDocument)
     : undefined
 
   return {
@@ -69,9 +69,9 @@ function isActive_for_subchildren(child: TaxonomyTermChildrenLevel2) {
 function collectExercises(children: TaxonomyTermChildrenLevel1[]) {
   const result: (
     | []
-    | [EditorExercisePlugin]
-    | [EditorExercisePlugin, EditorSolutionPlugin]
-    | [EditorTemplateGroupedExercise]
+    | [EditorExerciseDocument]
+    | [EditorExerciseDocument, EditorSolutionDocument]
+    | [EditorTemplateGroupedExerciseDocument]
   )[] = []
   children.forEach((child) => {
     if (child.__typename === UuidType.Exercise && child.currentRevision) {
@@ -155,7 +155,7 @@ function collectNestedTaxonomyTerms(
         url: getAlias(child),
         //@ts-expect-error static
         description: child.description
-          ? (JSON.parse(child.description) as SupportedEditorPlugin)
+          ? (JSON.parse(child.description) as SupportedEditorDocument)
           : undefined,
         articles: collectType(subChildren, UuidType.Article),
         exercises: collectExerciseFolders(subChildren),

--- a/src/fetcher/static-request-page.ts
+++ b/src/fetcher/static-request-page.ts
@@ -18,7 +18,7 @@ import { prettifyLinksInState } from './prettify-links-state/prettify-links-in-s
 import { dataQuery } from './query'
 import {
   createStaticExerciseGroup,
-  staticCreateExercise,
+  staticCreateExerciseAndSolution,
 } from './static-create-exercises'
 import { staticBuildTaxonomyData } from './static-create-taxonomy'
 import {
@@ -32,7 +32,7 @@ import { FrontendNodeType } from '@/frontend-node-types'
 import { getInstanceDataByLang } from '@/helper/feature-i18n'
 import { hasSpecialUrlChars } from '@/helper/urls/check-special-url-chars'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
-import type { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorRowsDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 // ALWAYS start alias with slash
 export async function staticRequestPage(
@@ -169,7 +169,7 @@ export async function staticRequestPage(
     uuid.__typename === UuidType.Exercise ||
     uuid.__typename === UuidType.GroupedExercise
   ) {
-    const exercise = staticCreateExercise(uuid)
+    const exercise = staticCreateExerciseAndSolution(uuid)
     return {
       kind: 'single-entity',
       entityData: {
@@ -231,7 +231,7 @@ export async function staticRequestPage(
         contentType: 'exercisegroup',
         metaImage,
         metaDescription: getMetaDescription(
-          exercise[0]?.state.content as unknown as SupportedEditorDocument
+          exercise[0]?.state.content as unknown as EditorRowsDocument
         ),
       },
       horizonData,
@@ -242,7 +242,7 @@ export async function staticRequestPage(
 
   const content = await prettifyLinksInState(
     uuid.currentRevision?.content
-      ? (JSON.parse(uuid.currentRevision?.content) as SupportedEditorDocument)
+      ? (JSON.parse(uuid.currentRevision?.content) as EditorRowsDocument)
       : undefined
   )
 

--- a/src/fetcher/static-request-page.ts
+++ b/src/fetcher/static-request-page.ts
@@ -210,8 +210,7 @@ export async function staticRequestPage(
   }
 
   if (uuid.__typename === UuidType.ExerciseGroup) {
-    const exercise = createStaticExerciseGroup(uuid)
-
+    const exerciseGroup = createStaticExerciseGroup(uuid)
     return {
       kind: 'single-entity',
       entityData: {
@@ -220,7 +219,7 @@ export async function staticRequestPage(
         alias: uuid.alias,
         typename: UuidType.ExerciseGroup,
         // @ts-expect-error static
-        content: exercise,
+        content: exerciseGroup,
         unrevisedRevisions: uuid.revisions?.totalCount,
         isUnrevised: !uuid.currentRevision,
       },
@@ -230,9 +229,11 @@ export async function staticRequestPage(
         title,
         contentType: 'exercisegroup',
         metaImage,
-        metaDescription: getMetaDescription(
-          exercise[0]?.state.content as unknown as EditorRowsDocument
-        ),
+        metaDescription: exerciseGroup?.state.content
+          ? getMetaDescription(
+              exerciseGroup?.state.content as unknown as EditorRowsDocument
+            )
+          : undefined,
       },
       horizonData,
       cacheKey,

--- a/src/fetcher/static-request-page.ts
+++ b/src/fetcher/static-request-page.ts
@@ -32,7 +32,7 @@ import { FrontendNodeType } from '@/frontend-node-types'
 import { getInstanceDataByLang } from '@/helper/feature-i18n'
 import { hasSpecialUrlChars } from '@/helper/urls/check-special-url-chars'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
-import type { SupportedEditorPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { SupportedEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 // ALWAYS start alias with slash
 export async function staticRequestPage(
@@ -231,7 +231,7 @@ export async function staticRequestPage(
         contentType: 'exercisegroup',
         metaImage,
         metaDescription: getMetaDescription(
-          exercise[0]?.state.content as unknown as SupportedEditorPlugin
+          exercise[0]?.state.content as unknown as SupportedEditorDocument
         ),
       },
       horizonData,
@@ -242,7 +242,7 @@ export async function staticRequestPage(
 
   const content = await prettifyLinksInState(
     uuid.currentRevision?.content
-      ? (JSON.parse(uuid.currentRevision?.content) as SupportedEditorPlugin)
+      ? (JSON.parse(uuid.currentRevision?.content) as SupportedEditorDocument)
       : undefined
   )
 

--- a/src/frontend-node-types.ts
+++ b/src/frontend-node-types.ts
@@ -7,13 +7,13 @@ import { TableType } from './serlo-editor/plugins/serlo-table/renderer'
 import type { CustomText } from './serlo-editor/plugins/text'
 import { EditorPluginType } from './serlo-editor-integration/types/editor-plugin-type'
 import type {
-  EditorAnchorPlugin,
-  EditorAudioPlugin,
-  EditorGeogebraPlugin,
-  EditorH5PPlugin,
-  EditorHighlightPlugin,
-  EditorInjectionPlugin,
-  EditorVideoPlugin,
+  EditorAnchorDocument,
+  EditorAudioDocument,
+  EditorGeogebraDocument,
+  EditorH5PDocument,
+  EditorHighlightDocument,
+  EditorInjectionDocument,
+  EditorVideoDocument,
 } from './serlo-editor-integration/types/editor-plugins'
 
 // The actual content of the page.
@@ -194,7 +194,7 @@ export interface FrontendBoxNode {
   pluginId?: string
 }
 
-export type FrontendAnchorNode = EditorAnchorPlugin & {
+export type FrontendAnchorNode = EditorAnchorDocument & {
   type: FrontendNodeType.Anchor
   children?: undefined
 }
@@ -231,13 +231,13 @@ export interface FrontendTdNode {
   children?: FrontendContentNode[]
 }
 
-export type FrontendGeogebraNode = EditorGeogebraPlugin & {
+export type FrontendGeogebraNode = EditorGeogebraDocument & {
   type: FrontendNodeType.Geogebra
   children?: undefined
   pluginId?: string
 }
 
-export type FrontendInjectionNode = EditorInjectionPlugin & {
+export type FrontendInjectionNode = EditorInjectionDocument & {
   type: FrontendNodeType.Injection
   children?: undefined
   pluginId?: string
@@ -289,7 +289,7 @@ export interface TaskEditorState {
   interactive?:
     | EditorPluginScMcExercise
     | EditorPluginInputExercise
-    | EditorH5PPlugin
+    | EditorH5PDocument
 }
 
 export interface SolutionEditorState {
@@ -341,21 +341,21 @@ export interface FrontendExerciseGroupNode {
   unrevisedRevisions?: number
 }
 
-export type FrontendVideoNode = EditorVideoPlugin & {
+export type FrontendVideoNode = EditorVideoDocument & {
   license?: LicenseData
   type: FrontendNodeType.Video
   children?: undefined
   pluginId?: string
 }
 
-export type FrontendAudioNode = EditorAudioPlugin & {
+export type FrontendAudioNode = EditorAudioDocument & {
   type: FrontendNodeType.Audio
   children?: undefined
   pluginId?: string
   src: string
 }
 
-export type FrontendCodeNode = EditorHighlightPlugin & {
+export type FrontendCodeNode = EditorHighlightDocument & {
   type: FrontendNodeType.Code
   children?: undefined
   pluginId?: string

--- a/src/pages/entity/repository/compare/[entity_id]/[revision_id].tsx
+++ b/src/pages/entity/repository/compare/[entity_id]/[revision_id].tsx
@@ -9,7 +9,6 @@ import { requestRevision } from '@/fetcher/revision/request'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks<RevisionProps>(({ pageData }) => (
-  // TODO: Does not do anything yet. Just to show where the context could be provided.
   <RevisionViewProvider value>
     <FrontendClientBase
       entityId={pageData.revisionData.thisRevision.id}

--- a/src/pages/static/show-revision.tsx
+++ b/src/pages/static/show-revision.tsx
@@ -12,7 +12,7 @@ import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
 import {
   AnyEditorDocument,
-  SupportedEditorPlugin,
+  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 interface TmpProps {
@@ -71,7 +71,7 @@ export const getStaticProps: GetStaticProps<TmpProps> = async () => {
   ) as AnyEditorDocument
 
   const contentWithPrettyLinks = await prettifyLinksInState(
-    solutionMockState as SupportedEditorPlugin
+    solutionMockState as SupportedEditorDocument
   )
 
   if (!contentWithPrettyLinks) return { notFound: true }

--- a/src/pages/static/show-revision.tsx
+++ b/src/pages/static/show-revision.tsx
@@ -10,10 +10,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
-import {
-  AnyEditorDocument,
-  SupportedEditorDocument,
-} from '@/serlo-editor-integration/types/editor-plugins'
+import { AnyEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 interface TmpProps {
   editorState: AnyEditorDocument
@@ -70,16 +67,12 @@ export const getStaticProps: GetStaticProps<TmpProps> = async () => {
     '{"plugin":"rows","state":[{"plugin":"solution","state":{"prerequisite":{"id":"1555","title":"Test"},"strategy":{"plugin":"text","state":[{"type":"p","children":[{"text":"Test "},{"type":"a","href":"/43458","children":[{"text":"Toller"}]},{"text":" testlink"}]}],"id":"619943ae-93c8-4fc0-a1dd-20dc2a4a52e3"},"steps":{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"Steps "},{"type":"a","href":"/1555","children":[{"text":"Link"}]},{"text":" 123  "}]}],"id":"496ca820-21f6-4ec5-83bf-5fc16f25607a"}],"id":"845d8c6e-b2ff-4630-9df3-bc2145e37310"}},"id":"6208fbe2-a007-46dd-80ec-cc4e28484c53"}]}'
   ) as AnyEditorDocument
 
-  const contentWithPrettyLinks = await prettifyLinksInState(
-    solutionMockState as SupportedEditorDocument
-  )
+  const contentWithPrettyLinks = await prettifyLinksInState(solutionMockState)
 
   if (!contentWithPrettyLinks) return { notFound: true }
 
   return {
-    props: {
-      editorState: contentWithPrettyLinks,
-    },
+    props: { editorState: contentWithPrettyLinks },
     revalidate: 60 * 2, // 2 min,
   }
 }

--- a/src/schema/convert-edtr-io-state.tsx
+++ b/src/schema/convert-edtr-io-state.tsx
@@ -12,23 +12,23 @@ import { Sign } from '@/serlo-editor/plugins/equations/sign'
 import { CustomElement, CustomText } from '@/serlo-editor/plugins/text'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import {
-  SupportedEditorPlugin,
-  UnknownEditorPlugin,
+  SupportedEditorDocument,
+  UnknownEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 type SlateElementOrText = CustomElement | CustomText
 
 function isSupportedEditorPlugin(
   node: ConvertData
-): node is SupportedEditorPlugin {
+): node is SupportedEditorDocument {
   return Object.values(EditorPluginType).includes(
-    (node as SupportedEditorPlugin).plugin
+    (node as SupportedEditorDocument).plugin
   )
 }
 
 export type ConvertData =
-  | SupportedEditorPlugin
-  | UnknownEditorPlugin
+  | SupportedEditorDocument
+  | UnknownEditorDocument
   // | FrontendContentNode
   | SlateElementOrText
 
@@ -53,7 +53,7 @@ export function convert(node?: ConvertNode): FrontendContentNode[] {
 }
 
 function convertPlugin(
-  node: SupportedEditorPlugin | UnknownEditorPlugin
+  node: SupportedEditorDocument | UnknownEditorDocument
 ): FrontendContentNode[] {
   if (!isSupportedEditorPlugin(node)) return []
 
@@ -108,7 +108,7 @@ function convertPlugin(
     const { caption, maxWidth, link, src } = node.state
 
     const convertedCaption = caption
-      ? convert(caption as SupportedEditorPlugin)
+      ? convert(caption as SupportedEditorDocument)
       : undefined
 
     const captionTexts = convertedCaption?.[0]?.children?.[0]?.children
@@ -117,16 +117,16 @@ function convertPlugin(
     const alt = node.state.alt
       ? node.state.alt
       : caption
-      ? captionTexts && captionTexts.length > 0
-        ? captionTexts
+        ? captionTexts && captionTexts.length > 0
+          ? captionTexts
             .map((textPlugin) => {
               return textPlugin.type === FrontendNodeType.Text
                 ? textPlugin.text
                 : ''
             })
             .join('')
+          : ''
         : ''
-      : ''
 
     return [
       {
@@ -143,12 +143,12 @@ function convertPlugin(
   if (node.plugin === EditorPluginType.Box) {
     // get rid of wrapping p and inline math in title
     const convertedTitle = convert(
-      node.state.title as SupportedEditorPlugin
+      node.state.title as SupportedEditorDocument
     )[0] as FrontendTextNode | FrontendMathNode | undefined
     const title = convertedTitle
       ? ((convertedTitle.type === FrontendNodeType.Math
-          ? [{ ...convertedTitle, type: FrontendNodeType.InlineMath }]
-          : convertedTitle.children) as unknown as FrontendContentNode[])
+        ? [{ ...convertedTitle, type: FrontendNodeType.InlineMath }]
+        : convertedTitle.children) as unknown as FrontendContentNode[])
       : ([{ type: FrontendNodeType.Text, text: '' }] as FrontendTextNode[])
 
     return [
@@ -157,7 +157,7 @@ function convertPlugin(
         boxType: node.state.type as BoxType,
         anchorId: node.state.anchorId,
         title,
-        children: convert(node.state.content.state as SupportedEditorPlugin),
+        children: convert(node.state.content.state as SupportedEditorDocument),
         pluginId: node.id,
       },
     ]
@@ -180,7 +180,7 @@ function convertPlugin(
           },
           {
             type: FrontendNodeType.SpoilerBody,
-            children: convert(node.state.content as SupportedEditorPlugin),
+            children: convert(node.state.content as SupportedEditorDocument),
           },
         ],
         pluginId: node.id,
@@ -193,8 +193,8 @@ function convertPlugin(
       {
         type: FrontendNodeType.Multimedia,
         mediaWidth: width,
-        media: convert(node.state.multimedia as SupportedEditorPlugin),
-        children: convert(node.state.explanation as SupportedEditorPlugin),
+        media: convert(node.state.multimedia as SupportedEditorDocument),
+        children: convert(node.state.explanation as SupportedEditorDocument),
         pluginId: node.id,
       },
     ]
@@ -213,7 +213,7 @@ function convertPlugin(
         children: row.columns.map((cell) => {
           return {
             type: FrontendNodeType.SerloTd,
-            children: convert(cell.content as SupportedEditorPlugin),
+            children: convert(cell.content as SupportedEditorDocument),
           }
         }),
       }
@@ -285,8 +285,8 @@ function convertPlugin(
     return [
       {
         type: FrontendNodeType.PageLayout,
-        column1: convert(node.state.column1 as SupportedEditorPlugin),
-        column2: convert(node.state.column2 as SupportedEditorPlugin),
+        column1: convert(node.state.column1 as SupportedEditorDocument),
+        column2: convert(node.state.column2 as SupportedEditorDocument),
         widthPercent: node.state.widthPercent,
         pluginId: node.id,
       },

--- a/src/serlo-editor-integration/create-renderers.tsx
+++ b/src/serlo-editor-integration/create-renderers.tsx
@@ -5,18 +5,18 @@ import { ExtraInfoIfRevisionView } from './extra-info-if-revision-view'
 import { ImageSerloStaticRenderer } from './serlo-plugin-wrappers/image-serlo-static-renderer'
 import { EditorPluginType } from './types/editor-plugin-type'
 import type {
-  EditorAnchorPlugin,
-  EditorExercisePlugin,
-  EditorGeogebraPlugin,
-  EditorH5PPlugin,
-  EditorHighlightPlugin,
-  EditorInjectionPlugin,
-  EditorInputExercisePlugin,
-  EditorScMcExercisePlugin,
-  EditorSolutionPlugin,
-  EditorSpoilerPlugin,
-  EditorTemplateGroupedExercise,
-  EditorVideoPlugin,
+  EditorAnchorDocument,
+  EditorExerciseDocument,
+  EditorGeogebraDocument,
+  EditorH5PDocument,
+  EditorHighlightDocument,
+  EditorInjectionDocument,
+  EditorInputExerciseDocument,
+  EditorScMcExerciseDocument,
+  EditorSolutionDocument,
+  EditorSpoilerDocument,
+  EditorTemplateGroupedExerciseDocument,
+  EditorVideoDocument,
 } from './types/editor-plugins'
 import { TemplatePluginType } from './types/template-plugin-type'
 import { Lazy } from '@/components/content/lazy'
@@ -48,38 +48,38 @@ import { parseVideoUrl } from '@/serlo-editor/plugins/video/renderer'
 import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
 import { MultimediaSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/multimedia-serlo-static-renderer'
 
-const ExerciseSerloStaticRenderer = dynamic<EditorExercisePlugin>(() =>
+const ExerciseSerloStaticRenderer = dynamic<EditorExerciseDocument>(() =>
   import(
     '@/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer'
   ).then((mod) => mod.ExerciseSerloStaticRenderer)
 )
-const H5pSerloStaticRenderer = dynamic<EditorH5PPlugin>(() =>
+const H5pSerloStaticRenderer = dynamic<EditorH5PDocument>(() =>
   import(
     '@/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static'
   ).then((mod) => mod.H5pSerloStaticRenderer)
 )
-const InputSerloStaticRenderer = dynamic<EditorInputExercisePlugin>(() =>
+const InputSerloStaticRenderer = dynamic<EditorInputExerciseDocument>(() =>
   import(
     '@/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer'
   ).then((mod) => mod.InputSerloStaticRenderer)
 )
-const SerloScMcExerciseStaticRenderer = dynamic<EditorScMcExercisePlugin>(() =>
+const SerloScMcExerciseStaticRenderer = dynamic<EditorScMcExerciseDocument>(() =>
   import(
     '@/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer'
   ).then((mod) => mod.ScMcSerloStaticRenderer)
 )
-const SolutionSerloStaticRenderer = dynamic<EditorSolutionPlugin>(() =>
+const SolutionSerloStaticRenderer = dynamic<EditorSolutionDocument>(() =>
   import(
     '@/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer'
   ).then((mod) => mod.SolutionSerloStaticRenderer)
 )
 const TextExerciseGroupTypeStaticRenderer =
-  dynamic<EditorTemplateGroupedExercise>(() =>
+  dynamic<EditorTemplateGroupedExerciseDocument>(() =>
     import(
       '@/serlo-editor/plugins/serlo-template-plugins/exercise-group/static'
     ).then((mod) => mod.TextExerciseGroupTypeStaticRenderer)
   )
-const HighlightStaticRenderer = dynamic<EditorHighlightPlugin>(() =>
+const HighlightStaticRenderer = dynamic<EditorHighlightDocument>(() =>
   import('@/serlo-editor/plugins/highlight/static').then(
     (mod) => mod.HighlightStaticRenderer
   )
@@ -114,7 +114,7 @@ export function createRenderers({
       },
       {
         type: EditorPluginType.Spoiler,
-        renderer: (state: EditorSpoilerPlugin) => {
+        renderer: (state: EditorSpoilerDocument) => {
           return (
             <SpoilerStaticRenderer
               {...state}
@@ -127,7 +127,7 @@ export function createRenderers({
       { type: EditorPluginType.SerloTable, renderer: SerloTableStaticRenderer },
       {
         type: EditorPluginType.Injection,
-        renderer: (props: EditorInjectionPlugin) => {
+        renderer: (props: EditorInjectionDocument) => {
           return (
             <>
               <InjectionStaticRenderer {...props} />
@@ -139,7 +139,7 @@ export function createRenderers({
       { type: EditorPluginType.Equations, renderer: EquationsStaticRenderer },
       {
         type: EditorPluginType.Geogebra,
-        renderer: (state: EditorGeogebraPlugin) => {
+        renderer: (state: EditorGeogebraDocument) => {
           if (!state.state) return null
           const { url } = parseId(state.state)
           return (
@@ -159,7 +159,7 @@ export function createRenderers({
       },
       {
         type: EditorPluginType.Video,
-        renderer: (state: EditorVideoPlugin) => {
+        renderer: (state: EditorVideoDocument) => {
           const { src } = state.state
           if (!src) return null
           const [iframeSrc, type] = parseVideoUrl(src, instance)
@@ -180,7 +180,7 @@ export function createRenderers({
       },
       {
         type: EditorPluginType.Anchor,
-        renderer: (props: EditorAnchorPlugin) => {
+        renderer: (props: EditorAnchorDocument) => {
           return (
             <>
               <AnchorStaticRenderer {...props} />
@@ -205,7 +205,7 @@ export function createRenderers({
       },
       {
         type: EditorPluginType.Highlight,
-        renderer: (props: EditorHighlightPlugin) => {
+        renderer: (props: EditorHighlightDocument) => {
           return (
             <>
               <HighlightStaticRenderer {...props} />

--- a/src/serlo-editor-integration/create-renderers.tsx
+++ b/src/serlo-editor-integration/create-renderers.tsx
@@ -63,10 +63,11 @@ const InputSerloStaticRenderer = dynamic<EditorInputExerciseDocument>(() =>
     '@/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer'
   ).then((mod) => mod.InputSerloStaticRenderer)
 )
-const SerloScMcExerciseStaticRenderer = dynamic<EditorScMcExerciseDocument>(() =>
-  import(
-    '@/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer'
-  ).then((mod) => mod.ScMcSerloStaticRenderer)
+const SerloScMcExerciseStaticRenderer = dynamic<EditorScMcExerciseDocument>(
+  () =>
+    import(
+      '@/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer'
+    ).then((mod) => mod.ScMcSerloStaticRenderer)
 )
 const SolutionSerloStaticRenderer = dynamic<EditorSolutionDocument>(() =>
   import(

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic'
 import { useContext, useEffect, useState } from 'react'
 
-import type { EditorExercisePlugin } from '../types/editor-plugins'
+import type { EditorExerciseDocument } from '../types/editor-plugins'
 import { useAuthentication } from '@/auth/use-authentication'
 import { ExerciseLicenseNotice } from '@/components/content/license/exercise-license-notice'
 import type { MoreAuthorToolsProps } from '@/components/user-tools/foldout-author-menus/more-author-tools'
@@ -17,7 +17,7 @@ const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
 )
 
 // Special version for serlo.org with author tools and license
-export function ExerciseSerloStaticRenderer(props: EditorExercisePlugin) {
+export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
   const auth = useAuthentication()
   const [loaded, setLoaded] = useState(false)
   useEffect(() => setLoaded(true), [])

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
@@ -6,10 +6,10 @@ import { useAB } from '@/contexts/ab'
 import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { parseH5pUrl } from '@/serlo-editor/plugins/h5p/renderer'
-import type { EditorH5PPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorH5PDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 // Special version for serlo.org with exercise submission events
-export function H5pSerloStaticRenderer(props: EditorH5PPlugin) {
+export function H5pSerloStaticRenderer(props: EditorH5PDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
   const entityId = useEntityId()

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/image-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/image-serlo-static-renderer.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from 'next/router'
 
 import { ExtraInfoIfRevisionView } from '../extra-info-if-revision-view'
-import { EditorImagePlugin } from '../types/editor-plugins'
+import { EditorImageDocument } from '../types/editor-plugins'
 import { ImageStaticRenderer } from '@/serlo-editor/plugins/image/static'
 
-export function ImageSerloStaticRenderer(props: EditorImagePlugin) {
+export function ImageSerloStaticRenderer(props: EditorImageDocument) {
   const pathNameBase = useRouter().asPath.split('/').pop()
   return (
     <>

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
@@ -8,9 +8,9 @@ import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { InputExerciseStaticRenderer } from '@/serlo-editor/plugins/input-exercise/static'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorInputExercisePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorInputExerciseDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function InputSerloStaticRenderer(props: EditorInputExercisePlugin) {
+export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
   const entityId = useEntityId()
   const revisionId = useRevisionId()
   const exStrings = useInstanceData().strings.content.exercises

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/multimedia-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/multimedia-serlo-static-renderer.tsx
@@ -6,8 +6,8 @@ import { LightBoxProps } from '@/components/content/light-box'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import {
-  EditorImagePlugin,
-  EditorMultimediaPlugin,
+  EditorImageDocument,
+  EditorMultimediaDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 const LightBox = dynamic<LightBoxProps>(() =>
@@ -15,7 +15,7 @@ const LightBox = dynamic<LightBoxProps>(() =>
 )
 
 // adds a dynamically loaded lightbox component to multimedia image elements
-export function MultimediaSerloStaticRenderer(state: EditorMultimediaPlugin) {
+export function MultimediaSerloStaticRenderer(state: EditorMultimediaDocument) {
   const { multimedia } = state.state
   const [open, setOpen] = useState(false)
 
@@ -33,7 +33,7 @@ export function MultimediaSerloStaticRenderer(state: EditorMultimediaPlugin) {
 
   function renderLightBox() {
     if (!mediaChildIsImage || !open) return null
-    const imageState = (multimedia as EditorImagePlugin).state
+    const imageState = (multimedia as EditorImageDocument).state
 
     return (
       <LightBox

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/helper/exercise-submission'
 import { ScMcExerciseRendererAnswer } from '@/serlo-editor/plugins/sc-mc-exercise/renderer/renderer'
 import { ScMcExerciseStaticRenderer } from '@/serlo-editor/plugins/sc-mc-exercise/static'
-import { EditorScMcExercisePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorScMcExerciseDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function ScMcSerloStaticRenderer(props: EditorScMcExercisePlugin) {
+export function ScMcSerloStaticRenderer(props: EditorScMcExerciseDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
   const entityId = useEntityId()

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
@@ -41,10 +41,10 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
   const solutionVisibleOnInit = isRevisionView
     ? true
     : isPrintMode
-      ? printModeSolutionVisible
-      : typeof window === 'undefined'
-        ? false
-        : window.location.href.includes('#comment-')
+    ? printModeSolutionVisible
+    : typeof window === 'undefined'
+    ? false
+    : window.location.href.includes('#comment-')
 
   const beforeSlot = (
     <>

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useContext, useEffect, useState } from 'react'
 
-import type { EditorSolutionPlugin } from '../types/editor-plugins'
+import type { EditorSolutionDocument } from '../types/editor-plugins'
 import { useAuthentication } from '@/auth/use-authentication'
 import type { CommentAreaEntityProps } from '@/components/comments/comment-area-entity'
 import { Lazy } from '@/components/content/lazy'
@@ -27,7 +27,7 @@ const CommentAreaEntity = dynamic<CommentAreaEntityProps>(() =>
 )
 
 // Special version for serlo.org with author tools and license
-export function SolutionSerloStaticRenderer(props: EditorSolutionPlugin) {
+export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
   const auth = useAuthentication()
   const [loaded, setLoaded] = useState(false)
   useEffect(() => setLoaded(true), [])
@@ -41,10 +41,10 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionPlugin) {
   const solutionVisibleOnInit = isRevisionView
     ? true
     : isPrintMode
-    ? printModeSolutionVisible
-    : typeof window === 'undefined'
-    ? false
-    : window.location.href.includes('#comment-')
+      ? printModeSolutionVisible
+      : typeof window === 'undefined'
+        ? false
+        : window.location.href.includes('#comment-')
 
   const beforeSlot = (
     <>

--- a/src/serlo-editor-integration/types/editor-plugins.ts
+++ b/src/serlo-editor-integration/types/editor-plugins.ts
@@ -37,39 +37,37 @@ export type SlateTextElement = CustomText
 
 // All supported editor plugins in their serialized versions
 
-// TODO: after static renderer PR is merged rename all …Plugin to …Document
-
-export interface EditorAnchorPlugin {
+export interface EditorAnchorDocument {
   plugin: EditorPluginType.Anchor
   state: Prettify<StateTypeSerializedType<AnchorPluginState>>
   id?: string
 }
-export interface EditorArticlePlugin {
+export interface EditorArticleDocument {
   plugin: EditorPluginType.Article
   state: Prettify<StateTypeSerializedType<ArticlePluginState>>
   id?: string
 }
-export interface EditorArticleIntroductionPlugin {
+export interface EditorArticleIntroductionDocument {
   plugin: EditorPluginType.ArticleIntroduction
   state: Prettify<StateTypeSerializedType<MultimediaPluginState>>
   id?: string
 }
-export interface EditorBoxPlugin {
+export interface EditorBoxDocument {
   plugin: EditorPluginType.Box
   state: Prettify<StateTypeSerializedType<BoxPluginState>>
   id?: string
 }
-export interface EditorUnsupportedPlugin {
+export interface EditorUnsupportedDocument {
   plugin: EditorPluginType.Unsupported
   state: Prettify<StateTypeSerializedType<UnsupportedPluginState>>
   id?: string
 }
-export interface EditorEquationsPlugin {
+export interface EditorEquationsDocument {
   plugin: EditorPluginType.Equations
   state: Prettify<StateTypeSerializedType<EquationsPluginState>>
   id?: string
 }
-export interface EditorExercisePlugin {
+export interface EditorExerciseDocument {
   plugin: EditorPluginType.Exercise
   state: Prettify<StateTypeSerializedType<ExercisePluginState>>
   id?: string
@@ -84,57 +82,57 @@ export interface EditorExercisePlugin {
     license?: License
   }
 }
-export interface EditorGeogebraPlugin {
+export interface EditorGeogebraDocument {
   plugin: EditorPluginType.Geogebra
   state: Prettify<StateTypeSerializedType<GeogebraPluginState>>
   id?: string
 }
-export interface EditorHighlightPlugin {
+export interface EditorHighlightDocument {
   plugin: EditorPluginType.Highlight
   state: Prettify<StateTypeSerializedType<HighlightPluginState>>
   id?: string
 }
-export interface EditorImagePlugin {
+export interface EditorImageDocument {
   plugin: EditorPluginType.Image
   state: Prettify<StateTypeSerializedType<ImagePluginState>>
   id?: string
 }
-export interface EditorInjectionPlugin {
+export interface EditorInjectionDocument {
   plugin: EditorPluginType.Injection
   state: Prettify<StateTypeSerializedType<InjectionPluginState>>
   id?: string
 }
-export interface EditorInputExercisePlugin {
+export interface EditorInputExerciseDocument {
   plugin: EditorPluginType.InputExercise
   state: Prettify<StateTypeSerializedType<InputExercisePluginState>>
   id?: string
 }
-export interface EditorMultimediaPlugin {
+export interface EditorMultimediaDocument {
   plugin: EditorPluginType.Multimedia
   state: Prettify<StateTypeSerializedType<MultimediaPluginState>>
   id?: string
 }
-export interface EditorRowsPlugin {
+export interface EditorRowsDocument {
   plugin: EditorPluginType.Rows
   state: Prettify<StateTypeSerializedType<RowsPluginState>>
   id?: string
 }
-export interface EditorScMcExercisePlugin {
+export interface EditorScMcExerciseDocument {
   plugin: EditorPluginType.ScMcExercise
   state: Prettify<StateTypeSerializedType<ScMcExercisePluginState>>
   id?: string
 }
-export interface EditorSpoilerPlugin {
+export interface EditorSpoilerDocument {
   plugin: EditorPluginType.Spoiler
   state: Prettify<StateTypeSerializedType<SpoilerPluginState>>
   id?: string
 }
-export interface EditorSerloInjectionPlugin {
+export interface EditorSerloInjectionDocument {
   plugin: EditorPluginType.Injection
   state: Prettify<StateTypeSerializedType<InjectionPluginState>>
   id?: string
 }
-export interface EditorSolutionPlugin {
+export interface EditorSolutionDocument {
   plugin: EditorPluginType.Solution
   state: Prettify<StateTypeSerializedType<SolutionPluginState>>
   id?: string
@@ -148,56 +146,56 @@ export interface EditorSolutionPlugin {
     license?: License
   }
 }
-export interface EditorSerloTablePlugin {
+export interface EditorSerloTableDocument {
   plugin: EditorPluginType.SerloTable
   state: Prettify<StateTypeSerializedType<SerloTablePluginState>>
   id?: string
 }
-export interface EditorTextPlugin {
+export interface EditorTextDocument {
   plugin: EditorPluginType.Text
   state: Prettify<StateTypeSerializedType<TextEditorState>>
   id?: string
 }
-export interface EditorVideoPlugin {
+export interface EditorVideoDocument {
   plugin: EditorPluginType.Video
   state: Prettify<StateTypeSerializedType<VideoPluginState>>
   id?: string
 }
-export interface EditorAudioPlugin {
+export interface EditorAudioDocument {
   plugin: EditorPluginType.Audio
   state: Prettify<StateTypeSerializedType<AudioPluginState>>
   id?: string
 }
-export interface EditorPageLayoutPlugin {
+export interface EditorPageLayoutDocument {
   plugin: EditorPluginType.PageLayout
   state: StateTypeSerializedType<PageLayoutPluginState>
   id?: string
 }
-export interface EditorPageTeamPlugin {
+export interface EditorPageTeamDocument {
   plugin: EditorPluginType.PageTeam
   state: Prettify<StateTypeSerializedType<PageTeamPluginState>>
   id?: string
 }
-export interface EditorPagePartnersPlugin {
+export interface EditorPagePartnersDocument {
   plugin: EditorPluginType.PagePartners
   state: Prettify<StateTypeSerializedType<PagePartnersPluginState>>
   id?: string
 }
-export interface EditorH5PPlugin {
+export interface EditorH5PDocument {
   plugin: EditorPluginType.H5p
   state: Prettify<StateTypeSerializedType<H5pPluginState>>
   id?: string
 }
 
 // Template Plugins
-export interface EditorTemplateGroupedExercise {
+export interface EditorTemplateGroupedExerciseDocument {
   plugin: TemplatePluginType.TextExerciseGroup
   state: Prettify<StateTypeSerializedType<TextExerciseGroupTypePluginState>> & {
     // extra field that is not actually part of the state until we move solutions into exercises
     exercisesWithSolutions: (
       | []
-      | [EditorExercisePlugin, EditorSolutionPlugin]
-      | [EditorExercisePlugin]
+      | [EditorExerciseDocument, EditorSolutionDocument]
+      | [EditorExerciseDocument]
     )[]
   }
   id?: string
@@ -210,35 +208,35 @@ export interface EditorTemplateGroupedExercise {
   }
 }
 
-export type SupportedEditorPlugin =
-  | EditorArticlePlugin
-  | EditorArticleIntroductionPlugin
-  | EditorGeogebraPlugin
-  | EditorAnchorPlugin
-  | EditorVideoPlugin
-  | EditorAudioPlugin
-  | EditorSerloTablePlugin
-  | EditorHighlightPlugin
-  | EditorSerloInjectionPlugin
-  | EditorMultimediaPlugin
-  | EditorSpoilerPlugin
-  | EditorBoxPlugin
-  | EditorImagePlugin
-  | EditorTextPlugin
-  | EditorRowsPlugin
-  | EditorEquationsPlugin
-  | EditorExercisePlugin
-  | EditorPageLayoutPlugin
-  | EditorPageTeamPlugin
-  | EditorPagePartnersPlugin
+export type SupportedEditorDocument =
+  | EditorArticleDocument
+  | EditorArticleIntroductionDocument
+  | EditorGeogebraDocument
+  | EditorAnchorDocument
+  | EditorVideoDocument
+  | EditorAudioDocument
+  | EditorSerloTableDocument
+  | EditorHighlightDocument
+  | EditorSerloInjectionDocument
+  | EditorMultimediaDocument
+  | EditorSpoilerDocument
+  | EditorBoxDocument
+  | EditorImageDocument
+  | EditorTextDocument
+  | EditorRowsDocument
+  | EditorEquationsDocument
+  | EditorExerciseDocument
+  | EditorPageLayoutDocument
+  | EditorPageTeamDocument
+  | EditorPagePartnersDocument
 
-export interface UnknownEditorPlugin {
+export interface UnknownEditorDocument {
   plugin: string
   state?: unknown
   id?: string
 }
 
-export type AnyEditorDocument = SupportedEditorPlugin | UnknownEditorPlugin
+export type AnyEditorDocument = SupportedEditorDocument | UnknownEditorDocument
 
 // dark ts magic ✨
 type Prettify<T> = {

--- a/src/serlo-editor-integration/types/editor-plugins.ts
+++ b/src/serlo-editor-integration/types/editor-plugins.ts
@@ -187,16 +187,18 @@ export interface EditorH5PDocument {
   id?: string
 }
 
+// helper type until they actually are merged
+export interface ExerciseWithSolution {
+  exercise: EditorExerciseDocument
+  solution?: EditorSolutionDocument
+}
+
 // Template Plugins
 export interface EditorTemplateGroupedExerciseDocument {
   plugin: TemplatePluginType.TextExerciseGroup
   state: Prettify<StateTypeSerializedType<TextExerciseGroupTypePluginState>> & {
     // extra field that is not actually part of the state until we move solutions into exercises
-    exercisesWithSolutions: (
-      | []
-      | [EditorExerciseDocument, EditorSolutionDocument]
-      | [EditorExerciseDocument]
-    )[]
+    exercisesWithSolutions: ExerciseWithSolution[]
   }
   id?: string
 

--- a/src/serlo-editor-integration/types/editor-plugins.ts
+++ b/src/serlo-editor-integration/types/editor-plugins.ts
@@ -168,7 +168,7 @@ export interface EditorAudioDocument {
 }
 export interface EditorPageLayoutDocument {
   plugin: EditorPluginType.PageLayout
-  state: StateTypeSerializedType<PageLayoutPluginState>
+  state: Prettify<StateTypeSerializedType<PageLayoutPluginState>>
   id?: string
 }
 export interface EditorPageTeamDocument {

--- a/src/serlo-editor-integration/types/plugin-type-guards.ts
+++ b/src/serlo-editor-integration/types/plugin-type-guards.ts
@@ -1,161 +1,161 @@
 import { EditorPluginType } from './editor-plugin-type'
 import type {
   AnyEditorDocument,
-  EditorAnchorPlugin,
-  EditorArticleIntroductionPlugin,
-  EditorArticlePlugin,
-  EditorAudioPlugin,
-  EditorBoxPlugin,
-  EditorEquationsPlugin,
-  EditorExercisePlugin,
-  EditorGeogebraPlugin,
-  EditorH5PPlugin,
-  EditorHighlightPlugin,
-  EditorImagePlugin,
-  EditorInjectionPlugin,
-  EditorInputExercisePlugin,
-  EditorMultimediaPlugin,
-  EditorPageLayoutPlugin,
-  EditorPagePartnersPlugin,
-  EditorPageTeamPlugin,
-  EditorRowsPlugin,
-  EditorScMcExercisePlugin,
-  EditorSerloInjectionPlugin,
-  EditorSerloTablePlugin,
-  EditorSolutionPlugin,
-  EditorSpoilerPlugin,
-  EditorTextPlugin,
-  EditorUnsupportedPlugin,
-  EditorVideoPlugin,
+  EditorAnchorDocument,
+  EditorArticleIntroductionDocument,
+  EditorArticleDocument,
+  EditorAudioDocument,
+  EditorBoxDocument,
+  EditorEquationsDocument,
+  EditorExerciseDocument,
+  EditorGeogebraDocument,
+  EditorH5PDocument,
+  EditorHighlightDocument,
+  EditorImageDocument,
+  EditorInjectionDocument,
+  EditorInputExerciseDocument,
+  EditorMultimediaDocument,
+  EditorPageLayoutDocument,
+  EditorPagePartnersDocument,
+  EditorPageTeamDocument,
+  EditorRowsDocument,
+  EditorScMcExerciseDocument,
+  EditorSerloInjectionDocument,
+  EditorSerloTableDocument,
+  EditorSolutionDocument,
+  EditorSpoilerDocument,
+  EditorTextDocument,
+  EditorUnsupportedDocument,
+  EditorVideoDocument,
 } from './editor-plugins'
 
 export function isAnchorDocument(
   document: AnyEditorDocument
-): document is EditorAnchorPlugin {
+): document is EditorAnchorDocument {
   return document.plugin === EditorPluginType.Anchor
 }
 export function isArticleDocument(
   document: AnyEditorDocument
-): document is EditorArticlePlugin {
+): document is EditorArticleDocument {
   return document.plugin === EditorPluginType.Article
 }
 export function isArticleIntroductionDocument(
   document: AnyEditorDocument
-): document is EditorArticleIntroductionPlugin {
+): document is EditorArticleIntroductionDocument {
   return document.plugin === EditorPluginType.ArticleIntroduction
 }
 export function isBoxDocument(
   document: AnyEditorDocument
-): document is EditorBoxPlugin {
+): document is EditorBoxDocument {
   return document.plugin === EditorPluginType.Box
 }
 export function isUnsupportedDocument(
   document: AnyEditorDocument
-): document is EditorUnsupportedPlugin {
+): document is EditorUnsupportedDocument {
   return document.plugin === EditorPluginType.Unsupported
 }
 export function isEquationsDocument(
   document: AnyEditorDocument
-): document is EditorEquationsPlugin {
+): document is EditorEquationsDocument {
   return document.plugin === EditorPluginType.Equations
 }
 export function isExerciseDocument(
   document: AnyEditorDocument
-): document is EditorExercisePlugin {
+): document is EditorExerciseDocument {
   return document.plugin === EditorPluginType.Exercise
 }
 export function isGeogebraDocument(
   document: AnyEditorDocument
-): document is EditorGeogebraPlugin {
+): document is EditorGeogebraDocument {
   return document.plugin === EditorPluginType.Geogebra
 }
 export function isHighlightDocument(
   document: AnyEditorDocument
-): document is EditorHighlightPlugin {
+): document is EditorHighlightDocument {
   return document.plugin === EditorPluginType.Highlight
 }
 export function isImageDocument(
   document: AnyEditorDocument
-): document is EditorImagePlugin {
+): document is EditorImageDocument {
   return document.plugin === EditorPluginType.Image
 }
 export function isInjectionDocument(
   document: AnyEditorDocument
-): document is EditorInjectionPlugin {
+): document is EditorInjectionDocument {
   return document.plugin === EditorPluginType.Injection
 }
 export function isInputExerciseDocument(
   document: AnyEditorDocument
-): document is EditorInputExercisePlugin {
+): document is EditorInputExerciseDocument {
   return document.plugin === EditorPluginType.InputExercise
 }
 export function isMultimediaDocument(
   document: AnyEditorDocument
-): document is EditorMultimediaPlugin {
+): document is EditorMultimediaDocument {
   return document.plugin === EditorPluginType.Multimedia
 }
 export function isRowsDocument(
   document: AnyEditorDocument
-): document is EditorRowsPlugin {
+): document is EditorRowsDocument {
   return document.plugin === EditorPluginType.Rows
 }
 export function isScMcExerciseDocument(
   document: AnyEditorDocument
-): document is EditorScMcExercisePlugin {
+): document is EditorScMcExerciseDocument {
   return document.plugin === EditorPluginType.ScMcExercise
 }
 export function isSpoilerDocument(
   document: AnyEditorDocument
-): document is EditorSpoilerPlugin {
+): document is EditorSpoilerDocument {
   return document.plugin === EditorPluginType.Spoiler
 }
 export function isSerloInjection(
   document: AnyEditorDocument
-): document is EditorSerloInjectionPlugin {
+): document is EditorSerloInjectionDocument {
   return document.plugin === EditorPluginType.Injection
 }
 export function isSolutionDocument(
   document: AnyEditorDocument
-): document is EditorSolutionPlugin {
+): document is EditorSolutionDocument {
   return document.plugin === EditorPluginType.Solution
 }
 export function isSerloTableDocument(
   document: AnyEditorDocument
-): document is EditorSerloTablePlugin {
+): document is EditorSerloTableDocument {
   return document.plugin === EditorPluginType.SerloTable
 }
 export function isTextDocument(
   document: AnyEditorDocument
-): document is EditorTextPlugin {
+): document is EditorTextDocument {
   return document.plugin === EditorPluginType.Text
 }
 export function isVideoDocument(
   document: AnyEditorDocument
-): document is EditorVideoPlugin {
+): document is EditorVideoDocument {
   return document.plugin === EditorPluginType.Video
 }
 export function isAudioDocument(
   document: AnyEditorDocument
-): document is EditorAudioPlugin {
+): document is EditorAudioDocument {
   return document.plugin === EditorPluginType.Audio
 }
 export function isPageLayoutDocument(
   document: AnyEditorDocument
-): document is EditorPageLayoutPlugin {
+): document is EditorPageLayoutDocument {
   return document.plugin === EditorPluginType.PageLayout
 }
 export function isPageTeamDocument(
   document: AnyEditorDocument
-): document is EditorPageTeamPlugin {
+): document is EditorPageTeamDocument {
   return document.plugin === EditorPluginType.PageTeam
 }
 export function isPagePartnersDocument(
   document: AnyEditorDocument
-): document is EditorPagePartnersPlugin {
+): document is EditorPagePartnersDocument {
   return document.plugin === EditorPluginType.PagePartners
 }
 export function isH5PDocument(
   document: AnyEditorDocument
-): document is EditorH5PPlugin {
+): document is EditorH5PDocument {
   return document.plugin === EditorPluginType.H5p
 }

--- a/src/serlo-editor/plugins/anchor/static.tsx
+++ b/src/serlo-editor/plugins/anchor/static.tsx
@@ -1,5 +1,5 @@
-import { EditorAnchorPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorAnchorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function AnchorStaticRenderer({ state }: EditorAnchorPlugin) {
+export function AnchorStaticRenderer({ state }: EditorAnchorDocument) {
   return <a id={state} />
 }

--- a/src/serlo-editor/plugins/article/static.tsx
+++ b/src/serlo-editor/plugins/article/static.tsx
@@ -4,11 +4,11 @@ import { Link } from '@/components/content/link'
 import { ArticleNodeUuidLink } from '@/frontend-node-types'
 import { ArticleRenderer } from '@/serlo-editor/plugins/article/renderer'
 import {
-  EditorArticlePlugin,
-  EditorMultimediaPlugin,
+  EditorArticleDocument,
+  EditorMultimediaDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function ArticleStaticRenderer({ state }: EditorArticlePlugin) {
+export function ArticleStaticRenderer({ state }: EditorArticleDocument) {
   const {
     introduction,
     content,
@@ -22,7 +22,7 @@ export function ArticleStaticRenderer({ state }: EditorArticlePlugin) {
   const hasExercises = exercises && exercises.length
 
   const introductionOrNull = isEmptyTextDocument(
-    (introduction as EditorMultimediaPlugin).state.explanation
+    (introduction as EditorMultimediaDocument).state.explanation
   ) ? null : (
     <StaticRenderer document={{ ...introduction, plugin: 'multimedia' }} />
   )

--- a/src/serlo-editor/plugins/box/static.tsx
+++ b/src/serlo-editor/plugins/box/static.tsx
@@ -4,9 +4,9 @@ import { isEmptyRowsDocument } from '../rows/utils/static-is-empty'
 import { StaticSlate } from '../text/static-slate'
 import { BoxRenderer, BoxType } from '@/serlo-editor/plugins/box/renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorBoxPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorBoxDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function BoxStaticRenderer({ state }: EditorBoxPlugin) {
+export function BoxStaticRenderer({ state }: EditorBoxDocument) {
   const { type: boxType, title, anchorId, content } = state
   if (!content || !boxType || isEmptyRowsDocument(content)) return null
 

--- a/src/serlo-editor/plugins/equations/static.tsx
+++ b/src/serlo-editor/plugins/equations/static.tsx
@@ -5,9 +5,9 @@ import {
   EquationsRendererStep,
 } from '@/serlo-editor/plugins/equations/renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorEquationsPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorEquationsDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function EquationsStaticRenderer({ state }: EditorEquationsPlugin) {
+export function EquationsStaticRenderer({ state }: EditorEquationsDocument) {
   const { steps, firstExplanation, transformationTarget } = state
   const MathRenderer = editorRenderers.getMathRenderer()
 

--- a/src/serlo-editor/plugins/exercise/static.tsx
+++ b/src/serlo-editor/plugins/exercise/static.tsx
@@ -1,7 +1,7 @@
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorExercisePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorExerciseDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function ExerciseStaticRenderer({ state }: EditorExercisePlugin) {
+export function ExerciseStaticRenderer({ state }: EditorExerciseDocument) {
   const { content, interactive } = state
   if (!content) return null
 

--- a/src/serlo-editor/plugins/geogebra/static.tsx
+++ b/src/serlo-editor/plugins/geogebra/static.tsx
@@ -2,9 +2,9 @@ import {
   GeogebraRenderer,
   parseId,
 } from '@/serlo-editor/plugins/geogebra/renderer'
-import { EditorGeogebraPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorGeogebraDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function GeogebraStaticRenderer({ state: id }: EditorGeogebraPlugin) {
+export function GeogebraStaticRenderer({ state: id }: EditorGeogebraDocument) {
   const { url } = parseId(id)
   return <GeogebraRenderer url={url} id={id} />
 }

--- a/src/serlo-editor/plugins/h5p/static.tsx
+++ b/src/serlo-editor/plugins/h5p/static.tsx
@@ -1,6 +1,6 @@
 import { H5pRenderer } from './renderer'
-import { EditorH5PPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorH5PDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function H5pStaticRenderer({ state: url }: EditorH5PPlugin) {
+export function H5pStaticRenderer({ state: url }: EditorH5PDocument) {
   return <H5pRenderer url={url} />
 }

--- a/src/serlo-editor/plugins/highlight/static.tsx
+++ b/src/serlo-editor/plugins/highlight/static.tsx
@@ -1,7 +1,7 @@
 import { HighlightRenderer } from './renderer'
-import { EditorHighlightPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorHighlightDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function HighlightStaticRenderer({ state }: EditorHighlightPlugin) {
+export function HighlightStaticRenderer({ state }: EditorHighlightDocument) {
   if (!state.code.trim().length) return null
   return <HighlightRenderer {...state} />
 }

--- a/src/serlo-editor/plugins/image/static.tsx
+++ b/src/serlo-editor/plugins/image/static.tsx
@@ -3,12 +3,12 @@ import { extractStringFromTextDocument } from '../text/utils/static-extract-text
 import { isEmptyTextDocument } from '../text/utils/static-is-empty'
 import { useInstanceData } from '@/contexts/instance-context'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorImagePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorImageDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export function ImageStaticRenderer({
   state,
   pathNameBase,
-}: EditorImagePlugin & { pathNameBase?: string }) {
+}: EditorImageDocument & { pathNameBase?: string }) {
   const { caption, src: fileSrc, link, alt, maxWidth: maxWidthNumber } = state
   const altFallback = useInstanceData().strings.content.imageAltFallback
 
@@ -20,8 +20,8 @@ export function ImageStaticRenderer({
   const altOrFallbacks = alt
     ? alt
     : hasVisibleCaption
-    ? extractStringFromTextDocument(caption)
-    : altFallback
+      ? extractStringFromTextDocument(caption)
+      : altFallback
 
   return (
     <ImageRenderer

--- a/src/serlo-editor/plugins/image/static.tsx
+++ b/src/serlo-editor/plugins/image/static.tsx
@@ -20,8 +20,8 @@ export function ImageStaticRenderer({
   const altOrFallbacks = alt
     ? alt
     : hasVisibleCaption
-      ? extractStringFromTextDocument(caption)
-      : altFallback
+    ? extractStringFromTextDocument(caption)
+    : altFallback
 
   return (
     <ImageRenderer

--- a/src/serlo-editor/plugins/injection/static.tsx
+++ b/src/serlo-editor/plugins/injection/static.tsx
@@ -99,17 +99,17 @@ export function InjectionStaticRenderer({
               const solutionContentAndContext = exercise.solution
                 ?.currentRevision?.content
                 ? {
-                  ...(JSON.parse(
-                    exercise.solution?.currentRevision?.content
-                  ) as AnyEditorDocument),
-                  serloContext: {
-                    license:
-                      exercise.solution?.license &&
+                    ...(JSON.parse(
+                      exercise.solution?.currentRevision?.content
+                    ) as AnyEditorDocument),
+                    serloContext: {
+                      license:
+                        exercise.solution?.license &&
                         !exercise.solution?.license.default
-                        ? exercise.solution?.license
-                        : undefined,
-                  },
-                }
+                          ? exercise.solution?.license
+                          : undefined,
+                    },
+                  }
                 : null
 
               return exercise.currentRevision

--- a/src/serlo-editor/plugins/injection/static.tsx
+++ b/src/serlo-editor/plugins/injection/static.tsx
@@ -11,14 +11,14 @@ import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import {
   AnyEditorDocument,
-  EditorInjectionPlugin,
-  EditorRowsPlugin,
+  EditorInjectionDocument,
+  EditorRowsDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
 
 export function InjectionStaticRenderer({
   state: href,
-}: EditorInjectionPlugin) {
+}: EditorInjectionDocument) {
   const [content, setContent] = useState<
     AnyEditorDocument[] | 'loading' | 'error'
   >('loading')
@@ -99,17 +99,17 @@ export function InjectionStaticRenderer({
               const solutionContentAndContext = exercise.solution
                 ?.currentRevision?.content
                 ? {
-                    ...(JSON.parse(
-                      exercise.solution?.currentRevision?.content
-                    ) as AnyEditorDocument),
-                    serloContext: {
-                      license:
-                        exercise.solution?.license &&
+                  ...(JSON.parse(
+                    exercise.solution?.currentRevision?.content
+                  ) as AnyEditorDocument),
+                  serloContext: {
+                    license:
+                      exercise.solution?.license &&
                         !exercise.solution?.license.default
-                          ? exercise.solution?.license
-                          : undefined,
-                    },
-                  }
+                        ? exercise.solution?.license
+                        : undefined,
+                  },
+                }
                 : null
 
               return exercise.currentRevision
@@ -124,7 +124,7 @@ export function InjectionStaticRenderer({
                 state: {
                   content: JSON.parse(
                     uuid.currentRevision.content
-                  ) as EditorRowsPlugin,
+                  ) as EditorRowsDocument,
                   // solutions are not really part of the state at this point, but cleaner this way
                   exercisesWithSolutions,
                 },

--- a/src/serlo-editor/plugins/input-exercise/static.tsx
+++ b/src/serlo-editor/plugins/input-exercise/static.tsx
@@ -3,12 +3,12 @@ import type { Element } from 'slate'
 import { InputExerciseRenderer } from './renderer'
 import { StaticSlate } from '../text/static-slate'
 import { isEmptyTextDocument } from '../text/utils/static-is-empty'
-import { EditorInputExercisePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorInputExerciseDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export function InputExerciseStaticRenderer({
   state,
   onEvaluate,
-}: EditorInputExercisePlugin & {
+}: EditorInputExerciseDocument & {
   onEvaluate?: (correct: boolean, val: string) => void
 }) {
   const answers = state.answers.map((answer) => {

--- a/src/serlo-editor/plugins/multimedia/static.tsx
+++ b/src/serlo-editor/plugins/multimedia/static.tsx
@@ -5,23 +5,23 @@ import { isEmptyRowsDocument } from '../rows/utils/static-is-empty'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import {
-  EditorAudioPlugin,
-  EditorGeogebraPlugin,
-  EditorImagePlugin,
-  EditorMultimediaPlugin,
-  EditorVideoPlugin,
+  EditorAudioDocument,
+  EditorGeogebraDocument,
+  EditorImageDocument,
+  EditorMultimediaDocument,
+  EditorVideoDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 type MultimediaChild =
-  | EditorImagePlugin
-  | EditorVideoPlugin
-  | EditorAudioPlugin
-  | EditorGeogebraPlugin
+  | EditorImageDocument
+  | EditorVideoDocument
+  | EditorAudioDocument
+  | EditorGeogebraDocument
 
 export function MultimediaStaticRenderer({
   state,
   setOpen,
-}: EditorMultimediaPlugin & { setOpen?: (arg: boolean) => void }) {
+}: EditorMultimediaDocument & { setOpen?: (arg: boolean) => void }) {
   const { explanation, multimedia, width: mediaWidth } = state
 
   if (isEmptyMedia() && isEmptyRowsDocument(explanation)) return null

--- a/src/serlo-editor/plugins/page-layout/static.tsx
+++ b/src/serlo-editor/plugins/page-layout/static.tsx
@@ -1,6 +1,6 @@
 import { PageLayoutRenderer } from './renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import type { EditorPageLayoutPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorPageLayoutDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export interface PageLayoutRendererProps {
   widthPercent: number // for first column
@@ -8,7 +8,7 @@ export interface PageLayoutRendererProps {
   column2: JSX.Element
 }
 
-export const PageLayoutStaticRenderer = ({ state }: EditorPageLayoutPlugin) => {
+export const PageLayoutStaticRenderer = ({ state }: EditorPageLayoutDocument) => {
   const { widthPercent, column1, column2 } = state
 
   return (

--- a/src/serlo-editor/plugins/page-layout/static.tsx
+++ b/src/serlo-editor/plugins/page-layout/static.tsx
@@ -8,7 +8,9 @@ export interface PageLayoutRendererProps {
   column2: JSX.Element
 }
 
-export const PageLayoutStaticRenderer = ({ state }: EditorPageLayoutDocument) => {
+export const PageLayoutStaticRenderer = ({
+  state,
+}: EditorPageLayoutDocument) => {
   const { widthPercent, column1, column2 } = state
 
   return (

--- a/src/serlo-editor/plugins/page-team/static.tsx
+++ b/src/serlo-editor/plugins/page-team/static.tsx
@@ -1,6 +1,6 @@
 import { PageTeamRenderer } from './renderer'
-import type { EditorPageTeamPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorPageTeamDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function PageTeamStaticRenderer({ state }: EditorPageTeamPlugin) {
+export function PageTeamStaticRenderer({ state }: EditorPageTeamDocument) {
   return <PageTeamRenderer data={state.data} />
 }

--- a/src/serlo-editor/plugins/rows/static.tsx
+++ b/src/serlo-editor/plugins/rows/static.tsx
@@ -1,7 +1,7 @@
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import type { EditorRowsPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorRowsDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function RowsStaticRenderer({ state }: EditorRowsPlugin) {
+export function RowsStaticRenderer({ state }: EditorRowsDocument) {
   return (
     <>
       {state.map((row, index) => {

--- a/src/serlo-editor/plugins/sc-mc-exercise/static.tsx
+++ b/src/serlo-editor/plugins/sc-mc-exercise/static.tsx
@@ -9,7 +9,7 @@ import { StaticSlate } from '../text/static-slate'
 import { isEmptyTextDocument } from '../text/utils/static-is-empty'
 import { shuffleArray } from '@/helper/shuffle-array'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorScMcExercisePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorScMcExerciseDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export function ScMcExerciseStaticRenderer({
   state,
@@ -17,7 +17,7 @@ export function ScMcExerciseStaticRenderer({
   idBase,
   onEvaluate,
   renderExtraAnswerContent,
-}: EditorScMcExercisePlugin & {
+}: EditorScMcExerciseDocument & {
   idBase: string
   isPrintMode?: boolean
   onEvaluate: ScMcExerciseRendererProps['onEvaluate']

--- a/src/serlo-editor/plugins/serlo-table/static.tsx
+++ b/src/serlo-editor/plugins/serlo-table/static.tsx
@@ -3,9 +3,9 @@ import {
   TableType,
 } from '@/serlo-editor/plugins/serlo-table/renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorSerloTablePlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorSerloTableDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function SerloTableStaticRenderer({ state }: EditorSerloTablePlugin) {
+export function SerloTableStaticRenderer({ state }: EditorSerloTableDocument) {
   const { rows, tableType } = state
   if (!rows || rows.length === 0) return null
 

--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/static.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/static.tsx
@@ -7,8 +7,8 @@ import type { MoreAuthorToolsProps } from '@/components/user-tools/foldout-autho
 import { ExerciseInlineType } from '@/data-types'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import {
-  EditorRowsPlugin,
-  EditorTemplateGroupedExercise,
+  EditorRowsDocument,
+  EditorTemplateGroupedExerciseDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 
 const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
@@ -18,7 +18,7 @@ const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
 )
 
 export function TextExerciseGroupTypeStaticRenderer(
-  props: EditorTemplateGroupedExercise
+  props: EditorTemplateGroupedExerciseDocument
 ) {
   const { state, serloContext: context } = props
   const [loaded, setLoaded] = useState(false)
@@ -67,7 +67,7 @@ export function TextExerciseGroupTypeStaticRenderer(
       ) : null}
       <TextExerciseGroupTypeRenderer
         content={
-          <StaticRenderer document={content as unknown as EditorRowsPlugin} />
+          <StaticRenderer document={content as unknown as EditorRowsDocument} />
         }
         exercises={rendered}
       />

--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/static.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/static.tsx
@@ -29,27 +29,20 @@ export function TextExerciseGroupTypeStaticRenderer(
 
   const { content, exercisesWithSolutions } = state
 
-  const rendered = exercisesWithSolutions.map((exerciseWithSolution, index) => {
-    if (exerciseWithSolution.length === 0) return null
-    const exercise = exerciseWithSolution[0]
-    const solution = exerciseWithSolution[1]
-
-    const id = String(
-      exercise.id ?? Object.hasOwn(exercise, 'serloContext')
-        ? exercise.serloContext?.uuid
-        : index
-    )
-
-    return {
-      id,
-      element: (
-        <>
-          <StaticRenderer document={exercise} />
-          {solution ? <StaticRenderer document={solution} /> : null}
-        </>
-      ),
+  const rendered = exercisesWithSolutions.map(
+    ({ exercise, solution }, index) => {
+      const id = `${exercise.id ?? exercise.serloContext?.uuid ?? index}`
+      return {
+        id,
+        element: (
+          <>
+            <StaticRenderer document={exercise} />
+            {solution ? <StaticRenderer document={solution} /> : null}
+          </>
+        ),
+      }
     }
-  })
+  )
 
   return (
     <div className="relative">

--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
@@ -23,6 +23,7 @@ import {
   StateTypeSerializedType,
 } from '@/serlo-editor/plugin'
 import { selectSerializedDocument, store } from '@/serlo-editor/store'
+import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
 
 // text-exercises also include interactive exercises, we keep the naming to avoid db-migration
@@ -30,7 +31,7 @@ import { TemplatePluginType } from '@/serlo-editor-integration/types/template-pl
 export const textExerciseGroupTypeState = entityType(
   {
     ...entity,
-    content: editorContent(),
+    content: editorContent(EditorPluginType.Rows),
     cohesive: boolean(false),
     /* cohesive field would indicate whether the children of a grouped exercise are cohesive
     this field might be used in the future, but currently it has no effect and can not be changed
@@ -44,11 +45,11 @@ export const textExerciseGroupTypeState = entityType(
 export type TextExerciseGroupTypePluginState = typeof textExerciseGroupTypeState
 
 export const textExerciseGroupTypePlugin: EditorPlugin<TextExerciseGroupTypePluginState> =
-  {
-    Component: TextExerciseGroupTypeEditor,
-    state: textExerciseGroupTypeState,
-    config: {},
-  }
+{
+  Component: TextExerciseGroupTypeEditor,
+  state: textExerciseGroupTypeState,
+  config: {},
+}
 
 function TextExerciseGroupTypeEditor(
   props: EditorPluginProps<TextExerciseGroupTypePluginState>

--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
@@ -45,11 +45,11 @@ export const textExerciseGroupTypeState = entityType(
 export type TextExerciseGroupTypePluginState = typeof textExerciseGroupTypeState
 
 export const textExerciseGroupTypePlugin: EditorPlugin<TextExerciseGroupTypePluginState> =
-{
-  Component: TextExerciseGroupTypeEditor,
-  state: textExerciseGroupTypeState,
-  config: {},
-}
+  {
+    Component: TextExerciseGroupTypeEditor,
+    state: textExerciseGroupTypeState,
+    config: {},
+  }
 
 function TextExerciseGroupTypeEditor(
   props: EditorPluginProps<TextExerciseGroupTypePluginState>

--- a/src/serlo-editor/plugins/solution/static.tsx
+++ b/src/serlo-editor/plugins/solution/static.tsx
@@ -3,7 +3,7 @@ import { isEmptyRowsDocument } from '../rows/utils/static-is-empty'
 import { isEmptyTextDocument } from '../text/utils/static-is-empty'
 import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import type { EditorSolutionPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorSolutionDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export function StaticSolutionRenderer({
   state,
@@ -11,7 +11,7 @@ export function StaticSolutionRenderer({
   beforeSlot,
   afterSlot,
   onSolutionOpen,
-}: EditorSolutionPlugin & {
+}: EditorSolutionDocument & {
   solutionVisibleOnInit: boolean
   afterSlot?: JSX.Element | null
   beforeSlot?: JSX.Element | null

--- a/src/serlo-editor/plugins/spoiler/static.tsx
+++ b/src/serlo-editor/plugins/spoiler/static.tsx
@@ -1,11 +1,11 @@
 import { SpoilerRenderer } from './renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
-import { EditorSpoilerPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorSpoilerDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
 export function SpoilerStaticRenderer({
   state,
   openOverwrite,
-}: EditorSpoilerPlugin & { openOverwrite?: boolean }) {
+}: EditorSpoilerDocument & { openOverwrite?: boolean }) {
   const { title, content } = state
   return (
     <SpoilerRenderer

--- a/src/serlo-editor/plugins/text/static.tsx
+++ b/src/serlo-editor/plugins/text/static.tsx
@@ -1,9 +1,9 @@
 import { Fragment } from 'react'
 
 import { StaticSlate } from './static-slate'
-import type { EditorTextPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import type { EditorTextDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function TextStaticRenderer({ state }: EditorTextPlugin) {
+export function TextStaticRenderer({ state }: EditorTextDocument) {
   return (
     <>
       {Object.values(state).map((item, index) => {

--- a/src/serlo-editor/plugins/video/static.tsx
+++ b/src/serlo-editor/plugins/video/static.tsx
@@ -3,9 +3,9 @@ import {
   parseVideoUrl,
   VideoRenderer,
 } from '@/serlo-editor/plugins/video/renderer'
-import { EditorVideoPlugin } from '@/serlo-editor-integration/types/editor-plugins'
+import { EditorVideoDocument } from '@/serlo-editor-integration/types/editor-plugins'
 
-export function VideoStaticRenderer({ state: { src } }: EditorVideoPlugin) {
+export function VideoStaticRenderer({ state: { src } }: EditorVideoDocument) {
   const { lang } = useInstanceData()
 
   const [iframeSrc, type] = parseVideoUrl(src, lang)

--- a/src/serlo-editor/static-renderer/helper/get-children-of-serialized-document.tsx
+++ b/src/serlo-editor/static-renderer/helper/get-children-of-serialized-document.tsx
@@ -1,6 +1,6 @@
 import {
   AnyEditorDocument,
-  SupportedEditorPlugin,
+  SupportedEditorDocument,
 } from '@/serlo-editor-integration/types/editor-plugins'
 import {
   isArticleIntroductionDocument,
@@ -29,26 +29,26 @@ export function getChildrenOfSerializedDocument(
       ? document.state
       : //
       isArticleDocument(document)
-      ? [document.state.introduction, document.state.content]
-      : //
-      isMultimediaDocument(document) || isArticleIntroductionDocument(document)
-      ? [document.state.explanation, document.state.multimedia]
-      : //
-      isPageLayoutDocument(document)
-      ? [document.state.column1, document.state.column2]
-      : //
-      isExerciseDocument(document)
-      ? [document.state.content, document.state.interactive]
-      : //
-      isSolutionDocument(document)
-      ? [document.state.steps, document.state.strategy]
-      : //
-      isImageDocument(document)
-      ? [document.state.caption]
-      : //
-        []
+        ? [document.state.introduction, document.state.content]
+        : //
+        isMultimediaDocument(document) || isArticleIntroductionDocument(document)
+          ? [document.state.explanation, document.state.multimedia]
+          : //
+          isPageLayoutDocument(document)
+            ? [document.state.column1, document.state.column2]
+            : //
+            isExerciseDocument(document)
+              ? [document.state.content, document.state.interactive]
+              : //
+              isSolutionDocument(document)
+                ? [document.state.steps, document.state.strategy]
+                : //
+                isImageDocument(document)
+                  ? [document.state.caption]
+                  : //
+                  []
 
-  return children as SupportedEditorPlugin[]
+  return children as SupportedEditorDocument[]
 
   // ignoring for now
   // Equations

--- a/src/serlo-editor/static-renderer/helper/get-children-of-serialized-document.tsx
+++ b/src/serlo-editor/static-renderer/helper/get-children-of-serialized-document.tsx
@@ -1,7 +1,4 @@
-import {
-  AnyEditorDocument,
-  SupportedEditorDocument,
-} from '@/serlo-editor-integration/types/editor-plugins'
+import { AnyEditorDocument } from '@/serlo-editor-integration/types/editor-plugins'
 import {
   isArticleIntroductionDocument,
   isArticleDocument,
@@ -29,26 +26,26 @@ export function getChildrenOfSerializedDocument(
       ? document.state
       : //
       isArticleDocument(document)
-        ? [document.state.introduction, document.state.content]
-        : //
-        isMultimediaDocument(document) || isArticleIntroductionDocument(document)
-          ? [document.state.explanation, document.state.multimedia]
-          : //
-          isPageLayoutDocument(document)
-            ? [document.state.column1, document.state.column2]
-            : //
-            isExerciseDocument(document)
-              ? [document.state.content, document.state.interactive]
-              : //
-              isSolutionDocument(document)
-                ? [document.state.steps, document.state.strategy]
-                : //
-                isImageDocument(document)
-                  ? [document.state.caption]
-                  : //
-                  []
+      ? [document.state.introduction, document.state.content]
+      : //
+      isMultimediaDocument(document) || isArticleIntroductionDocument(document)
+      ? [document.state.explanation, document.state.multimedia]
+      : //
+      isPageLayoutDocument(document)
+      ? [document.state.column1, document.state.column2]
+      : //
+      isExerciseDocument(document)
+      ? [document.state.content, document.state.interactive]
+      : //
+      isSolutionDocument(document)
+      ? [document.state.steps, document.state.strategy]
+      : //
+      isImageDocument(document)
+      ? [document.state.caption]
+      : //
+        []
 
-  return children as SupportedEditorDocument[]
+  return children as AnyEditorDocument[]
 
   // ignoring for now
   // Equations


### PR DESCRIPTION
main change is renaming of `Editor[Name]Plugin` to `Editor[Name]Document` now that I have a better understanding what document means in the context of the editor ;) 