### PR TITLE
fix(gaps): Delete gap when del/backspace is pressed within an empty gap

### DIFF
--- a/apps/web/src/assets-webkit/styles/serlo-tailwind.css
+++ b/apps/web/src/assets-webkit/styles/serlo-tailwind.css
@@ -355,6 +355,17 @@
     }
   }
 
+  /* When using appearance-none, we need to add back the caret */
+  .serlo-custom-select::after {
+    /* caret symbol */
+    content: '▼';
+    pointer-events: none;
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
   .serlo-tooltip-trigger {
     @apply relative;
 
@@ -435,7 +446,7 @@
     }
   }
 
-  /* heavily inspired by Shaw (https://css-tricks.com/auto-growing-inputs-textareas/#aa-other-ideas) 
+  /* heavily inspired by Shaw (https://css-tricks.com/auto-growing-inputs-textareas/#aa-other-ideas)
     this needs a data-value on the wrapping element equal to the value of the input
   */
   .serlo-autogrow-input {

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -913,7 +913,7 @@ export const loggedInData = {
           title: 'Fill In The Blanks Exercise',
           description: 'Text with blanks',
           placeholder: 'Write a text and add blanks',
-          chooseType: 'Choose the exercise type',
+          chooseType: 'Choose how to solve the exercise',
           modes: {
             typing: 'Typing',
             'drag-and-drop': 'Drag & Drop',

--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -24,7 +24,7 @@ export function toggleBlank(editor: SlateEditor) {
   }
 }
 
-function removeBlanks(editor: SlateEditor) {
+export function removeBlanks(editor: SlateEditor) {
   Editor.withoutNormalizing(editor, () => {
     if (!editor.selection) return
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -1,3 +1,4 @@
+import { removeBlanks } from '@editor/editor-ui/plugin-toolbar/text-controls/utils/blank'
 import {
   ChangeEvent,
   KeyboardEvent as ReactKeyboardEvent,
@@ -89,6 +90,12 @@ export function BlankRenderer({ element }: BlankRendererProps) {
     const selectionCollapsed = selectionStart === selectionEnd
     const caretAtRightEnd = selectionEnd === value.length
     const caretAtLeftEnd = selectionStart === 0
+    const isInputEmpty = value.length === 0
+
+    if (isInputEmpty && (event.key === 'Backspace' || event.key === 'Delete')) {
+      event.preventDefault()
+      removeBlanks(editor)
+    }
 
     // Move the selection right of the blank on arrow right
     if (

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/editor.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/editor.tsx
@@ -56,6 +56,7 @@ export function FillInTheBlanksExerciseEditor(
         <FillInTheBlanksStaticRenderer {...staticDocument} />
       ) : (
         <FillInTheBlanksRenderer
+          isEditing
           text={props.state.text.render({
             config: {
               placeholder: editorStrings.plugins.blanksExercise.placeholder,

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -34,10 +34,12 @@ interface FillInTheBlanksRendererProps {
   }
   mode: FillInTheBlanksMode
   initialTextInBlank: 'empty' | 'correct-answer'
+
+  isEditing?: boolean
 }
 
 export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
-  const { text, textPluginState, mode, initialTextInBlank } = props
+  const { text, textPluginState, mode, initialTextInBlank, isEditing } = props
 
   const exStrings = useInstanceData().strings.content.exercises
 
@@ -133,28 +135,32 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
         </DraggableSolutionArea>
       ) : null}
 
-      {/* Copied from mc-renderer.tsx */}
-      <div className="mt-2 flex">
-        <button
-          className={cn(
-            'serlo-button-blue mr-3 h-8',
-            allBlanksHaveText ? '' : 'pointer-events-none opacity-0'
-          )}
-          onClick={() => {
-            checkAnswers()
-            setShowFeedback(true)
-          }}
-        >
-          {exStrings.check}
-        </button>
-        {showFeedback && (
-          <Feedback
-            correct={[...feedbackForBlanks].every(
-              (entry) => entry[1].isCorrect
+      {/* Only show "Stimmt's?" during render/preview*/}
+      {!isEditing && (
+        <div className="mt-2 flex">
+          <button
+            className={cn(
+              'serlo-button-blue mr-3 h-8',
+              allBlanksHaveText && blanks.length > 0
+                ? ''
+                : 'pointer-events-none opacity-0'
             )}
-          />
-        )}
-      </div>
+            onClick={() => {
+              checkAnswers()
+              setShowFeedback(true)
+            }}
+          >
+            {exStrings.check}
+          </button>
+          {showFeedback && (
+            <Feedback
+              correct={[...feedbackForBlanks].every(
+                (entry) => entry[1].isCorrect
+              )}
+            />
+          )}
+        </div>
+      )}
 
       {/* Only debug output from here on */}
       <div className="hidden">

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
@@ -29,7 +29,7 @@ export const FillInTheBlanksToolbar = ({
         <>
           <button
             onClick={() => setPreviewActive(!previewActive)}
-            className="serlo-tooltip-trigger mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
+            className="line-height-[normal] vertical-align serlo-tooltip-trigger mr-2 rounded-md border border-gray-500 px-1 py-[1px] text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
           >
             <EditorTooltip
               text={
@@ -42,7 +42,7 @@ export const FillInTheBlanksToolbar = ({
             {blanksExerciseStrings.previewMode}{' '}
             <FaIcon icon={previewActive ? faCheckCircle : faCircle} />
           </button>
-          <label className="serlo-tooltip-trigger mr-2">
+          <label className="serlo-tooltip-trigger mr-2 text-sm">
             <EditorTooltip text={blanksExerciseStrings.chooseType} />
             <select
               value={state.mode.value}
@@ -50,9 +50,10 @@ export const FillInTheBlanksToolbar = ({
                 state.mode.set(event.target.value)
               }}
               className={cn(`
-                bg-editor-primary-10 mr-2 max-w-[13rem] cursor-pointer rounded-md !border
-                border-gray-500 bg-transparent px-1 py-[1px] text-sm transition-all
-                hover:bg-editor-primary-200 focus:bg-editor-primary-200 focus:outline-none
+                bg-editor-primary-10 vertical-align mr-2 max-w-[13rem] cursor-pointer rounded-md
+                !border border-gray-500 bg-transparent px-1 py-[1px] text-sm
+                transition-all hover:bg-editor-primary-200
+                focus:bg-editor-primary-200
               `)}
             >
               {(['typing', 'drag-and-drop'] as const).map((mode) => (

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
@@ -42,7 +42,7 @@ export const FillInTheBlanksToolbar = ({
             {blanksExerciseStrings.previewMode}{' '}
             <FaIcon icon={previewActive ? faCheckCircle : faCircle} />
           </button>
-          <label className="serlo-tooltip-trigger mr-2 text-sm">
+          <label className="serlo-custom-select serlo-tooltip-trigger relative mr-2 text-sm">
             <EditorTooltip text={blanksExerciseStrings.chooseType} />
             <select
               value={state.mode.value}
@@ -50,7 +50,8 @@ export const FillInTheBlanksToolbar = ({
                 state.mode.set(event.target.value)
               }}
               className={cn(`
-                bg-editor-primary-10 vertical-align mr-2 max-w-[13rem] cursor-pointer rounded-md
+                bg-editor-primary-10 vertical-align
+                mr-2 max-w-[13rem] cursor-pointer appearance-none rounded-md
                 !border border-gray-500 bg-transparent px-1 py-[1px] text-sm
                 transition-all hover:bg-editor-primary-200
                 focus:bg-editor-primary-200


### PR DESCRIPTION
Let me know what you think of this behavior. This is how I'd expect it to be, but I'm curious if someone prefers not having the gap deleted. 

Edit: It just dawned on me, that  I need to check tomorrow if this will delete the gap in render mode for the students solving the exercise :see_no_evil: Obviously, it should only delete the gap when the author is editing the gaps :sweat_smile:  