### PR TITLE
fix(static): fix overflowing video & geogebra

### DIFF
--- a/src/components/author/revision/revision-preview-boxes.tsx
+++ b/src/components/author/revision/revision-preview-boxes.tsx
@@ -9,8 +9,8 @@ import {
 } from './revision-diff-viewer'
 import { useInstanceData } from '@/contexts/instance-context'
 import { type RevisionData, UuidRevType } from '@/data-types'
-import { GeogebraStaticRenderer } from '@/serlo-editor/plugins/geogebra/static'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
+import { GeogebraSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/geogebra-serlo-static-renderer'
 import { VideoSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
@@ -94,7 +94,7 @@ export function RevisionPreviewBoxes({
             state={{ src: dataSet.url, alt: dataSet.title ?? 'Video' }}
           />
         ) : (
-          <GeogebraStaticRenderer
+          <GeogebraSerloStaticRenderer
             plugin={EditorPluginType.Geogebra}
             state={dataSet.url}
           />

--- a/src/components/author/revision/revision-preview-boxes.tsx
+++ b/src/components/author/revision/revision-preview-boxes.tsx
@@ -10,8 +10,8 @@ import {
 import { useInstanceData } from '@/contexts/instance-context'
 import { type RevisionData, UuidRevType } from '@/data-types'
 import { GeogebraStaticRenderer } from '@/serlo-editor/plugins/geogebra/static'
-import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
+import { VideoSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 export interface RevisionPreviewBoxesProps {
@@ -89,7 +89,7 @@ export function RevisionPreviewBoxes({
         changes={dataSet.url !== data.currentRevision.url}
       >
         {isVideo ? (
-          <VideoStaticRenderer
+          <VideoSerloStaticRenderer
             plugin={EditorPluginType.Video}
             state={{ src: dataSet.url, alt: dataSet.title ?? 'Video' }}
           />

--- a/src/components/pages/editor/editor-presentation.tsx
+++ b/src/components/pages/editor/editor-presentation.tsx
@@ -12,8 +12,8 @@ import { Logo } from '@/components/navigation/header/logo'
 import { breakpoints } from '@/helper/breakpoints'
 import { tw } from '@/helper/tw'
 import { editorRenderers } from '@/serlo-editor/plugin/helpers/editor-renderer'
-import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
 import { createRenderers } from '@/serlo-editor-integration/create-renderers'
+import { VideoSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
 const h2Class =
@@ -87,7 +87,7 @@ export function EditorPresentation() {
               </p>
             </div>
             <div className="-mx-side mt-8 pl-2 sm:max-w-[32rem] sm:flex-1">
-              <VideoStaticRenderer
+              <VideoSerloStaticRenderer
                 plugin={EditorPluginType.Video}
                 state={{
                   src: 'https://www.youtube.com/watch?v=wjaPgGdw23w',

--- a/src/serlo-editor-integration/create-renderers.tsx
+++ b/src/serlo-editor-integration/create-renderers.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic'
 import { ComponentProps } from 'react'
 
 import { ExtraInfoIfRevisionView } from './extra-info-if-revision-view'
+import { GeogebraSerloStaticRenderer } from './serlo-plugin-wrappers/geogebra-serlo-static-renderer'
 import { ImageSerloStaticRenderer } from './serlo-plugin-wrappers/image-serlo-static-renderer'
 import { VideoSerloStaticRenderer } from './serlo-plugin-wrappers/video-serlo-static-renderer'
 import { EditorPluginType } from './types/editor-plugin-type'
@@ -9,7 +10,6 @@ import type {
   EditorAnchorDocument,
   EditorEquationsDocument,
   EditorExerciseDocument,
-  EditorGeogebraDocument,
   EditorH5PDocument,
   EditorHighlightDocument,
   EditorInjectionDocument,
@@ -26,9 +26,7 @@ import type {
 import { TemplatePluginType } from './types/template-plugin-type'
 import { Lazy } from '@/components/content/lazy'
 import { Link } from '@/components/content/link'
-import type { PrivacyWrapperProps } from '@/components/content/privacy-wrapper'
 import { isPrintMode } from '@/components/print-mode'
-import { ExternalProvider } from '@/helper/use-consent'
 import {
   InitRenderersArgs,
   LinkRenderer,
@@ -36,8 +34,6 @@ import {
 import { AnchorStaticRenderer } from '@/serlo-editor/plugins/anchor/static'
 import { ArticleStaticRenderer } from '@/serlo-editor/plugins/article/static'
 import { BoxStaticRenderer } from '@/serlo-editor/plugins/box/static'
-import { parseId } from '@/serlo-editor/plugins/geogebra/renderer'
-import { GeogebraStaticRenderer } from '@/serlo-editor/plugins/geogebra/static'
 import { RowsStaticRenderer } from '@/serlo-editor/plugins/rows/static'
 import { SpoilerStaticRenderer } from '@/serlo-editor/plugins/spoiler/static'
 import type { MathElement } from '@/serlo-editor/plugins/text'
@@ -117,11 +113,6 @@ const StaticMath = dynamic<MathElement>(() =>
     (mod) => mod.StaticMath
   )
 )
-const PrivacyWrapper = dynamic<PrivacyWrapperProps>(() =>
-  import('@/components/content/privacy-wrapper').then(
-    (mod) => mod.PrivacyWrapper
-  )
-)
 
 export function createRenderers(): InitRenderersArgs {
   return {
@@ -163,23 +154,7 @@ export function createRenderers(): InitRenderersArgs {
       { type: EditorPluginType.Equations, renderer: EquationsStaticRenderer },
       {
         type: EditorPluginType.Geogebra,
-        renderer: (state: EditorGeogebraDocument) => {
-          if (!state.state) return null
-          const { url } = parseId(state.state)
-          return (
-            <Lazy noPrint>
-              <PrivacyWrapper
-                type="applet"
-                provider={ExternalProvider.GeoGebra}
-                embedUrl={url}
-                className="print:hidden"
-              >
-                <GeogebraStaticRenderer {...state} />
-              </PrivacyWrapper>
-              <p className="serlo-p hidden print:block">[{url}]</p>
-            </Lazy>
-          )
-        },
+        renderer: GeogebraSerloStaticRenderer,
       },
       {
         type: EditorPluginType.Video,

--- a/src/serlo-editor-integration/create-renderers.tsx
+++ b/src/serlo-editor-integration/create-renderers.tsx
@@ -3,6 +3,7 @@ import { ComponentProps } from 'react'
 
 import { ExtraInfoIfRevisionView } from './extra-info-if-revision-view'
 import { ImageSerloStaticRenderer } from './serlo-plugin-wrappers/image-serlo-static-renderer'
+import { VideoSerloStaticRenderer } from './serlo-plugin-wrappers/video-serlo-static-renderer'
 import { EditorPluginType } from './types/editor-plugin-type'
 import type {
   EditorAnchorDocument,
@@ -21,7 +22,6 @@ import type {
   EditorSolutionDocument,
   EditorSpoilerDocument,
   EditorTemplateExerciseGroupDocument,
-  EditorVideoDocument,
 } from './types/editor-plugins'
 import { TemplatePluginType } from './types/template-plugin-type'
 import { Lazy } from '@/components/content/lazy'
@@ -42,8 +42,6 @@ import { RowsStaticRenderer } from '@/serlo-editor/plugins/rows/static'
 import { SpoilerStaticRenderer } from '@/serlo-editor/plugins/spoiler/static'
 import type { MathElement } from '@/serlo-editor/plugins/text'
 import { TextStaticRenderer } from '@/serlo-editor/plugins/text/static'
-import { parseVideoUrl } from '@/serlo-editor/plugins/video/renderer'
-import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
 import { MultimediaSerloStaticRenderer } from '@/serlo-editor-integration/serlo-plugin-wrappers/multimedia-serlo-static-renderer'
 
 const EquationsStaticRenderer = dynamic<EditorEquationsDocument>(() =>
@@ -185,24 +183,7 @@ export function createRenderers(): InitRenderersArgs {
       },
       {
         type: EditorPluginType.Video,
-        renderer: (state: EditorVideoDocument) => {
-          const { src } = state.state
-          if (!src) return null
-          const [iframeSrc, type] = parseVideoUrl(src)
-          return (
-            <Lazy noPrint>
-              <PrivacyWrapper
-                type="video"
-                provider={type as unknown as ExternalProvider}
-                embedUrl={iframeSrc}
-                className="print:hidden"
-              >
-                <VideoStaticRenderer {...state} />
-              </PrivacyWrapper>
-              <p className="serlo-p hidden print:block">[{src}]</p>
-            </Lazy>
-          )
-        },
+        renderer: VideoSerloStaticRenderer,
       },
       {
         type: EditorPluginType.Anchor,

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/geogebra-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/geogebra-serlo-static-renderer.tsx
@@ -1,0 +1,32 @@
+import dynamic from 'next/dynamic'
+
+import { EditorGeogebraDocument } from '../types/editor-plugins'
+import { Lazy } from '@/components/content/lazy'
+import type { PrivacyWrapperProps } from '@/components/content/privacy-wrapper'
+import { ExternalProvider } from '@/helper/use-consent'
+import { parseId } from '@/serlo-editor/plugins/geogebra/renderer'
+import { GeogebraStaticRenderer } from '@/serlo-editor/plugins/geogebra/static'
+
+const PrivacyWrapper = dynamic<PrivacyWrapperProps>(() =>
+  import('@/components/content/privacy-wrapper').then(
+    (mod) => mod.PrivacyWrapper
+  )
+)
+
+export function GeogebraSerloStaticRenderer(props: EditorGeogebraDocument) {
+  if (!props.state) return null
+  const { url } = parseId(props.state)
+  return (
+    <Lazy noPrint>
+      <PrivacyWrapper
+        type="applet"
+        provider={ExternalProvider.GeoGebra}
+        embedUrl={url}
+        className="print:hidden"
+      >
+        <GeogebraStaticRenderer {...props} />
+      </PrivacyWrapper>
+      <p className="serlo-p hidden print:block">[{url}]</p>
+    </Lazy>
+  )
+}

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer.tsx
@@ -1,0 +1,25 @@
+import { EditorVideoDocument } from '../types/editor-plugins'
+import { Lazy } from '@/components/content/lazy'
+import { PrivacyWrapper } from '@/components/content/privacy-wrapper'
+import { ExternalProvider } from '@/helper/use-consent'
+import { parseVideoUrl } from '@/serlo-editor/plugins/video/renderer'
+import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
+
+export function VideoSerloStaticRenderer(props: EditorVideoDocument) {
+  const { src } = props.state
+  if (!src) return null
+  const [iframeSrc, type] = parseVideoUrl(src)
+  return (
+    <Lazy noPrint>
+      <PrivacyWrapper
+        type="video"
+        provider={type as unknown as ExternalProvider}
+        embedUrl={iframeSrc}
+        className="print:hidden"
+      >
+        <VideoStaticRenderer {...props} />
+      </PrivacyWrapper>
+      <p className="serlo-p hidden print:block">[{src}]</p>
+    </Lazy>
+  )
+}

--- a/src/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer.tsx
+++ b/src/serlo-editor-integration/serlo-plugin-wrappers/video-serlo-static-renderer.tsx
@@ -1,9 +1,17 @@
+import dynamic from 'next/dynamic'
+
 import { EditorVideoDocument } from '../types/editor-plugins'
 import { Lazy } from '@/components/content/lazy'
-import { PrivacyWrapper } from '@/components/content/privacy-wrapper'
+import type { PrivacyWrapperProps } from '@/components/content/privacy-wrapper'
 import { ExternalProvider } from '@/helper/use-consent'
 import { parseVideoUrl } from '@/serlo-editor/plugins/video/renderer'
 import { VideoStaticRenderer } from '@/serlo-editor/plugins/video/static'
+
+const PrivacyWrapper = dynamic<PrivacyWrapperProps>(() =>
+  import('@/components/content/privacy-wrapper').then(
+    (mod) => mod.PrivacyWrapper
+  )
+)
 
 export function VideoSerloStaticRenderer(props: EditorVideoDocument) {
   const { src } = props.state


### PR DESCRIPTION
closes #3026 (https://frontend-git-fix-overflowing-iframes-serlo.vercel.app/editor)
closes #3025 (https://frontend-git-fix-overflowing-iframes-serlo.vercel.app/entity/repository/compare/138251/149309)

- privacy wrapper was missing in `/editor` and revision view
- that caused iframes to overflow somehow
- added custom serlo static wrapper to add privacy wrapper everywhere
- (probably needs another investigation when using video and geogebra directly e.g. in edusharing)