### PR TITLE
fix(blanks): Overflow of text toolbar

### DIFF
--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-controls.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/plugin-toolbar-text-controls.tsx
@@ -3,7 +3,11 @@ import { Fragment, useState } from 'react'
 import { Editor as SlateEditor } from 'slate'
 
 import { PluginToolbarTextControlButton } from './plugin-toolbar-text-control-button'
-import type { NestedControlButton, ControlButton } from './types'
+import {
+  type NestedControlButton,
+  type ControlButton,
+  TextEditorFormattingOption,
+} from './types'
 import { FaIcon } from '@/components/fa-icon'
 
 export interface PluginToolbarTextControlsProps {
@@ -24,13 +28,16 @@ export function PluginToolbarTextControls({
   const [subMenu, setSubMenu] = useState<number>()
 
   const isMath = (control: ControlButton) =>
-    Object.hasOwn(control, 'name') && control.name === 'math'
+    Object.hasOwn(control, 'name') &&
+    control.name === TextEditorFormattingOption.math
 
   const isBlank = (control: ControlButton) =>
-    Object.hasOwn(control, 'name') && control.name === 'textBlank'
+    Object.hasOwn(control, 'name') &&
+    control.name === TextEditorFormattingOption.textBlank
 
   const mathActive = controls.find(isMath)?.isActive(editor)
-  const blankActive = controls.find(isBlank)?.isActive(editor)
+  const hasFillInTheBlanks = controls.find(isBlank)
+  const blankActive = hasFillInTheBlanks?.isActive(editor)
   const isSpecialMode = mathActive || blankActive
 
   if (typeof subMenu !== 'number') {
@@ -39,6 +46,14 @@ export function PluginToolbarTextControls({
         {controls.map((control, index) => {
           if (mathActive && !isMath(control)) return null
           if (blankActive && !isBlank(control)) return null
+          // To save space in the toolbar, we don't render the code editor
+          // within a fill-in-the-gap exercise
+          if (
+            hasFillInTheBlanks &&
+            control.name === TextEditorFormattingOption.code
+          ) {
+            return null
+          }
 
           const next = controls.at(index + 1)
           const showSeparator =

--- a/packages/editor/src/plugins/text/components/text-editor.tsx
+++ b/packages/editor/src/plugins/text/components/text-editor.tsx
@@ -54,7 +54,7 @@ export function TextEditor(props: TextEditorProps) {
       // Fast Refresh will rerun useMemo and create a new editor instance,
       // but <Slate /> is confused by it
       // Generate a unique key per editor instance and set it on the component
-      // to syncronize rerendering
+      // to synchronize rerendering
       editorKey: v4(),
     }
   }, [createTextEditor])


### PR DESCRIPTION
While working on the tests, I saw in the PR https://github.com/serlo/frontend/pull/3265 that the toolbar is overflowing with too many controls. 

![Screenshot from 2024-01-13 10-05-54](https://github.com/serlo/frontend/assets/28842311/83333c2d-7c89-4bd8-bd39-f227116bcfe6)


There are multiple ways we could fix it. Either disallow some of the other toolbar controls like I did in this PR by removing the code editor within fill-in-the-gap. Alternatives I could see to removing the code toggle are the two list buttons. 
![image](https://github.com/serlo/frontend/assets/28842311/a75c23ac-e01e-4935-8ff8-1a03dc4637ed)

If however, that is undesired and one should be able to create code blocks or lists within the fill-in-the-gaps, we could think of changing the title `Lückentext Aufgabe` to just `Lückentext` (10 chars) which also makes it work. However, with the internationalized English version, "Fill in the blanks" (18 chars) I haven't tried if it'd still overflow. 

@LarsTheGlidingSquirrel which text controls should be available? To me it'd make sense to only render those that are allowed within a fill-in-the-blanks exercise.