### PR TITLE
feat(blank): check drag and drop answers

### DIFF
--- a/packages/editor/src/core/components/dnd-wrapper.tsx
+++ b/packages/editor/src/core/components/dnd-wrapper.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+
+export const DndWrapper = ({ children }: { children: ReactNode }) => {
+  return (
+    <DndProvider
+      backend={HTML5Backend}
+      context={typeof window === 'undefined' ? undefined : window}
+    >
+      {children}
+    </DndProvider>
+  )
+}

--- a/packages/editor/src/core/editor.tsx
+++ b/packages/editor/src/core/editor.tsx
@@ -1,9 +1,8 @@
 import { useEffect, ReactNode, useRef, useState } from 'react'
-import { DndProvider } from 'react-dnd'
-import { HTML5Backend } from 'react-dnd-html5-backend'
 import { HotkeysProvider, useHotkeys } from 'react-hotkeys-hook'
 import { Provider } from 'react-redux'
 
+import { DndWrapper } from './components/dnd-wrapper'
 import { PreferenceContextProvider } from './contexts'
 import { useBlurOnOutsideClick } from './hooks/use-blur-on-outside-click'
 import { SubDocument } from './sub-document'
@@ -26,13 +25,13 @@ import { ROOT } from '../store/root/constants'
 export function Editor(props: EditorProps) {
   return (
     <Provider store={store}>
-      <DndProvider backend={HTML5Backend} context={window}>
+      <DndWrapper>
         <HotkeysProvider
           initiallyActiveScopes={['global', 'root-up-down-enter']}
         >
           <InnerDocument {...props} />
         </HotkeysProvider>
-      </DndProvider>
+      </DndWrapper>
     </Provider>
   )
 }

