### PR TITLE
feat(a11y): bigger link targets in taxonomies

### DIFF
--- a/src/components/taxonomy/topic-category-link.tsx
+++ b/src/components/taxonomy/topic-category-link.tsx
@@ -1,0 +1,41 @@
+import { faTools } from '@fortawesome/free-solid-svg-icons'
+import clsx from 'clsx'
+
+import { FaIcon } from '../fa-icon'
+import { Link } from '@/components/content/link'
+import { useLoggedInData } from '@/contexts/logged-in-data-context'
+import {
+  TaxonomyLink,
+  TopicCategoryCustomType,
+  TopicCategoryType,
+} from '@/data-types'
+
+export interface TopicCategoryProps {
+  links: TaxonomyLink[]
+  full?: boolean
+  category: TopicCategoryType | TopicCategoryCustomType
+  id?: number
+}
+
+export function TopicCategoryLink({ link }: { link: TaxonomyLink }) {
+  const loggedInData = useLoggedInData()
+
+  return (
+    <li className="" key={link.url + '_' + link.title}>
+      <Link
+        className={clsx(
+          link.unrevised ? 'opacity-60' : undefined,
+          'block py-1.5 text-lg leading-cozy'
+        )}
+        href={link.url}
+      >
+        {link.title}
+        {link.unrevised && (
+          <span title={loggedInData?.strings.revisions.unrevisedTaxNote}>
+            <FaIcon icon={faTools} className="ml-1 text-base" />
+          </span>
+        )}
+      </Link>
+    </li>
+  )
+}

--- a/src/components/taxonomy/topic-category.tsx
+++ b/src/components/taxonomy/topic-category.tsx
@@ -1,12 +1,10 @@
-import { faTools } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
+import { TopicCategoryLink } from './topic-category-link'
 import { FaIcon } from '../fa-icon'
 import { useAuthentication } from '@/auth/use-authentication'
-import { Link } from '@/components/content/link'
 import { useInstanceData } from '@/contexts/instance-context'
-import { useLoggedInData } from '@/contexts/logged-in-data-context'
 import {
   TaxonomyLink,
   TopicCategoryCustomType,
@@ -24,7 +22,6 @@ export interface TopicCategoryProps {
 export function TopicCategory({ links, full, category }: TopicCategoryProps) {
   const [mounted, setMounted] = useState(false)
   const { strings } = useInstanceData()
-  const loggedInData = useLoggedInData()
   const auth = useAuthentication()
 
   useEffect(() => {
@@ -39,41 +36,25 @@ export function TopicCategory({ links, full, category }: TopicCategoryProps) {
 
   if (!mounted) return null
 
+  const filteredLinks = links.filter((link) => {
+    if (link.unrevised && !mounted) return false
+    if (link.unrevised && mounted && !auth) return false
+    return true
+  })
+
   return (
     <ul
       key={category}
       className={clsx('mt-5 first:mt-0', full && 'mb-6 mt-0 mobile:mt-2')}
     >
-      <h4 className="mb-4 text-lg font-bold text-gray-900">
+      <h4 className="mb-2.5 text-lg font-bold text-gray-900">
         {strings.categories[category]}{' '}
         <FaIcon icon={categoryIconMapping[category]} />
       </h4>
 
-      {links.map(renderLink)}
+      {filteredLinks.map((link) => (
+        <TopicCategoryLink key={link.id} link={link} />
+      ))}
     </ul>
   )
-
-  function renderLink(link: TaxonomyLink) {
-    if (link.unrevised && !mounted) return null
-    if (link.unrevised && mounted && !auth) return null
-
-    return (
-      <li className="mb-3 block leading-cozy" key={link.url + '_' + link.title}>
-        <Link
-          className={clsx(
-            link.unrevised ? 'opacity-60' : undefined,
-            'text-[1.2rem]'
-          )}
-          href={link.url}
-        >
-          {link.title}
-          {link.unrevised && (
-            <span title={loggedInData?.strings.revisions.unrevisedTaxNote}>
-              <FaIcon icon={faTools} className="ml-1 text-base" />
-            </span>
-          )}
-        </Link>
-      </li>
-    )
-  }
 }


### PR DESCRIPTION
for https://trello.com/c/e6lXRFqu/282-bessere-accessibility-durch-gr%C3%B6%C3%9Fere-klickfl%C3%A4chen-bei-links


also: own component for topic link


### [Preview](https://frontend-git-bigger-click-targets-in-taxonomies-serlo.vercel.app/biologie)

old click target:
![image](https://github.com/serlo/frontend/assets/1258870/9920f59a-e7af-40e6-9288-48bb459c5cfe)

new click target (green areas included)
![image](https://github.com/serlo/frontend/assets/1258870/1b2991c6-8a59-4e0c-b829-4a9209d8906a)
