### PR TITLE
fix(blanks): Focus editor after gap is removed

### DIFF
--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -54,7 +54,7 @@ function removeBlanks(editor: SlateEditor) {
   // After the blank is removed, we must refocus the editor. Without the timeout
   // it blows up and moving this code to the unmounting of the blank-renderer
   // also blows up when changing from preview to edit mode.
-  setTimeout(() => ReactEditor.focus(editor), 1)
+  setTimeout(() => ReactEditor.focus(editor))
 }
 
 function addBlank(editor: SlateEditor) {

--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -7,6 +7,7 @@ import {
   Editor,
   Path,
 } from 'slate'
+import { ReactEditor } from 'slate-react'
 import { v4 as uuid_v4 } from 'uuid'
 
 import { selectionHasElement, trimSelection } from './selection'
@@ -50,6 +51,10 @@ function removeBlanks(editor: SlateEditor) {
       },
     })
   })
+  // After the blank is removed, we must refocus the editor. Without the timeout
+  // it blows up and moving this code to the unmounting of the blank-renderer
+  // also blows up when changing from preview to edit mode.
+  setTimeout(() => ReactEditor.focus(editor), 1)
 }
 
 function addBlank(editor: SlateEditor) {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -28,11 +28,8 @@ export function BlankRenderer({ element }: BlankRendererProps) {
     const input = inputRef.current
     if (input) input.focus()
 
-    // Focus editor when the blank is removed
-    return () => {
-      // TODO: uncommented this breaks the preview mode somehow, investigate
-      // ReactEditor.focus(editor)
-    }
+    // Editor gets refocused when the blank is removed from within
+    // text-controls/utils/blank.ts as it leads to slate errors on unmount.
 
     // Only run on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Would be so happy to see a better solution for this but after a lot of trial and error, this seems to be one of the only options with good UX + no exception. 