### PR TITLE
feat(rows-plugin): restrict where exercises can be used

### DIFF
--- a/src/serlo-editor/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/src/serlo-editor/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -1,4 +1,5 @@
 import { EditorPluginType } from '@/serlo-editor/types/editor-plugin-type'
+import { TemplatePluginType } from '@/serlo-editor/types/template-plugin-type'
 
 export function checkIsAllowedNesting(
   pluginType: string,
@@ -38,6 +39,20 @@ export function checkIsAllowedNesting(
     ).length > 1
   ) {
     return false
+  }
+
+  if (pluginType === EditorPluginType.Exercise) {
+    // never allow exercises in solutions
+    if (typesOfAncestors.includes(EditorPluginType.Solution)) return false
+
+    const rootPlugin = typesOfAncestors[0]
+    if (
+      rootPlugin.startsWith('type-') && // only on serlo, allowed everywhere in edusharing
+      rootPlugin !== TemplatePluginType.Article &&
+      rootPlugin !== TemplatePluginType.CoursePage
+    ) {
+      return false
+    }
   }
 
   return true

--- a/src/serlo-editor/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/src/serlo-editor/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -47,7 +47,9 @@ export function checkIsAllowedNesting(
 
     const rootPlugin = typesOfAncestors[0]
     if (
-      rootPlugin.startsWith('type-') && // only on serlo, allowed everywhere in edusharing
+      // serlo template plugins start with "type-…"
+      // so we use this to not hide exercises in edusharing and /___editor_preview
+      rootPlugin.startsWith('type-') &&
       rootPlugin !== TemplatePluginType.Article &&
       rootPlugin !== TemplatePluginType.CoursePage
     ) {


### PR DESCRIPTION
root plugin:
- serlo: only show in articles and coursePages templates for now
- every else: show everywhere

parent plugins:
- always hide in solutions