--- a/packages/editor/src/core/editor.tsx
+++ b/packages/editor/src/core/editor.tsx
@@ -26,7 +26,7 @@ import { ROOT } from '../store/root/constants'
 export function Editor(props: EditorProps) {
   return (
     <Provider store={store}>
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={HTML5Backend} context={window}>
         <HotkeysProvider
           initiallyActiveScopes={['global', 'root-up-down-enter']}
         >

--- a/packages/editor/src/editor-ui/exercises/exercise-feedback.tsx
+++ b/packages/editor/src/editor-ui/exercises/exercise-feedback.tsx
@@ -7,7 +7,7 @@ export interface SolutionFeedbackProps {
   missedSome?: boolean
 }
 
-export function SolutionFeedback(props: SolutionFeedbackProps) {
+export function ExerciseFeedback(props: SolutionFeedbackProps) {
   const { children, correct, missedSome } = props
 
   const exStrings = useInstanceData().strings.content.exercises

--- a/packages/editor/src/editor-ui/exercises/solution-feedback.tsx
+++ b/packages/editor/src/editor-ui/exercises/solution-feedback.tsx
@@ -1,13 +1,15 @@
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import type { ReactNode } from 'react'
 
-export interface FeedbackProps {
+export interface SolutionFeedbackProps {
   correct: boolean
   children?: ReactNode
   missedSome?: boolean
 }
 
-export function Feedback({ children, correct, missedSome }: FeedbackProps) {
+export function SolutionFeedback(props: SolutionFeedbackProps) {
+  const { children, correct, missedSome } = props
+
   const exStrings = useInstanceData().strings.content.exercises
   const fallbackString =
     exStrings[correct ? 'correct' : missedSome ? 'missedSome' : 'wrong']

--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -1,4 +1,4 @@
-import type { Blank } from '@editor/plugins/text'
+import { BlankInterface as Blank } from '@editor/plugins/fill-in-the-blanks-exercise/types'
 import {
   Editor as SlateEditor,
   Element,

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
@@ -27,12 +27,23 @@ export function BlankRendererStatic({ blankId }: BlankRendererStaticProps) {
   )
   const draggableText = draggable?.text ?? ''
 
+  const feedback = context.feedbackForBlanks
+  const isAnswerCorrect = feedback.get(blankId)?.isCorrect
+
   return context.mode === 'typing' ? (
-    <BlankRendererInput blankId={blankId} context={context} />
+    <BlankRendererInput
+      blankId={blankId}
+      context={context}
+      isAnswerCorrect={isAnswerCorrect}
+    />
   ) : (
     <DroppableBlank blankId={blankId} isDisabled={draggableId !== null}>
       {draggableId ? (
-        <DraggableSolution text={draggableText} draggableId={draggableId} />
+        <DraggableSolution
+          text={draggableText}
+          draggableId={draggableId}
+          isAnswerCorrect={isAnswerCorrect}
+        />
       ) : null}
     </DroppableBlank>
   )

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 
-import { BlankRendererInput } from './components/blank-renderer-input'
 import { BlankDraggableAnswer } from './components/blank-draggable-answer'
+import { BlankRendererInput } from './components/blank-renderer-input'
 import { DroppableBlank } from './components/droppable-blank'
 import { FillInTheBlanksContext } from './context/blank-context'
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 
 import { BlankRendererInput } from './components/blank-renderer-input'
-import { DraggableSolution } from './components/blank-solution'
+import { BlankDraggableAnswer } from './components/blank-draggable-answer'
 import { DroppableBlank } from './components/droppable-blank'
 import { FillInTheBlanksContext } from './context/blank-context'
 
@@ -39,7 +39,7 @@ export function BlankRendererStatic({ blankId }: BlankRendererStaticProps) {
   ) : (
     <DroppableBlank blankId={blankId} isDisabled={draggableId !== null}>
       {draggableId ? (
-        <DraggableSolution
+        <BlankDraggableAnswer
           text={draggableText}
           draggableId={draggableId}
           isAnswerCorrect={isAnswerCorrect}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer-static.tsx
@@ -27,7 +27,7 @@ export function BlankRendererStatic({ blankId }: BlankRendererStaticProps) {
   )
   const draggableText = draggable?.text ?? ''
 
-  const feedback = context.feedbackForBlanks
+  const feedback = context.feedbackForBlanks.value
   const isAnswerCorrect = feedback.get(blankId)?.isCorrect
 
   return context.mode === 'typing' ? (

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -11,10 +11,10 @@ import { ReactEditor, useSelected, useSlate, useFocused } from 'slate-react'
 
 import { BlankRendererInput } from './components/blank-renderer-input'
 import { FillInTheBlanksContext } from './context/blank-context'
-import type { Blank } from '../text'
+import type { BlankInterface } from './types'
 
 interface BlankRendererProps {
-  element: Blank
+  element: BlankInterface
 }
 
 export function BlankRenderer({ element }: BlankRendererProps) {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
@@ -1,0 +1,43 @@
+import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
+import { useState } from 'react'
+
+// TODO: Shouldn't import this from another plugin
+import { Feedback } from '../../sc-mc-exercise/renderer/feedback'
+import { cn } from '@/helper/cn'
+
+interface BlankCheckButtonProps {
+  isVisible: boolean
+  feedback: Map<string, { isCorrect?: boolean | undefined }>
+  onClick: () => void
+}
+
+export function BlankCheckButton(props: BlankCheckButtonProps) {
+  const { isVisible, feedback, onClick } = props
+
+  const exStrings = useInstanceData().strings.content.exercises
+
+  // Used to show feedback when user clicked "Stimmts?" button
+  const [showFeedback, setShowFeedback] = useState<boolean>(false)
+
+  return (
+    <div className="mt-2 flex">
+      <button
+        className={cn(
+          'serlo-button-blue mr-3 h-8',
+          isVisible ? '' : 'pointer-events-none opacity-0'
+        )}
+        onClick={() => {
+          onClick()
+          setShowFeedback(true)
+        }}
+      >
+        {exStrings.check}
+      </button>
+      {showFeedback && (
+        <Feedback
+          correct={[...feedback].every((entry) => entry[1].isCorrect)}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
@@ -1,8 +1,7 @@
+import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { useState } from 'react'
 
-// TODO: Shouldn't import this from another plugin
-import { Feedback } from '../../sc-mc-exercise/renderer/feedback'
 import { cn } from '@/helper/cn'
 
 interface BlankCheckButtonProps {
@@ -34,7 +33,7 @@ export function BlankCheckButton(props: BlankCheckButtonProps) {
         {exStrings.check}
       </button>
       {showFeedback && (
-        <Feedback
+        <SolutionFeedback
           correct={[...feedback].every((entry) => entry[1].isCorrect)}
         />
       )}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
@@ -1,42 +1,33 @@
 import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
-import { useState } from 'react'
 
 import { cn } from '@/helper/cn'
 
 interface BlankCheckButtonProps {
   isVisible: boolean
   feedback: Map<string, { isCorrect?: boolean | undefined }>
+  isFeedbackVisible: boolean
   onClick: () => void
 }
 
 export function BlankCheckButton(props: BlankCheckButtonProps) {
-  const { isVisible, feedback, onClick } = props
+  const { isVisible, feedback, isFeedbackVisible, onClick } = props
 
-  const exStrings = useInstanceData().strings.content.exercises
+  const exercisesStrings = useInstanceData().strings.content.exercises
 
-  // Used to show feedback when user clicked "Stimmts?" button
-  const [showFeedback, setShowFeedback] = useState<boolean>(false)
+  const className = cn(
+    'serlo-button-blue mr-3 h-8',
+    isVisible ? '' : 'pointer-events-none opacity-0'
+  )
+
+  const isCorrect = [...feedback].every((entry) => entry[1].isCorrect)
 
   return (
     <div className="mt-2 flex">
-      <button
-        className={cn(
-          'serlo-button-blue mr-3 h-8',
-          isVisible ? '' : 'pointer-events-none opacity-0'
-        )}
-        onClick={() => {
-          onClick()
-          setShowFeedback(true)
-        }}
-      >
-        {exStrings.check}
+      <button className={className} onClick={onClick}>
+        {exercisesStrings.check}
       </button>
-      {showFeedback && (
-        <SolutionFeedback
-          correct={[...feedback].every((entry) => entry[1].isCorrect)}
-        />
-      )}
+      {isFeedbackVisible ? <SolutionFeedback correct={isCorrect} /> : null}
     </div>
   )
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-check-button.tsx
@@ -1,4 +1,4 @@
-import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
+import { ExerciseFeedback } from '@editor/editor-ui/exercises/exercise-feedback'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 
 import { cn } from '@/helper/cn'
@@ -27,7 +27,7 @@ export function BlankCheckButton(props: BlankCheckButtonProps) {
       <button className={className} onClick={onClick}>
         {exercisesStrings.check}
       </button>
-      {isFeedbackVisible ? <SolutionFeedback correct={isCorrect} /> : null}
+      {isFeedbackVisible ? <ExerciseFeedback correct={isCorrect} /> : null}
     </div>
   )
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
@@ -3,19 +3,19 @@ import { useDrag } from 'react-dnd'
 import type { DraggableId } from '..'
 import { cn } from '@/helper/cn'
 
-export const blankSolutionDragType = 'blank-solution'
+export const blankDraggableAnswerDragType = 'blank-solution'
 
-interface DraggableSolutionProps {
+interface BlankDraggableAnswerProps {
   text: string
   draggableId: DraggableId
   isAnswerCorrect?: boolean
 }
 
-export function DraggableSolution(props: DraggableSolutionProps) {
+export function BlankDraggableAnswer(props: BlankDraggableAnswerProps) {
   const { draggableId, text, isAnswerCorrect } = props
 
   const [, dragRef] = useDrag({
-    type: blankSolutionDragType,
+    type: blankDraggableAnswerDragType,
     item: { draggableId },
   })
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-area.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-area.tsx
@@ -1,20 +1,20 @@
 import { ReactNode } from 'react'
 import { useDrop } from 'react-dnd'
 
-import { blankSolutionDragType } from './blank-solution'
+import { blankDraggableAnswerDragType } from './blank-draggable-answer'
 import type { DraggableId } from '..'
 import { cn } from '@/helper/cn'
 
-interface DraggableSolutionAreaProps {
+interface BlankDraggableAreaProps {
   children: ReactNode
   onDrop: (item: { draggableId: DraggableId }) => void
 }
 
-export function DraggableSolutionArea(props: DraggableSolutionAreaProps) {
+export function BlankDraggableArea(props: BlankDraggableAreaProps) {
   const { onDrop, children } = props
 
   const [{ isOver }, dropRef] = useDrop({
-    accept: blankSolutionDragType,
+    accept: blankDraggableAnswerDragType,
     drop: onDrop,
     collect: (monitor) => ({
       isOver: monitor.isOver(),

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-renderer-input.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-renderer-input.tsx
@@ -1,5 +1,6 @@
 import { ChangeEventHandler, KeyboardEventHandler, forwardRef } from 'react'
 
+import { BlankId } from '..'
 import { FillInTheBlanksContextType } from '../context/blank-context'
 import { cn } from '@/helper/cn'
 
@@ -56,5 +57,10 @@ export const BlankRendererInput = forwardRef<
 
     // Update state
     context.textUserTypedIntoBlanks.set(newTextUserTypedIntoBlankList)
+
+    // Reset feedback state
+    context.feedbackForBlanks.set(
+      new Map<BlankId, { isCorrect: boolean | undefined }>()
+    )
   }
 })

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-renderer-input.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-renderer-input.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/helper/cn'
 interface BlankRendererInputProps {
   blankId: string
   context: FillInTheBlanksContextType
+  isAnswerCorrect?: boolean
   onChange?: ChangeEventHandler<HTMLInputElement>
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>
 }
@@ -14,10 +15,8 @@ export const BlankRendererInput = forwardRef<
   HTMLInputElement,
   BlankRendererInputProps
 >(function BlankRendererInput(props, ref) {
-  const { blankId, context, onChange, onKeyDown } = props
+  const { blankId, context, isAnswerCorrect, onChange, onKeyDown } = props
 
-  const feedback = context.feedbackForBlanks
-  const isAnswerCorrect = feedback.get(blankId)?.isCorrect
   const text = context.textInBlanks.get(blankId)?.text ?? ''
 
   return (

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution-area.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution-area.tsx
@@ -2,38 +2,34 @@ import { ReactNode } from 'react'
 import { useDrop } from 'react-dnd'
 
 import { blankSolutionDragType } from './blank-solution'
-import type { BlankId, DraggableId } from '..'
+import type { DraggableId } from '..'
 import { cn } from '@/helper/cn'
 
-export function DraggableSolutionArea(props: {
+interface DraggableSolutionAreaProps {
   children: ReactNode
-  locationOfDraggables: {
-    value: Map<DraggableId, BlankId>
-    set: React.Dispatch<React.SetStateAction<Map<DraggableId, BlankId>>>
-  }
-}) {
+  onDrop: (item: { draggableId: DraggableId }) => void
+}
+
+export function DraggableSolutionArea(props: DraggableSolutionAreaProps) {
+  const { onDrop, children } = props
+
   const [{ isOver }, dropRef] = useDrop({
     accept: blankSolutionDragType,
-    drop: (item: { draggableId: DraggableId }) => {
-      const newMap = new Map<DraggableId, BlankId>(
-        props.locationOfDraggables.value
-      )
-      newMap.delete(item.draggableId)
-      props.locationOfDraggables.set(newMap)
-    },
+    drop: onDrop,
     collect: (monitor) => ({
       isOver: monitor.isOver(),
     }),
   })
+
   return (
     <div
       className={cn(
-        'mt-5 min-h-8 w-full rounded-full bg-slate-100',
+        'mt-5 flex min-h-8 w-full items-stretch rounded-full bg-slate-100',
         isOver ? 'bg-slate-200' : ''
       )}
       ref={dropRef}
     >
-      {props.children}
+      {children}
     </div>
   )
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution.tsx
@@ -1,16 +1,18 @@
 import { useDrag } from 'react-dnd'
 
 import type { DraggableId } from '..'
+import { cn } from '@/helper/cn'
 
 export const blankSolutionDragType = 'blank-solution'
 
 interface DraggableSolutionProps {
   text: string
   draggableId: DraggableId
+  isAnswerCorrect?: boolean
 }
 
 export function DraggableSolution(props: DraggableSolutionProps) {
-  const { draggableId, text } = props
+  const { draggableId, text, isAnswerCorrect } = props
 
   const [, dragRef] = useDrag({
     type: blankSolutionDragType,
@@ -19,7 +21,11 @@ export function DraggableSolution(props: DraggableSolutionProps) {
 
   return (
     <span
-      className="rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2"
+      className={cn(
+        'rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2',
+        isAnswerCorrect && 'border-green-500',
+        isAnswerCorrect === false && 'border-red-500'
+      )}
       ref={dragRef}
     >
       {text}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-solution.tsx
@@ -4,21 +4,25 @@ import type { DraggableId } from '..'
 
 export const blankSolutionDragType = 'blank-solution'
 
-export function DraggableSolution(props: {
+interface DraggableSolutionProps {
   text: string
   draggableId: DraggableId
-}) {
+}
+
+export function DraggableSolution(props: DraggableSolutionProps) {
+  const { draggableId, text } = props
+
   const [, dragRef] = useDrag({
     type: blankSolutionDragType,
-    item: { draggableId: props.draggableId },
+    item: { draggableId },
   })
 
   return (
-    <div
-      className="inline-block h-full rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2"
+    <span
+      className="rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2"
       ref={dragRef}
     >
-      {props.text}
-    </div>
+      {text}
+    </span>
   )
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/droppable-blank.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/droppable-blank.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useContext } from 'react'
 import { useDrop } from 'react-dnd'
 
-import { blankSolutionDragType } from './blank-solution'
+import { blankDraggableAnswerDragType } from './blank-draggable-answer'
 import type { BlankId, DraggableId } from '..'
 import { FillInTheBlanksContext } from '../context/blank-context'
 import { cn } from '@/helper/cn'
@@ -18,7 +18,7 @@ export function DroppableBlank(props: DroppableBlankProps) {
   const fillInTheBlanksContext = useContext(FillInTheBlanksContext)
 
   const [{ isOver }, dropRef] = useDrop({
-    accept: blankSolutionDragType,
+    accept: blankDraggableAnswerDragType,
     drop: ({ draggableId }: { draggableId: DraggableId }) => {
       if (!fillInTheBlanksContext) return
       const newMap = new Map<DraggableId, BlankId>(

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/context/blank-context.ts
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/context/blank-context.ts
@@ -4,7 +4,12 @@ import type { BlankId, DraggableId, FillInTheBlanksMode } from '..'
 
 export interface FillInTheBlanksContextType {
   mode: FillInTheBlanksMode
-  feedbackForBlanks: Map<BlankId, { isCorrect?: boolean }>
+  feedbackForBlanks: {
+    value: Map<BlankId, { isCorrect?: boolean }>
+    set: React.Dispatch<
+      React.SetStateAction<Map<BlankId, { isCorrect?: boolean }>>
+    >
+  }
   textInBlanks: Map<BlankId, { text: string }>
   textUserTypedIntoBlanks: {
     value: Map<BlankId, { text: string }>

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -4,8 +4,8 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 
 import type { BlankId, DraggableId, FillInTheBlanksMode } from '.'
 import { BlankCheckButton } from './components/blank-check-button'
-import { DraggableSolution } from './components/blank-solution'
-import { DraggableSolutionArea } from './components/blank-solution-area'
+import { BlankDraggableAnswer } from './components/blank-draggable-answer'
+import { BlankDraggableArea } from './components/blank-draggable-area'
 import { FillInTheBlanksContext } from './context/blank-context'
 import { Blank, type BlankType } from './types'
 
@@ -74,6 +74,9 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
       const newMap = new Map<DraggableId, BlankId>(locationOfDraggables)
       newMap.delete(item.draggableId)
       setLocationOfDraggables(newMap)
+      setFeedbackForBlanks(
+        new Map<BlankId, { isCorrect: boolean | undefined }>()
+      )
       setIsFeedbackVisible(false)
     },
     [locationOfDraggables]
@@ -117,13 +120,13 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
         </FillInTheBlanksContext.Provider>
 
         {mode === 'drag-and-drop' ? (
-          <DraggableSolutionArea onDrop={handleDraggableAreaDrop}>
+          <BlankDraggableArea onDrop={handleDraggableAreaDrop}>
             {draggables.map((draggable, index) =>
               locationOfDraggables.get(draggable.draggableId) ? null : (
-                <DraggableSolution key={index} {...draggable} />
+                <BlankDraggableAnswer key={index} {...draggable} />
               )
             )}
-          </DraggableSolutionArea>
+          </BlankDraggableArea>
         ) : null}
 
         {!isEditing ? (

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -57,11 +57,18 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   }, [blanks, textUserTypedIntoBlanks, initialTextInBlank])
 
   const draggables = useMemo(() => {
-    return blanks.map(({ blankId, correctAnswers }) => ({
+    const sorted = blanks.map(({ blankId, correctAnswers }) => ({
       draggableId: `solution-${blankId}`,
       text: correctAnswers[0].answer,
     }))
-  }, [blanks])
+    if (isEditing) return sorted
+
+    const shuffled = sorted
+      .map((value) => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value)
+    return shuffled
+  }, [blanks, isEditing])
 
   // Maps DraggableId to the BlankId where this draggable element is currently located
   const [locationOfDraggables, setLocationOfDraggables] = useState(

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -1,16 +1,14 @@
-// import { DndContext, UniqueIdentifier } from '@dnd-kit/core'
-import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import * as t from 'io-ts'
-import { type ReactNode, useMemo, useState } from 'react'
-// import { DndProvider } from 'react-dnd'
-// import { HTML5Backend } from 'react-dnd-html5-backend'
+import { type ReactNode, useMemo, useState, useCallback } from 'react'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 
 import type { BlankId, DraggableId, FillInTheBlanksMode } from '.'
+import { BlankCheckButton } from './components/blank-check-button'
 import { DraggableSolution } from './components/blank-solution'
 import { DraggableSolutionArea } from './components/blank-solution-area'
 import { FillInTheBlanksContext } from './context/blank-context'
-import { Feedback } from '../sc-mc-exercise/renderer/feedback'
-import { cn } from '@/helper/cn'
+import { Blank } from '../text'
 
 // TODO: Copy of type in /src/plugins/text/types/text-editor.ts
 const Answer = t.type({
@@ -34,17 +32,11 @@ interface FillInTheBlanksRendererProps {
   }
   mode: FillInTheBlanksMode
   initialTextInBlank: 'empty' | 'correct-answer'
-
   isEditing?: boolean
 }
 
 export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   const { text, textPluginState, mode, initialTextInBlank, isEditing } = props
-
-  const exStrings = useInstanceData().strings.content.exercises
-
-  // Used to show feedback when user clicked "Stimmts?" button
-  const [showFeedback, setShowFeedback] = useState<boolean>(false)
 
   // Maps blankId to the learner feedback after clicking "Stimmts?" button
   // isCorrect === undefined -> no feedback
@@ -89,136 +81,136 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
     new Map<DraggableId, BlankId>()
   )
 
-  const allBlanksHaveText = [...textInBlanks.values()].every(
-    ({ text }) => text.length > 0
+  const handleDraggableAreaDrop = useCallback(
+    (item: { draggableId: DraggableId }) => {
+      const newMap = new Map<DraggableId, BlankId>(locationOfDraggables)
+      newMap.delete(item.draggableId)
+      setLocationOfDraggables(newMap)
+    },
+    [locationOfDraggables]
   )
+
+  const shouldShowCheckButton = useMemo(() => {
+    if (blanks.length < 1) return false
+    if (mode === 'typing') {
+      return [...textInBlanks.values()].every(({ text }) => text.length > 0)
+    }
+    return draggables.length === locationOfDraggables.size
+  }, [
+    blanks.length,
+    draggables.length,
+    locationOfDraggables.size,
+    mode,
+    textInBlanks,
+  ])
 
   return (
     // Additional prop 'context={window}' prevents error with nested DndProvider components. See: https://github.com/react-dnd/react-dnd/issues/3257#issuecomment-1239254032
-    // <DndProvider backend={HTML5Backend} context={window}>
-    <div className="mx-side mb-block leading-[30px] [&>p]:leading-[30px]">
-      <FillInTheBlanksContext.Provider
-        value={{
-          mode: mode,
-          feedbackForBlanks: feedbackForBlanks,
-          textInBlanks: textInBlanks,
-          textUserTypedIntoBlanks: {
-            value: textUserTypedIntoBlanks,
-            set: setTextUserTypedIntoBlanks,
-          },
-          draggables: draggables,
-          locationOfDraggables: {
-            value: locationOfDraggables,
-            set: setLocationOfDraggables,
-          },
-        }}
-      >
-        {text}
-      </FillInTheBlanksContext.Provider>
-      {mode === 'drag-and-drop' ? (
-        <DraggableSolutionArea
-          locationOfDraggables={{
-            value: locationOfDraggables,
-            set: setLocationOfDraggables,
+    <DndProvider backend={HTML5Backend} context={window}>
+      <div className="mx-side mb-block leading-[30px] [&>p]:leading-[30px]">
+        <FillInTheBlanksContext.Provider
+          value={{
+            mode,
+            feedbackForBlanks,
+            textInBlanks,
+            textUserTypedIntoBlanks: {
+              value: textUserTypedIntoBlanks,
+              set: setTextUserTypedIntoBlanks,
+            },
+            draggables,
+            locationOfDraggables: {
+              value: locationOfDraggables,
+              set: setLocationOfDraggables,
+            },
           }}
         >
-          {draggables.map((draggable, index) => {
-            if (locationOfDraggables.get(draggable.draggableId)) return null
+          {text}
+        </FillInTheBlanksContext.Provider>
+
+        {mode === 'drag-and-drop' ? (
+          <DraggableSolutionArea onDrop={handleDraggableAreaDrop}>
+            {draggables.map((draggable, index) =>
+              locationOfDraggables.get(draggable.draggableId) ? null : (
+                <DraggableSolution key={index} {...draggable} />
+              )
+            )}
+          </DraggableSolutionArea>
+        ) : null}
+
+        {!isEditing ? (
+          <BlankCheckButton
+            isVisible={shouldShowCheckButton}
+            feedback={feedbackForBlanks}
+            onClick={checkAnswers}
+          />
+        ) : null}
+
+        {/* Only debug output from here on */}
+        <div className="hidden">
+          Blanks state:
+          {blanks.map((blank, index) => (
+            <div key={index}>{JSON.stringify(blank)}</div>
+          ))}
+        </div>
+        <div className="hidden">
+          <div>State textUserTypedIntoBlank:</div>
+          {[...textUserTypedIntoBlanks].map((entry, index) => {
+            const blankId = entry[0]
+            const text = entry[1].text
             return (
-              <DraggableSolution
+              <div
+                className="ml-5"
                 key={index}
-                text={draggable.text}
-                draggableId={draggable.draggableId}
-              />
+              >{`Text: ${text} | BlankId: ${blankId}`}</div>
             )
           })}
-        </DraggableSolutionArea>
-      ) : null}
-
-      {/* Only show "Stimmt's?" during render/preview*/}
-      {!isEditing && (
-        <div className="mt-2 flex">
-          <button
-            className={cn(
-              'serlo-button-blue mr-3 h-8',
-              allBlanksHaveText && blanks.length > 0
-                ? ''
-                : 'pointer-events-none opacity-0'
-            )}
-            onClick={() => {
-              checkAnswers()
-              setShowFeedback(true)
-            }}
-          >
-            {exStrings.check}
-          </button>
-          {showFeedback && (
-            <Feedback
-              correct={[...feedbackForBlanks].every(
-                (entry) => entry[1].isCorrect
-              )}
-            />
-          )}
         </div>
-      )}
-
-      {/* Only debug output from here on */}
-      <div className="hidden">
-        Blanks state:
-        {blanks.map((blank, index) => (
-          <div key={index}>{JSON.stringify(blank)}</div>
-        ))}
+        <div className="hidden">
+          {[...locationOfDraggables].map((entry, index) => (
+            <div key={index}>
+              {`DraggableId: ${entry[0]} in blankId: ${entry[1]}`}
+            </div>
+          ))}
+        </div>
+        <div className="hidden">
+          {draggables.map((draggable, index) => (
+            <div key={index}>
+              {`DraggableId: ${draggable.draggableId} with text: ${draggable.text}`}
+            </div>
+          ))}
+        </div>
       </div>
-      <div className="hidden">
-        <div>State textUserTypedIntoBlank:</div>
-        {[...textUserTypedIntoBlanks].map((entry, index) => {
-          const blankId = entry[0]
-          const text = entry[1].text
-          return (
-            <div
-              className="ml-5"
-              key={index}
-            >{`Text: ${text} | BlankId: ${blankId}`}</div>
-          )
-        })}
-      </div>
-      <div className="hidden">
-        {[...locationOfDraggables].map((entry, index) => (
-          <div key={index}>
-            {`DraggableId: ${entry[0]} in blankId: ${entry[1]}`}
-          </div>
-        ))}
-      </div>
-      <div className="hidden">
-        {draggables.map((draggable, index) => (
-          <div key={index}>
-            {`DraggableId: ${draggable.draggableId} with text: ${draggable.text}`}
-          </div>
-        ))}
-      </div>
-    </div>
-    // </DndProvider>
+    </DndProvider>
   )
 
   function checkAnswers() {
-    if (mode === 'typing') {
-      const newBlankAnswersCorrectList = new Map<
-        BlankId,
-        { isCorrect: boolean | undefined }
-      >()
-      blanks.forEach((blankState) => {
-        const trimmedBlankText =
-          textInBlanks.get(blankState.blankId)?.text.trim() ?? ''
-        const isCorrect = blankState.correctAnswers.some(
-          ({ answer }) => answer === trimmedBlankText
-        )
-        newBlankAnswersCorrectList.set(blankState.blankId, { isCorrect })
-      })
+    const newBlankAnswersCorrectList = new Map<
+      BlankId,
+      { isCorrect: boolean | undefined }
+    >()
 
-      setFeedbackForBlanks(newBlankAnswersCorrectList)
-    } else if (mode === 'drag-and-drop') {
-      // TODO: Check answers in drag-and-drop mode
-    }
+    blanks.forEach((blankState) => {
+      const trimmedBlankText = getTrimmedBlankText(blankState.blankId)
+      const isCorrect = blankState.correctAnswers.some(
+        ({ answer }) => answer === trimmedBlankText
+      )
+      newBlankAnswersCorrectList.set(blankState.blankId, { isCorrect })
+    })
+
+    setFeedbackForBlanks(newBlankAnswersCorrectList)
+  }
+
+  function getTrimmedBlankText(blankId: string) {
+    if (mode === 'typing') return textInBlanks.get(blankId)?.text.trim() ?? ''
+
+    const draggableLocationInThisBlank = [...locationOfDraggables].find(
+      ([, draggableBlankId]) => blankId === draggableBlankId
+    )
+    const draggableInThisBlank = draggables.find(
+      ({ draggableId }) => draggableId === draggableLocationInThisBlank?.[0]
+    )
+
+    return draggableInThisBlank?.text.trim() ?? ''
   }
 }
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -1,6 +1,5 @@
+import { DndWrapper } from '@editor/core/components/dnd-wrapper'
 import { type ReactNode, useMemo, useState, useCallback } from 'react'
-import { DndProvider } from 'react-dnd'
-import { HTML5Backend } from 'react-dnd-html5-backend'
 
 import type { BlankId, DraggableId, FillInTheBlanksMode } from '.'
 import { BlankCheckButton } from './components/blank-check-button'
@@ -97,8 +96,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   ])
 
   return (
-    // Additional prop 'context={window}' prevents error with nested DndProvider components. See: https://github.com/react-dnd/react-dnd/issues/3257#issuecomment-1239254032
-    <DndProvider backend={HTML5Backend} context={window}>
+    <DndWrapper>
       <div className="mx-side mb-block leading-[30px] [&>p]:leading-[30px]">
         <FillInTheBlanksContext.Provider
           value={{
@@ -173,7 +171,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
           ))}
         </div>
       </div>
-    </DndProvider>
+    </DndWrapper>
   )
 
   function checkAnswers() {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -1,4 +1,3 @@
-import * as t from 'io-ts'
 import { type ReactNode, useMemo, useState, useCallback } from 'react'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
@@ -8,20 +7,7 @@ import { BlankCheckButton } from './components/blank-check-button'
 import { DraggableSolution } from './components/blank-solution'
 import { DraggableSolutionArea } from './components/blank-solution-area'
 import { FillInTheBlanksContext } from './context/blank-context'
-import { Blank } from '../text'
-
-// TODO: Copy of type in /src/plugins/text/types/text-editor.ts
-const Answer = t.type({
-  answer: t.string,
-})
-const Blank = t.type({
-  type: t.literal('textBlank'),
-  children: t.unknown,
-  blankId: t.string,
-  correctAnswers: t.array(Answer),
-})
-
-type Blanks = t.TypeOf<typeof Blank>[]
+import { Blank, type BlankType } from './types'
 
 interface FillInTheBlanksRendererProps {
   text: ReactNode
@@ -38,14 +24,14 @@ interface FillInTheBlanksRendererProps {
 export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   const { text, textPluginState, mode, initialTextInBlank, isEditing } = props
 
-  // Maps blankId to the learner feedback after clicking "Stimmts?" button
+  // Maps blankId to the learner feedback after clicking solution check button
   // isCorrect === undefined -> no feedback
   const [feedbackForBlanks, setFeedbackForBlanks] = useState(
     new Map<BlankId, { isCorrect?: boolean }>()
   )
 
-  /** Array of blank elements extracted from text editor state */
-  const blanks: Blanks = useMemo(() => {
+  // Array of blank elements extracted from text editor state
+  const blanks: BlankType[] = useMemo(() => {
     return getBlanksWithinObject(textPluginState)
   }, [textPluginState])
 
@@ -215,11 +201,11 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
 }
 
 /** Searches for blank objects in text plugin state. They can be at varying depths. */
-function getBlanksWithinObject(obj: object): Blanks {
+function getBlanksWithinObject(obj: object): BlankType[] {
   if (Blank.is(obj)) return [obj]
 
   // Recursively search this object's values for blank objects
-  return Object.values(obj).reduce((blanks: Blanks, value: unknown) => {
+  return Object.values(obj).reduce((blanks: BlankType[], value: unknown) => {
     if (typeof value === 'object' && value !== null) {
       return [...blanks, ...getBlanksWithinObject(value)]
     }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -24,6 +24,8 @@ interface FillInTheBlanksRendererProps {
 export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   const { text, textPluginState, mode, initialTextInBlank, isEditing } = props
 
+  const [isFeedbackVisible, setIsFeedbackVisible] = useState<boolean>(false)
+
   // Maps blankId to the learner feedback after clicking solution check button
   // isCorrect === undefined -> no feedback
   const [feedbackForBlanks, setFeedbackForBlanks] = useState(
@@ -72,6 +74,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
       const newMap = new Map<DraggableId, BlankId>(locationOfDraggables)
       newMap.delete(item.draggableId)
       setLocationOfDraggables(newMap)
+      setIsFeedbackVisible(false)
     },
     [locationOfDraggables]
   )
@@ -127,6 +130,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
           <BlankCheckButton
             isVisible={shouldShowCheckButton}
             feedback={feedbackForBlanks}
+            isFeedbackVisible={isFeedbackVisible}
             onClick={checkAnswers}
           />
         ) : null}
@@ -184,6 +188,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
     })
 
     setFeedbackForBlanks(newBlankAnswersCorrectList)
+    setIsFeedbackVisible(true)
   }
 
   function getTrimmedBlankText(blankId: string) {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -108,7 +108,10 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
         <FillInTheBlanksContext.Provider
           value={{
             mode,
-            feedbackForBlanks,
+            feedbackForBlanks: {
+              value: feedbackForBlanks,
+              set: setFeedbackForBlanks,
+            },
             textInBlanks,
             textUserTypedIntoBlanks: {
               value: textUserTypedIntoBlanks,

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/toolbar.tsx
@@ -21,9 +21,6 @@ export const FillInTheBlanksToolbar = ({
 }) => {
   const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
 
-  // set to true only for testing while (drag & drop mode is not actually working atm.)
-  const allowModeSwitch = false
-
   return (
     <PluginToolbar
       pluginType={EditorPluginType.FillInTheBlanksExercise}
@@ -45,20 +42,18 @@ export const FillInTheBlanksToolbar = ({
             {blanksExerciseStrings.previewMode}{' '}
             <FaIcon icon={previewActive ? faCheckCircle : faCircle} />
           </button>
-          {allowModeSwitch ? (
-            <ToolbarSelect
-              tooltipText={blanksExerciseStrings.chooseType}
-              value={state.mode.value}
-              changeValue={(value) => state.mode.set(value)}
-              options={[
-                { value: 'typing', text: blanksExerciseStrings.modes.typing },
-                {
-                  value: 'drag-and-drop',
-                  text: blanksExerciseStrings.modes['drag-and-drop'],
-                },
-              ]}
-            />
-          ) : null}
+          <ToolbarSelect
+            tooltipText={blanksExerciseStrings.chooseType}
+            value={state.mode.value}
+            changeValue={(value) => state.mode.set(value)}
+            options={[
+              { value: 'typing', text: blanksExerciseStrings.modes.typing },
+              {
+                value: 'drag-and-drop',
+                text: blanksExerciseStrings.modes['drag-and-drop'],
+              },
+            ]}
+          />
         </>
       }
       pluginControls={<InteractiveToolbarTools id={id} />}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
@@ -1,0 +1,23 @@
+import * as t from 'io-ts'
+
+import type { CustomText } from '../text'
+
+export const Answer = t.type({ answer: t.string })
+
+export const Blank = t.type({
+  type: t.literal('textBlank'),
+  children: t.unknown,
+  blankId: t.string,
+  correctAnswers: t.array(Answer),
+  // Here we could specify incorrect answers for this blank with specific learner feedback
+  // incorrectAnswers?: Answer[]
+  // Here we could add a default feedback for the learner
+  // defaultIncorrectAnswerFeedback: string
+})
+// BlankType is used internally within the BlanksExercise, in order to satisfy io-ts.
+// BlankInterface is used within Slate, as io-ts can't convert CustomText interface.
+// A long term solution would be to switch Text plugin's types/interfaces to io-ts completely.
+export type BlankType = t.TypeOf<typeof Blank>
+export interface BlankInterface extends t.TypeOf<typeof Blank> {
+  children: CustomText[]
+}

--- a/packages/editor/src/plugins/input-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/input-exercise/renderer.tsx
@@ -1,4 +1,4 @@
-import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
+import { ExerciseFeedback } from '@editor/editor-ui/exercises/exercise-feedback'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
 import type A from 'algebra.js'
@@ -79,9 +79,9 @@ export function InputExerciseRenderer({
           </button>
         ) : null}
         {feedback && value ? (
-          <SolutionFeedback correct={feedback.correct}>
+          <ExerciseFeedback correct={feedback.correct}>
             {feedback.message}
-          </SolutionFeedback>
+          </ExerciseFeedback>
         ) : null}
       </div>
     </div>

--- a/packages/editor/src/plugins/input-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/input-exercise/renderer.tsx
@@ -1,10 +1,10 @@
+import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
 import type A from 'algebra.js'
 import { useState, useEffect } from 'react'
 
 import { InputExerciseType } from './input-exercise-type'
-import { Feedback } from '../sc-mc-exercise/renderer/feedback'
 
 interface InputExersiseRendererProps {
   type: string
@@ -79,7 +79,9 @@ export function InputExerciseRenderer({
           </button>
         ) : null}
         {feedback && value ? (
-          <Feedback correct={feedback.correct}>{feedback.message}</Feedback>
+          <SolutionFeedback correct={feedback.correct}>
+            {feedback.message}
+          </SolutionFeedback>
         ) : null}
       </div>
     </div>

--- a/packages/editor/src/plugins/sc-mc-exercise/renderer/feedback.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/renderer/feedback.tsx
@@ -1,0 +1,31 @@
+import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
+import type { ReactNode } from 'react'
+
+export interface FeedbackProps {
+  correct: boolean
+  children?: ReactNode
+  missedSome?: boolean
+}
+
+export function Feedback({ children, correct, missedSome }: FeedbackProps) {
+  const exStrings = useInstanceData().strings.content.exercises
+  const fallbackString =
+    exStrings[correct ? 'correct' : missedSome ? 'missedSome' : 'wrong']
+
+  return (
+    <div className="ml-3 mt-1 flex text-lg animate-in fade-in">
+      <span className="-mt-1 mr-0.5 text-2xl motion-safe:animate-in motion-safe:zoom-in">
+        {correct ? '🎉' : '✋'}
+      </span>{' '}
+      <div className="serlo-p mb-0 ml-1">
+        {children ? (
+          <>
+            {missedSome && exStrings.missedSome} {children}
+          </>
+        ) : (
+          fallbackString
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/editor/src/plugins/sc-mc-exercise/renderer/mc-renderer.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/renderer/mc-renderer.tsx
@@ -1,3 +1,4 @@
+import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
 import { faSquare } from '@fortawesome/free-regular-svg-icons'
 import { faCheckSquare } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
@@ -5,7 +6,6 @@ import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
 import { useState } from 'react'
 
-import { Feedback } from './feedback'
 import type { ScMcExerciseRendererProps } from './renderer'
 
 export function McRenderer({
@@ -88,7 +88,7 @@ export function McRenderer({
           {exStrings.check}
         </button>
         {showFeedback && (
-          <Feedback correct={allCorrect} missedSome={missedSome} />
+          <SolutionFeedback correct={allCorrect} missedSome={missedSome} />
         )}
       </div>
     </div>

--- a/packages/editor/src/plugins/sc-mc-exercise/renderer/mc-renderer.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/renderer/mc-renderer.tsx
@@ -1,4 +1,4 @@
-import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
+import { ExerciseFeedback } from '@editor/editor-ui/exercises/exercise-feedback'
 import { faSquare } from '@fortawesome/free-regular-svg-icons'
 import { faCheckSquare } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
@@ -88,7 +88,7 @@ export function McRenderer({
           {exStrings.check}
         </button>
         {showFeedback && (
-          <SolutionFeedback correct={allCorrect} missedSome={missedSome} />
+          <ExerciseFeedback correct={allCorrect} missedSome={missedSome} />
         )}
       </div>
     </div>

--- a/packages/editor/src/plugins/sc-mc-exercise/renderer/sc-renderer.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/renderer/sc-renderer.tsx
@@ -1,3 +1,4 @@
+import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
 import { faCircle } from '@fortawesome/free-regular-svg-icons'
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
@@ -5,7 +6,6 @@ import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
 import { useState } from 'react'
 
-import { Feedback } from './feedback'
 import type { ScMcExerciseRendererProps } from './renderer'
 
 export function ScRenderer({
@@ -81,9 +81,9 @@ export function ScRenderer({
               : exStrings.chooseOption}
         </button>
         {showFeedback && selected !== undefined && answers[selected] ? (
-          <Feedback correct={answers[selected].isCorrect}>
+          <SolutionFeedback correct={answers[selected].isCorrect}>
             {answers[selected].feedback}
-          </Feedback>
+          </SolutionFeedback>
         ) : null}
       </div>
     </div>

--- a/packages/editor/src/plugins/sc-mc-exercise/renderer/sc-renderer.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/renderer/sc-renderer.tsx
@@ -1,4 +1,4 @@
-import { SolutionFeedback } from '@editor/editor-ui/exercises/solution-feedback'
+import { ExerciseFeedback } from '@editor/editor-ui/exercises/exercise-feedback'
 import { faCircle } from '@fortawesome/free-regular-svg-icons'
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
@@ -81,9 +81,9 @@ export function ScRenderer({
               : exStrings.chooseOption}
         </button>
         {showFeedback && selected !== undefined && answers[selected] ? (
-          <SolutionFeedback correct={answers[selected].isCorrect}>
+          <ExerciseFeedback correct={answers[selected].isCorrect}>
             {answers[selected].feedback}
-          </SolutionFeedback>
+          </ExerciseFeedback>
         ) : null}
       </div>
     </div>

--- a/packages/editor/src/plugins/text/index.tsx
+++ b/packages/editor/src/plugins/text/index.tsx
@@ -13,7 +13,6 @@ import type {
   Heading,
   Link,
   MathElement,
-  Blank,
 } from './types/text-editor'
 import { emptyDocumentFactory } from './utils/document'
 import { isEmptyObject } from './utils/object'
@@ -79,7 +78,6 @@ export type {
   ListItemText,
   Heading,
   Link,
-  Blank,
   MathElement,
   CustomText,
   TextEditorConfig,

--- a/packages/editor/src/plugins/text/types/text-editor.ts
+++ b/packages/editor/src/plugins/text/types/text-editor.ts
@@ -1,3 +1,4 @@
+import type { BlankInterface as Blank } from '@editor/plugins/fill-in-the-blanks-exercise/types'
 import { ListsEditor } from '@prezly/slate-lists'
 import type { BaseEditor } from 'slate'
 import { ReactEditor } from 'slate-react'
@@ -11,23 +12,6 @@ export type CustomElement =
   | Link
   | MathElement
   | Blank
-
-export interface Answer {
-  answer: string
-  // Here we could store feedback for the learner that shows up when answers are checked
-  //learnerFeedback?: string
-}
-
-export interface Blank {
-  type: 'textBlank'
-  children: CustomText[]
-  blankId: string // Used to uniquely identify a blank
-  correctAnswers: Answer[]
-  // Here we could specify incorrect answers for this blank with specific learner feedback
-  // incorrectAnswers?: Answer[]
-  // Here we could add a default feedback for the learner
-  // defaultIncorrectAnswerFeedback: string
-}
 
 export interface Heading {
   type: 'h'


### PR DESCRIPTION
The list of commits shows what's done, but to expand on it:
- Uncommented drag-and-drop code
- Adjusted and completed drag-and-drop solution-checking code from [Lars' branch](https://github.com/serlo/frontend/tree/blanks-exercise-drag-and-drop)
- Fixed styling of drag-and-drop solution that has no text + some other minor styling adjustments
- Extracted `SolutionFeedback` from `ScMcExercise`, as it's not used just there
- Unified `BlanksExercise` types, as they were also defined in Text plugin
- Some renaming to match component names to their respective file names

Questions: 
- @LarsTheGlidingSquirrel @elbotho Any ideas on how to further split up the `FillInTheBlanksRenderer` component?