### PR TITLE
Add option to configure allowedPlugins in solution

### DIFF
--- a/src/serlo-editor-integration/create-plugins.tsx
+++ b/src/serlo-editor-integration/create-plugins.tsx
@@ -48,7 +48,7 @@ import { taxonomyTypePlugin } from '@/serlo-editor/plugins/serlo-template-plugin
 import { textExerciseTypePlugin } from '@/serlo-editor/plugins/serlo-template-plugins/text-exercise'
 import { userTypePlugin } from '@/serlo-editor/plugins/serlo-template-plugins/user'
 import { videoTypePlugin } from '@/serlo-editor/plugins/serlo-template-plugins/video'
-import { solutionPlugin } from '@/serlo-editor/plugins/solution'
+import { createSolutionPlugin } from '@/serlo-editor/plugins/solution'
 import { createSpoilerPlugin } from '@/serlo-editor/plugins/spoiler'
 import { createTextPlugin } from '@/serlo-editor/plugins/text'
 import { unsupportedPlugin } from '@/serlo-editor/plugins/unsupported'
@@ -174,7 +174,7 @@ export function createPlugins({
       plugin: exercisePlugin,
       visibleInSuggestions: !isProduction,
     },
-    { type: EditorPluginType.Solution, plugin: solutionPlugin },
+    { type: EditorPluginType.Solution, plugin: createSolutionPlugin() },
     { type: EditorPluginType.H5p, plugin: H5pPlugin },
     {
       type: EditorPluginType.InputExercise,

--- a/src/serlo-editor/plugins/solution/index.tsx
+++ b/src/serlo-editor/plugins/solution/index.tsx
@@ -10,24 +10,39 @@ import {
 } from '@/serlo-editor/plugin'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 
-const solutionState = object({
-  strategy: child({ plugin: EditorPluginType.Text }),
-  steps: child({ plugin: EditorPluginType.Rows }),
-  prerequisite: optional(
-    object({
-      id: string(),
-      title: string(),
-      alias: optional(string()),
-    })
-  ),
-  licenseId: optional(number()),
-})
+function createSolutionState(config: SolutionConfig) {
+  return object({
+    strategy: child({ plugin: EditorPluginType.Text }),
+    steps: child({
+      plugin: EditorPluginType.Rows,
+      config: { allowedPlugins: config.allowedPlugins },
+    }),
+    prerequisite: optional(
+      object({
+        id: string(),
+        title: string(),
+        alias: optional(string()),
+      })
+    ),
+    licenseId: optional(number()),
+  })
+}
 
-export type SolutionPluginState = typeof solutionState
+export type SolutionPluginState = ReturnType<typeof createSolutionState>
 export type SolutionProps = EditorPluginProps<SolutionPluginState>
 
-export const solutionPlugin: EditorPlugin<SolutionPluginState> = {
-  Component: SolutionEditor,
-  state: solutionState,
-  config: {},
+export const defaultConfig: SolutionConfig = {}
+
+export function createSolutionPlugin(
+  config = defaultConfig
+): EditorPlugin<SolutionPluginState> {
+  return {
+    Component: SolutionEditor,
+    state: createSolutionState(config),
+    config: config,
+  }
+}
+
+export interface SolutionConfig {
+  allowedPlugins?: (EditorPluginType | string)[]
 }


### PR DESCRIPTION
Adds option to configure what plugins are allowed within a solution plugin. Useful for edu-sharing and other future editor integrations. 

TODOs:
- [x] Currently, all plugins are allowed per default. But for example having an exercise in the solution of an exercise makes little sense I think. Should we make the default more restrictive?
- [x] Is this still needed? 