### PR TITLE
Fix: Render ai generate exercise button only for new exercises

### DIFF
--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
@@ -1,4 +1,5 @@
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { useRouter } from 'next/router'
 
 import { TextExerciseGroupTypeRenderer } from './renderer'
 import {
@@ -27,7 +28,6 @@ import {
 import { selectStaticDocument, store } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
-import { useRouter } from 'next/router'
 
 // text-exercises also include interactive exercises, we keep the naming to avoid db-migration
 

--- a/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/exercise-group/text-exercise-group.tsx
@@ -27,6 +27,7 @@ import {
 import { selectStaticDocument, store } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
 import { TemplatePluginType } from '@/serlo-editor-integration/types/template-plugin-type'
+import { useRouter } from 'next/router'
 
 // text-exercises also include interactive exercises, we keep the naming to avoid db-migration
 
@@ -65,6 +66,11 @@ function TextExerciseGroupTypeEditor(
     replaceOwnState,
   } = props.state
   const { canUseAiFeaturesOutsideProduction } = useAiFeatures()
+  const router = useRouter()
+  const currentPath = router.asPath.toLowerCase()
+  const isCreatingNewExerciseGroup = currentPath.includes(
+    '/create/exercisegroup'
+  )
   const exGroupStrings = useEditorStrings().templatePlugins.textExerciseGroup
 
   const staticState = selectStaticDocument(store.getState(), props.id)
@@ -78,7 +84,7 @@ function TextExerciseGroupTypeEditor(
   return (
     <>
       <div className="absolute right-0 -mt-20 mr-side flex">
-        {canUseAiFeaturesOutsideProduction ? (
+        {canUseAiFeaturesOutsideProduction && isCreatingNewExerciseGroup ? (
           <AiExerciseGenerationButton />
         ) : null}
         <ContentLoaders

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/serlo-editor/plugin'
 import { selectStaticDocument, store } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
+import { useRouter } from 'next/router'
 
 export const textExerciseTypeState = entityType(
   {
@@ -42,6 +43,11 @@ function TextExerciseTypeEditor({
   const { content } = state
 
   const { canUseAiFeaturesOutsideProduction } = useAiFeatures()
+
+  const router = useRouter()
+  const currentPath = router.asPath.toLowerCase()
+  const isCreatingNewExercise = currentPath.includes('/create/exercise')
+
   const staticDocument = selectStaticDocument(store.getState(), id)
     ?.state as PrettyStaticState<TextExerciseTypePluginState>
   if (!staticDocument) return null
@@ -50,7 +56,7 @@ function TextExerciseTypeEditor({
     <>
       {config.skipControls ? null : (
         <div className="absolute right-0 -mt-20 mr-side flex flex-row gap-4">
-          {canUseAiFeaturesOutsideProduction ? (
+          {canUseAiFeaturesOutsideProduction && isCreatingNewExercise ? (
             <AiExerciseGenerationButton isSingularExercise />
           ) : null}
           <ContentLoaders

--- a/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
+++ b/src/serlo-editor/plugins/serlo-template-plugins/text-exercise.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { useRouter } from 'next/router'
 
 import { editorContent, entity, entityType } from './common/common'
 import { ContentLoaders } from './helpers/content-loaders/content-loaders'
@@ -13,7 +14,6 @@ import {
 } from '@/serlo-editor/plugin'
 import { selectStaticDocument, store } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor-integration/types/editor-plugin-type'
-import { useRouter } from 'next/router'
 
 export const textExerciseTypeState = entityType(
   {


### PR DESCRIPTION
I guess it doesn't make any sense to show this button when editing an existing exercise, does it? We'd have to add a warning that it overwrites the existing exercise, similarly what we do when importing a different entity.

![image](https://github.com/serlo/frontend/assets/28842311/c4035eca-51ab-4e5c-9d79-2d5c3489f075)
