### PR TITLE
feat(exercise-plugin): only show loaded exercise plugins

### DIFF
--- a/src/serlo-editor/plugin/helpers/editor-plugins.tsx
+++ b/src/serlo-editor/plugin/helpers/editor-plugins.tsx
@@ -37,13 +37,5 @@ export const editorPlugins = (function () {
     return (contextPlugin?.plugin as EditorPlugin) ?? null
   }
 
-  function getByTypeOrUndefined(pluginType: string) {
-    const plugins = getAllWithData()
-
-    return plugins.find((plugin) => plugin.type === pluginType)?.plugin as
-      | EditorPlugin
-      | undefined
-  }
-
-  return { init, getAllWithData, getByType, getByTypeOrUndefined }
+  return { init, getAllWithData, getByType }
 })()

--- a/src/serlo-editor/plugin/helpers/editor-plugins.tsx
+++ b/src/serlo-editor/plugin/helpers/editor-plugins.tsx
@@ -37,5 +37,13 @@ export const editorPlugins = (function () {
     return (contextPlugin?.plugin as EditorPlugin) ?? null
   }
 
-  return { init, getAllWithData, getByType }
+  function getByTypeOrUndefined(pluginType: string) {
+    const plugins = getAllWithData()
+
+    return plugins.find((plugin) => plugin.type === pluginType)?.plugin as
+      | EditorPlugin
+      | undefined
+  }
+
+  return { init, getAllWithData, getByType, getByTypeOrUndefined }
 })()

--- a/src/serlo-editor/plugins/exercise/editor.tsx
+++ b/src/serlo-editor/plugins/exercise/editor.tsx
@@ -36,7 +36,7 @@ export function ExerciseEditor({ editable, state }: ExerciseProps) {
           {interactive.render()}
         </>
       ) : editable ? (
-        <>
+        <div className="mx-side">
           <p className="mb-2 text-gray-400">
             {exStrings.addOptionalInteractiveEx}
           </p>
@@ -53,7 +53,7 @@ export function ExerciseEditor({ editable, state }: ExerciseProps) {
               )
             })}
           </div>
-        </>
+        </div>
       ) : null}
     </>
   )

--- a/src/serlo-editor/plugins/exercise/editor.tsx
+++ b/src/serlo-editor/plugins/exercise/editor.tsx
@@ -19,6 +19,7 @@ const allInteractiveExerciseTypes = [
 export function ExerciseEditor({ editable, state }: ExerciseProps) {
   const { content, interactive } = state
 
+  // only show supported interactive exercise types
   const interactiveExerciseTypes = allInteractiveExerciseTypes.filter(
     (type) => !!editorPlugins.getByTypeOrUndefined(type)
   )

--- a/src/serlo-editor/plugins/exercise/editor.tsx
+++ b/src/serlo-editor/plugins/exercise/editor.tsx
@@ -6,10 +6,11 @@ import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { tw } from '@/helper/tw'
 import { AddButton } from '@/serlo-editor/editor-ui'
 import { EditorTooltip } from '@/serlo-editor/editor-ui/editor-tooltip'
+import { editorPlugins } from '@/serlo-editor/plugin/helpers/editor-plugins'
 import { store, selectDocument } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-const interactiveExerciseTypes = [
+const allInteractiveExerciseTypes = [
   EditorPluginType.ScMcExercise,
   EditorPluginType.InputExercise,
   EditorPluginType.H5p,
@@ -17,6 +18,10 @@ const interactiveExerciseTypes = [
 
 export function ExerciseEditor({ editable, state }: ExerciseProps) {
   const { content, interactive } = state
+
+  const interactiveExerciseTypes = allInteractiveExerciseTypes.filter(
+    (type) => !!editorPlugins.getByTypeOrUndefined(type)
+  )
 
   const exStrings = useEditorStrings().templatePlugins.exercise
   return (

--- a/src/serlo-editor/plugins/exercise/editor.tsx
+++ b/src/serlo-editor/plugins/exercise/editor.tsx
@@ -20,8 +20,8 @@ export function ExerciseEditor({ editable, state }: ExerciseProps) {
   const { content, interactive } = state
 
   // only show supported interactive exercise types
-  const interactiveExerciseTypes = allInteractiveExerciseTypes.filter(
-    (type) => !!editorPlugins.getByTypeOrUndefined(type)
+  const interactiveExerciseTypes = allInteractiveExerciseTypes.filter((type) =>
+    editorPlugins.getAllWithData().some((plugin) => plugin.type === type)
   )
 
   const exStrings = useEditorStrings().templatePlugins.exercise


### PR DESCRIPTION
This implementations can decide which plugins they want to support by adding or omitting them from `createPlugins`