### PR TITLE
Fill in the blanks: Prepare for release on serlo.org

### DIFF
--- a/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/src/serlo-editor/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -48,7 +48,8 @@ export function toggleBlank(editor: SlateEditor) {
       type: 'blank',
       blankId: uuid_v4(),
       correctAnswer: '',
-      alternativeSolutions: [],
+      // Disabled alternative correct solutions for now
+      // alternativeSolutions: [],
       children: [{ text: '' }],
     })
     return
@@ -63,7 +64,8 @@ export function toggleBlank(editor: SlateEditor) {
         blankId: uuid_v4(),
         correctAnswer:
           SlateEditor.string(editor, trimmedSelection as Location) || '',
-        alternativeSolutions: [],
+        // Disabled alternative correct solutions for now
+        // alternativeSolutions: [],
         children: [{ text: '' }],
       },
     ],

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/context/blank-context.ts
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/context/blank-context.ts
@@ -1,13 +1,16 @@
 import { createContext } from 'react'
 
+import type { FillInTheBlanksMode } from '..'
+
 type BlankId = string
 
 // Used to pass state to BlankRenderer from FillInTheBlanksRenderer
 // BlankRenderer will use this state alongside the state stored in the slate custom element 'blank' to render.
-export const BlankStatesContext = createContext<{
-  mode: string
-  blanksFeedback: Map<BlankId, { isCorrect?: boolean }>
-  textUserTypedIntoBlank: {
+export const FillInTheBlanksContext = createContext<{
+  mode: FillInTheBlanksMode
+  feedbackForBlanks: Map<BlankId, { isCorrect?: boolean }>
+  textInBlanks: Map<BlankId, { text: string }>
+  textUserTypedIntoBlanks: {
     value: Map<BlankId, { text: string }>
     set: React.Dispatch<React.SetStateAction<Map<BlankId, { text: string }>>>
   }

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/editor.tsx
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/editor.tsx
@@ -1,0 +1,43 @@
+import type { FillInTheBlanksExerciseProps, FillInTheBlanksMode } from '.'
+import { FillInTheBlanksRenderer } from './renderer'
+import { PluginToolbar } from '@/serlo-editor/editor-ui/plugin-toolbar'
+import { selectDocument, useAppSelector } from '@/serlo-editor/store'
+import { EditorPluginType } from '@/serlo-editor/types/editor-plugin-type'
+
+export function FillInTheBlanksExerciseEditor(
+  props: FillInTheBlanksExerciseProps
+) {
+  const { focused } = props
+
+  // Rerender if text plugin state changes
+  const textPluginState = useAppSelector((state) => {
+    return selectDocument(state, props.state.text.id)
+  })
+
+  if (!textPluginState) return null
+
+  return (
+    <div className="mb-12 mt-10 pt-4">
+      {/* while developing */}
+      <div className="hidden">
+        {focused ? (
+          // TODO: Add button to toggle between fill-in-the-blanks and drag-and-drop
+          // TODO: Make toolbars nested like in multimedia
+          <PluginToolbar
+            pluginType={EditorPluginType.FillInTheBlanksExercise}
+            className="!left-[21px] top-[-33px] w-[calc(100%-37px)]"
+          />
+        ) : null}
+      </div>
+      <FillInTheBlanksRenderer
+        text={props.state.text.render()}
+        textPluginState={textPluginState}
+        mode={props.state.mode.value as FillInTheBlanksMode}
+        initialTextInBlank="correct-answer"
+      />
+
+      {/* Only debug views from here on */}
+      <div className="hidden">{JSON.stringify(textPluginState)}</div>
+    </div>
+  )
+}

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/index.tsx
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/index.tsx
@@ -1,6 +1,5 @@
-import { FillInTheBlanksRenderer } from './renderer'
+import { FillInTheBlanksExerciseEditor } from './editor'
 import { defaultFormattingOptions } from '../text/hooks/use-text-config'
-import { PluginToolbar } from '@/serlo-editor/editor-ui/plugin-toolbar'
 import { TextEditorFormattingOption } from '@/serlo-editor/editor-ui/plugin-toolbar/text-controls/types'
 import {
   type EditorPlugin,
@@ -9,8 +8,9 @@ import {
   child,
   string,
 } from '@/serlo-editor/plugin'
-import { selectDocument, useAppSelector } from '@/serlo-editor/store'
 import { EditorPluginType } from '@/serlo-editor/types/editor-plugin-type'
+
+export type FillInTheBlanksMode = 'typing' | 'drag-and-drop'
 
 export const fillInTheBlanksExercise: EditorPlugin<FillInTheBlanksExerciseState> =
   {
@@ -24,6 +24,8 @@ export type FillInTheBlanksExerciseState = ReturnType<
 >
 
 function createFillInTheBlanksExerciseState() {
+  const defaultMode: FillInTheBlanksMode = 'typing'
+
   return object({
     text: child({
       plugin: EditorPluginType.Text,
@@ -34,46 +36,9 @@ function createFillInTheBlanksExerciseState() {
         ],
       },
     }),
-    mode: string('fill-in-the-blanks'),
-    // mode: string('drag-and-drop'),
+    mode: string(defaultMode),
   })
 }
 
 export type FillInTheBlanksExerciseProps =
   EditorPluginProps<FillInTheBlanksExerciseState>
-
-export function FillInTheBlanksExerciseEditor(
-  props: FillInTheBlanksExerciseProps
-) {
-  const { focused } = props
-  // Only for debug view
-  const textPluginState = useAppSelector((state) => {
-    return selectDocument(state, props.state.text.id)
-  })
-
-  if (!textPluginState) return null
-
-  return (
-    <div className="mb-12 mt-10 pt-4">
-      {/* while developing */}
-      <div className="hidden">
-        {focused ? (
-          // TODO: Add button to toggle between fill-in-the-blanks and drag-and-drop
-          // TODO: Make toolbars nested like in multimedia
-          <PluginToolbar
-            pluginType={EditorPluginType.FillInTheBlanksExercise}
-            className="!left-[21px] top-[-33px] w-[calc(100%-37px)]"
-          />
-        ) : null}
-      </div>
-      <FillInTheBlanksRenderer
-        text={props.state.text.render()}
-        textPluginState={textPluginState}
-        mode={props.state.mode.value}
-      />
-
-      {/* Only debug views from here on */}
-      <div className="hidden">{JSON.stringify(textPluginState)}</div>
-    </div>
-  )
-}

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -32,7 +32,8 @@ const Blank = t.type({
   type: t.literal('blank'),
   blankId: t.string,
   correctAnswer: t.string,
-  alternativeSolutions: t.array(t.string),
+  // Disabled alternative correct solutions for now
+  // alternativeSolutions: t.array(t.string),
 })
 
 type Blanks = t.TypeOf<typeof Blank>[]
@@ -201,14 +202,14 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
         { isCorrect: boolean | undefined }
       >()
       blanks.forEach((blankState) => {
-        const blankText =
+        const trimmedBlankText =
           textInBlanks.get(blankState.blankId)?.text.trim() ?? ''
-        const isCorrect =
-          blankText === blankState.correctAnswer.trim() ||
-          blankText ===
-            blankState.alternativeSolutions.find(
-              (alternativeSolution) => blankText === alternativeSolution.trim()
-            )
+        const trimmedCorrectAnswer = blankState.correctAnswer.trim()
+        // Disabled alternative correct solutions for now
+        // const trimmedAlternativeSolutions = blankState.alternativeSolutions.map(alternativeSolution => alternativeSolution.trim())
+        const isCorrect = trimmedBlankText === trimmedCorrectAnswer
+        // Disabled alternative correct solutions for now
+        // || trimmedAlternativeSolutions.find((alternativeSolution) => trimmedBlankText === alternativeSolution)
         newBlankAnswersCorrectList.set(blankState.blankId, {
           isCorrect: isCorrect,
         })

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -1,10 +1,11 @@
 // import { DndContext, UniqueIdentifier } from '@dnd-kit/core'
 import * as t from 'io-ts'
-import { ReactNode, useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 
 // import { BlankSolution } from './components/blank-solution'
 // import { BlankSolutionsArea } from './components/blank-solution-area'
-import { BlankStatesContext } from './context/blank-context'
+import type { FillInTheBlanksMode } from '.'
+import { FillInTheBlanksContext } from './context/blank-context'
 import { Feedback } from '../sc-mc-exercise/renderer/feedback'
 import { useInstanceData } from '@/contexts/instance-context'
 
@@ -27,14 +28,14 @@ import { useInstanceData } from '@/contexts/instance-context'
 // >(null)
 
 // TODO: Copy of type in /src/serlo-editor/plugins/text/types/text-editor.ts
-const BlankState = t.type({
+const Blank = t.type({
   type: t.literal('blank'),
   blankId: t.string,
   correctAnswer: t.string,
   alternativeSolutions: t.array(t.string),
 })
 
-type BlankStates = t.TypeOf<typeof BlankState>[]
+type Blanks = t.TypeOf<typeof Blank>[]
 
 type BlankId = string
 
@@ -45,11 +46,12 @@ interface FillInTheBlanksRendererProps {
     state?: unknown
     id?: string | undefined
   }
-  mode: string
+  mode: FillInTheBlanksMode
+  initialTextInBlank: 'empty' | 'correct-answer'
 }
 
 export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
-  const { text, textPluginState, mode } = props
+  const { text, textPluginState, mode, initialTextInBlank } = props
 
   const exStrings = useInstanceData().strings.content.exercises
 
@@ -58,20 +60,36 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
 
   // Maps blankId to the learner feedback after clicking "Stimmts?" button
   // isCorrect === undefined -> no feedback
-  const [blanksFeedback, setBlanksFeedback] = useState(
+  const [feedbackForBlanks, setFeedbackForBlanks] = useState(
     new Map<BlankId, { isCorrect?: boolean }>()
   )
 
-  // Maps blankId to the text entered by the user
-  const [textUserTypedIntoBlank, setTextUserTypedIntoBlank] = useState(
+  /** Array of blank elements extracted from text editor state */
+  const blanks: Blanks = useMemo(() => {
+    return getBlanksWithinObject(textPluginState)
+  }, [textPluginState])
+
+  // Maps blankId to the text entered by the user. Modified when user types into a blank and causes rerender.
+  const [textUserTypedIntoBlanks, setTextUserTypedIntoBlanks] = useState(
     new Map<BlankId, { text: string }>()
   )
 
-  // List of blank elements found in text editor state
-  const blankStateList: BlankStates = useMemo(() => {
-    // TODO: Remove entries in textUserTypedIntoBlank where blankId no longer exists.
-    return getBlanksWithinObject(textPluginState)
-  }, [textPluginState])
+  /** Maps blankId to the text that should be displayed in the blank.  */
+  const textInBlanks = useMemo(() => {
+    const newMap = new Map<BlankId, { text: string }>()
+    blanks.forEach((blankState) =>
+      newMap.set(blankState.blankId, {
+        text:
+          initialTextInBlank === 'correct-answer'
+            ? blankState.correctAnswer
+            : '',
+      })
+    )
+    textUserTypedIntoBlanks.forEach((textUserTypedIntoBlank, blankId) =>
+      newMap.set(blankId, { text: textUserTypedIntoBlank.text })
+    )
+    return newMap
+  }, [blanks, textUserTypedIntoBlanks, initialTextInBlank])
 
   // --- Drag & drop stuff
   // TODO: Should get blank solutions from text state
@@ -97,18 +115,19 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
     // >
     // <BlankDragAndDropSolutions.Provider value={blankDragAndDropSolutions}>
     <div className="mx-side mb-block leading-[30px] [&>p]:leading-[30px]">
-      <BlankStatesContext.Provider
+      <FillInTheBlanksContext.Provider
         value={{
           mode: mode,
-          blanksFeedback: blanksFeedback,
-          textUserTypedIntoBlank: {
-            value: textUserTypedIntoBlank,
-            set: setTextUserTypedIntoBlank,
+          feedbackForBlanks: feedbackForBlanks,
+          textInBlanks: textInBlanks,
+          textUserTypedIntoBlanks: {
+            value: textUserTypedIntoBlanks,
+            set: setTextUserTypedIntoBlanks,
           },
         }}
       >
         {text}
-      </BlankStatesContext.Provider>
+      </FillInTheBlanksContext.Provider>
       {/* {mode === 'drag-and-drop' ? (
         <BlankSolutionsArea>
           <>
@@ -138,7 +157,9 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
         </button>
         {showFeedback && (
           <Feedback
-            correct={[...blanksFeedback].every((entry) => entry[1].isCorrect)}
+            correct={[...feedbackForBlanks].every(
+              (entry) => entry[1].isCorrect
+            )}
           />
         )}
       </div>
@@ -146,13 +167,13 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
       {/* Only debug output from here on */}
       <div className="hidden">
         Blanks state:
-        {blankStateList.map((blank, index) => (
+        {blanks.map((blank, index) => (
           <div key={index}>{JSON.stringify(blank)}</div>
         ))}
       </div>
       <div className="hidden">
         <div>State textUserTypedIntoBlank:</div>
-        {[...textUserTypedIntoBlank].map((entry, index) => {
+        {[...textUserTypedIntoBlanks].map((entry, index) => {
           const blankId = entry[0]
           const text = entry[1].text
           return (
@@ -174,41 +195,40 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   )
 
   function checkAnswers() {
-    if (mode === 'fill-in-the-blanks') {
+    if (mode === 'typing') {
       const newBlankAnswersCorrectList = new Map<
         BlankId,
         { isCorrect: boolean | undefined }
       >()
-      blankStateList.forEach((blankState) => {
-        const textUserTypedIntoThisBlank =
-          textUserTypedIntoBlank.get(blankState.blankId)?.text.trim() ?? ''
+      blanks.forEach((blankState) => {
+        const blankText =
+          textInBlanks.get(blankState.blankId)?.text.trim() ?? ''
         const isCorrect =
-          textUserTypedIntoThisBlank === blankState.correctAnswer.trim() ||
-          textUserTypedIntoThisBlank ===
+          blankText === blankState.correctAnswer.trim() ||
+          blankText ===
             blankState.alternativeSolutions.find(
-              (alternativeSolution) =>
-                textUserTypedIntoThisBlank === alternativeSolution.trim()
+              (alternativeSolution) => blankText === alternativeSolution.trim()
             )
         newBlankAnswersCorrectList.set(blankState.blankId, {
           isCorrect: isCorrect,
         })
       })
 
-      setBlanksFeedback(newBlankAnswersCorrectList)
+      setFeedbackForBlanks(newBlankAnswersCorrectList)
     } else if (mode === 'drag-and-drop') {
       // TODO: Check answers in drag-and-drop mode
     }
   }
 }
 
-// Searches for blank objects in text plugin state. They can be at varying depths.
-function getBlanksWithinObject(obj: object): BlankStates {
-  if (BlankState.is(obj)) {
+/** Searches for blank objects in text plugin state. They can be at varying depths. */
+function getBlanksWithinObject(obj: object): Blanks {
+  if (Blank.is(obj)) {
     return [obj]
   }
 
   // Recursively search this object's values for blank objects
-  return Object.values(obj).reduce((blanks: BlankStates, value: unknown) => {
+  return Object.values(obj).reduce((blanks: Blanks, value: unknown) => {
     if (typeof value === 'object' && value !== null) {
       return [...blanks, ...getBlanksWithinObject(value)]
     }

--- a/src/serlo-editor/plugins/fill-in-the-blanks-exercise/static.tsx
+++ b/src/serlo-editor/plugins/fill-in-the-blanks-exercise/static.tsx
@@ -1,3 +1,4 @@
+import type { FillInTheBlanksMode } from '.'
 import { FillInTheBlanksRenderer } from './renderer'
 import { StaticRenderer } from '@/serlo-editor/static-renderer/static-renderer'
 import { EditorFillInTheBlanksExerciseDocument } from '@/serlo-editor/types/editor-plugins'
@@ -5,12 +6,13 @@ import { EditorFillInTheBlanksExerciseDocument } from '@/serlo-editor/types/edit
 export function FillInTheBlanksStaticRenderer(
   state: EditorFillInTheBlanksExerciseDocument
 ) {
-  const { text, mode } = state.state
+  const { text } = state.state
   return (
     <FillInTheBlanksRenderer
       text={<StaticRenderer document={text} />}
       textPluginState={text}
-      mode={mode}
+      mode={state.state.mode as FillInTheBlanksMode}
+      initialTextInBlank="empty"
     />
   )
 }

--- a/src/serlo-editor/plugins/text/hooks/use-slate-render-handlers.tsx
+++ b/src/serlo-editor/plugins/text/hooks/use-slate-render-handlers.tsx
@@ -2,6 +2,7 @@ import { createElement, useCallback, useMemo } from 'react'
 import { Editor as SlateEditor, Transforms } from 'slate'
 import { ReactEditor, RenderElementProps, RenderLeafProps } from 'slate-react'
 
+import { BlankRenderer } from '../../fill-in-the-blanks-exercise/blank-renderer'
 import { MathElement } from '../components/math-element'
 import { TextLeafWithPlaceholder } from '../components/text-leaf-with-placeholder'
 import { ListElementType } from '../types/text-editor'
@@ -81,17 +82,14 @@ export const useSlateRenderHandlers = ({
         )
       }
       if (element.type === 'blank') {
-        // TODO: Render <BlankRenderer> here instead
-        // <BlankRenderer> needs to ...
-        // - always show input fields
-        // - accept callback onChange that is passed to input element to update correctAnswer
         return (
           <span {...attributes} contentEditable={false}>
-            <input
-              value={element.correctAnswer}
-              size={(element.correctAnswer.length ?? 4) + 1}
-              className="h-[25px] rounded-full border border-brand bg-brand-50 pl-2 pr-1"
+            <BlankRenderer
+              correctAnswer={element.correctAnswer}
+              blankId={element.blankId}
+              forceMode="typing"
               onChange={(e) => {
+                if (!e) return
                 const path = ReactEditor.findPath(editor, element)
                 Transforms.setNodes(
                   editor,

--- a/src/serlo-editor/plugins/text/types/text-editor.ts
+++ b/src/serlo-editor/plugins/text/types/text-editor.ts
@@ -17,7 +17,8 @@ export interface Blank {
   children: CustomText[]
   blankId: string // Used to uniquely identify a blank
   correctAnswer: string
-  alternativeSolutions: string[]
+  // Disabled alternative correct solutions for now
+  // alternativeSolutions: string[]
 }
 
 export interface Heading {


### PR DESCRIPTION
Changes: 
- `BlankRenderer` is now also used in the editor. That means both the editor and the static renderer use the same component for rendering blanks. -> Makes clicking "Stimmts?" now also work in the editor. 
- The feature to allow alternative correct solutions was deactivated because it is out of scope for the first release
- Renamings and code refactoring to improve clarity