### PR TITLE
feat(editor): mvp for copy&pasting plugins

### DIFF
--- a/apps/web/src/components/user/profile-experimental.tsx
+++ b/apps/web/src/components/user/profile-experimental.tsx
@@ -11,6 +11,12 @@ export const features = {
     activeInDev: true,
     hideInProduction: true,
   },
+  editorPluginCopyTool: {
+    cookieName: 'useEditorPluginCopyTool',
+    isActive: false,
+    activeInDev: true,
+    hideInProduction: true,
+  },
   editorAnchorLinkCopyTool: {
     cookieName: 'useEditorAnchorLinkCopyTool',
     isActive: false,

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -836,6 +836,8 @@ export const loggedInData = {
           link: 'Link (%ctrlOrCmd% + K)',
           noElementPasteInLists:
             'Sorry, pasting elements inside of lists is not allowed.',
+          pastingPluginNotAllowedHere:
+            'Sorry, pasting this plugin here is not allowed.',
           linkOverlay: {
             placeholder: 'https://… or /1234',
             inputLabel: 'Paste or type a link',
@@ -1076,6 +1078,7 @@ export const loggedInData = {
         ready: 'Ready to save?',
         anchorLinkWarning:
           'This link will only work in the frontend and for content that has a somewhat new revision.',
+        pluginCopyInfo: 'You can now paste this plugin into text plugins',
       },
       taxonomy: {
         title: 'Title',

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1079,6 +1079,7 @@ export const loggedInData = {
         anchorLinkWarning:
           'This link will only work in the frontend and for content that has a somewhat new revision.',
         pluginCopyInfo: 'You can now paste this plugin into text plugins',
+        pluginCopyButtonLabel: 'Copy plugin to clipboard',
       },
       taxonomy: {
         title: 'Title',

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
@@ -38,7 +38,7 @@ export function PluginCopyTool({ pluginId }: PluginCopyToolProps) {
   return (
     <DropdownButton
       onClick={handleOnClick}
-      label="Copy plugin to clipboard"
+      label={editorStrings.edtrIo.pluginCopyButtonLabel}
       icon={faCopy}
       className="mt-2.5 border-t pt-2.5"
       dataQa="plugin-copy-tool-button"

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
@@ -2,7 +2,7 @@ import { selectStaticDocumentWithoutIds, store } from '@editor/store'
 import { faCopy } from '@fortawesome/free-solid-svg-icons'
 import { shouldUseFeature } from '@serlo/frontend/src/components/user/profile-experimental'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
-// import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
+import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { showToastNotice } from '@serlo/frontend/src/helper/show-toast-notice'
 import { useCallback } from 'react'
 
@@ -15,7 +15,7 @@ interface PluginCopyToolProps {
  * experimental plugin to copy plugin's editor state to the clipboard
  */
 export function PluginCopyTool({ pluginId }: PluginCopyToolProps) {
-  // const editorStrings = useEditorStrings()
+  const editorStrings = useEditorStrings()
   const { strings } = useInstanceData()
 
   const handleOnClick = useCallback(() => {
@@ -24,8 +24,12 @@ export function PluginCopyTool({ pluginId }: PluginCopyToolProps) {
 
     void navigator.clipboard.writeText(JSON.stringify(rowsDocument))
     showToastNotice(strings.share.copySuccess, 'success', 2000)
-    // TODO: add explanation
-  }, [pluginId, strings.share.copySuccess])
+    showToastNotice(
+      '👉 ' + editorStrings.edtrIo.pluginCopyInfo,
+      undefined,
+      4000
+    )
+  }, [pluginId, strings, editorStrings])
 
   if (!navigator.clipboard || !shouldUseFeature('editorPluginCopyTool')) {
     return null

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-copy-tool.tsx
@@ -1,0 +1,43 @@
+import { selectStaticDocumentWithoutIds, store } from '@editor/store'
+import { faCopy } from '@fortawesome/free-solid-svg-icons'
+import { shouldUseFeature } from '@serlo/frontend/src/components/user/profile-experimental'
+import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
+// import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
+import { showToastNotice } from '@serlo/frontend/src/helper/show-toast-notice'
+import { useCallback } from 'react'
+
+import { DropdownButton } from './dropdown-button'
+
+interface PluginCopyToolProps {
+  pluginId: string
+}
+/**
+ * experimental plugin to copy plugin's editor state to the clipboard
+ */
+export function PluginCopyTool({ pluginId }: PluginCopyToolProps) {
+  // const editorStrings = useEditorStrings()
+  const { strings } = useInstanceData()
+
+  const handleOnClick = useCallback(() => {
+    const document = selectStaticDocumentWithoutIds(store.getState(), pluginId)
+    const rowsDocument = { plugin: 'rows', state: [document] }
+
+    void navigator.clipboard.writeText(JSON.stringify(rowsDocument))
+    showToastNotice(strings.share.copySuccess, 'success', 2000)
+    // TODO: add explanation
+  }, [pluginId, strings.share.copySuccess])
+
+  if (!navigator.clipboard || !shouldUseFeature('editorPluginCopyTool')) {
+    return null
+  }
+
+  return (
+    <DropdownButton
+      onClick={handleOnClick}
+      label="Copy plugin to clipboard"
+      icon={faCopy}
+      className="mt-2.5 border-t pt-2.5"
+      dataQa="plugin-copy-tool-button"
+    />
+  )
+}

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -14,6 +14,7 @@ import { useCallback, useContext } from 'react'
 
 import { AnchorLinkCopyTool } from './anchor-link-copy-tool'
 import { DropdownButton } from './dropdown-button'
+import { PluginCopyTool } from './plugin-copy-tool'
 
 interface PluginDefaultToolsProps {
   pluginId: string
@@ -81,6 +82,9 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         label={pluginStrings.rows.remove}
         icon={faTrashAlt}
         dataQa="remove-plugin-button"
+      />
+      <PluginCopyTool
+        pluginId={pluginId}
       />
       {serloEntityId ? (
         <AnchorLinkCopyTool serloEntityId={serloEntityId} pluginId={pluginId} />

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -83,9 +83,7 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
         icon={faTrashAlt}
         dataQa="remove-plugin-button"
       />
-      <PluginCopyTool
-        pluginId={pluginId}
-      />
+      <PluginCopyTool pluginId={pluginId} />
       {serloEntityId ? (
         <AnchorLinkCopyTool serloEntityId={serloEntityId} pluginId={pluginId} />
       ) : null}

--- a/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -52,7 +52,11 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       }
 
       // pasting editor document string and insert as plugins
-      if (!media && text.startsWith('{"plugin":"rows"')) {
+      if (
+        shouldUseFeature('editorPluginCopyTool') &&
+        !media &&
+        text.startsWith('{"plugin":"rows"')
+      ) {
         const rowsDocument = JSON.parse(text) as EditorRowsDocument
         if (rowsDocument.state.length !== 1) return
         const pluginDocument = rowsDocument.state.at(0)

--- a/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -6,6 +6,7 @@ import {
   useAppDispatch,
   store,
 } from '@editor/store'
+import type { EditorRowsDocument } from '@editor/types/editor-plugins'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { showToastNotice } from '@serlo/frontend/src/helper/show-toast-notice'
 import { useCallback } from 'react'
@@ -44,6 +45,16 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
         if (state?.state) {
           media = { state: state.state as unknown, pluginType: type }
           break
+        }
+      }
+
+      // TODO: validate somehow?
+      if (!media && text.startsWith('{"plugin":"rows"')) {
+        const rowsDocument = JSON.parse(text) as EditorRowsDocument
+        if (rowsDocument.state.length !== 0) return
+        const pluginDocument = rowsDocument.state.at(0)
+        if (pluginDocument) {
+          media = { pluginType: rowsDocument.plugin, state: rowsDocument.state }
         }
       }
 

--- a/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-editable-paste-handler.tsx
@@ -51,7 +51,7 @@ export const useEditablePasteHandler = (args: UseEditablePasteHandlerArgs) => {
       // TODO: validate somehow?
       if (!media && text.startsWith('{"plugin":"rows"')) {
         const rowsDocument = JSON.parse(text) as EditorRowsDocument
-        if (rowsDocument.state.length !== 0) return
+        if (rowsDocument.state.length !== 1) return
         const pluginDocument = rowsDocument.state.at(0)
         if (pluginDocument) {
           media = { pluginType: rowsDocument.plugin, state: rowsDocument.state }


### PR DESCRIPTION
## [Demo](https://frontend-git-feat-editor-plugin-copy-tool-serlo.vercel.app/entity/repository/add-revision/277232)

- copy state to clipboard from any plugin toolbar
- paste state into any text plugin (if the copied plugin is valid there)