### PR TITLE
fix(injection-plugin): do not load empty urls, …

### DIFF
--- a/src/components/author/revision/revision.tsx
+++ b/src/components/author/revision/revision.tsx
@@ -6,6 +6,7 @@ import {
   RevisionPreviewBoxes,
   type RevisionPreviewBoxesProps,
 } from './revision-preview-boxes'
+import { Lazy } from '@/components/content/lazy'
 import { Link } from '@/components/content/link'
 import { MaxWidthDiv } from '@/components/navigation/max-width-div'
 import { UserTools } from '@/components/user-tools/user-tools'
@@ -169,10 +170,12 @@ export function Revision({ data }: RevisionProps) {
               })}{' '}
             </span>
           )}
-          <InjectionStaticRenderer
-            plugin={EditorPluginType.Injection}
-            state={parentId.toString()}
-          />
+          <Lazy>
+            <InjectionStaticRenderer
+              plugin={EditorPluginType.Injection}
+              state={parentId.toString()}
+            />
+          </Lazy>
         </div>
       </>
     )

--- a/src/serlo-editor-integration/create-renderers.tsx
+++ b/src/serlo-editor-integration/create-renderers.tsx
@@ -143,11 +143,12 @@ export function createRenderers(): InitRenderersArgs {
       {
         type: EditorPluginType.Injection,
         renderer: (props: EditorInjectionDocument) => {
+          if (!props.state) return null
           return (
-            <>
+            <Lazy>
               <InjectionStaticRenderer {...props} />
               <ExtraInfoIfRevisionView>{props.state}</ExtraInfoIfRevisionView>
-            </>
+            </Lazy>
           )
         },
       },

--- a/src/serlo-editor/plugins/article/add-modal/article-related-exercises.tsx
+++ b/src/serlo-editor/plugins/article/add-modal/article-related-exercises.tsx
@@ -78,7 +78,6 @@ export function ArticleRelatedExercises({
 
     return (
       <div key={id} className="my-5 border-t-2 border-black py-5">
-        {/* TODO: Test if this works */}
         <InjectionStaticRenderer
           plugin={EditorPluginType.Injection}
           state={`/${id}`}

--- a/src/serlo-editor/plugins/article/renderer.tsx
+++ b/src/serlo-editor/plugins/article/renderer.tsx
@@ -33,12 +33,12 @@ export function ArticleRenderer({
       {content}
       {exercises || exercisesFolder ? (
         <>
-          <h2 className="serlo-h2">{strings.content.exercisesTitle}</h2>
+          <h2 className="serlo-h2 mb-16">{strings.content.exercisesTitle}</h2>
 
           {exercises}
 
           {exercisesFolder ? (
-            <p className="serlo-p">
+            <p className="serlo-p mt-8">
               {strings.content.moreExercises}:<br />
               {exercisesFolder}
             </p>

--- a/src/serlo-editor/plugins/article/static.tsx
+++ b/src/serlo-editor/plugins/article/static.tsx
@@ -22,8 +22,10 @@ export function ArticleStaticRenderer({ state }: EditorArticleDocument) {
     sources,
   } = state
 
+  const filteredExercises = exercises?.filter(({ state }) => !!state)
+
   const hasMoreLink = exerciseFolder.id && exerciseFolder.title
-  const hasExercises = exercises && exercises.length
+  const hasExercises = filteredExercises && filteredExercises.length
 
   const introductionOrNull = isEmptyTextDocument(
     (introduction as EditorMultimediaDocument).state.explanation
@@ -35,7 +37,9 @@ export function ArticleStaticRenderer({ state }: EditorArticleDocument) {
     <ArticleRenderer
       introduction={introductionOrNull}
       content={<StaticRenderer document={content} />}
-      exercises={hasExercises ? <StaticRenderer document={exercises} /> : null}
+      exercises={
+        hasExercises ? <StaticRenderer document={filteredExercises} /> : null
+      }
       exercisesFolder={
         hasMoreLink ? (
           <Link className="font-bold" href={`/${exerciseFolder.id}`}>

--- a/src/serlo-editor/plugins/injection/static.tsx
+++ b/src/serlo-editor/plugins/injection/static.tsx
@@ -23,12 +23,11 @@ export function InjectionStaticRenderer({
   const [content, setContent] = useState<
     AnyEditorDocument[] | 'loading' | 'error'
   >('loading')
-
   const { strings } = useInstanceData()
   const cleanedHref = href?.startsWith('/') ? href : `/${href}`
 
   useEffect(() => {
-    if (!cleanedHref) return
+    if (!href) return
 
     try {
       void fetch(endpoint, {


### PR DESCRIPTION
- filter empty urls 
- fix exercise injection spacing in article
- lazy load injections

this should already catch some of the error in #3029 (closes #3029)
rest are actually not found in the db so the reporting is correct.