### PR TITLE
fix(blank): droppable blank styling improvements

### DIFF
--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
@@ -8,11 +8,12 @@ export const blankDraggableAnswerDragType = 'blank-solution'
 interface BlankDraggableAnswerProps {
   text: string
   draggableId: DraggableId
+  isPending?: boolean
   isAnswerCorrect?: boolean
 }
 
 export function BlankDraggableAnswer(props: BlankDraggableAnswerProps) {
-  const { draggableId, text, isAnswerCorrect } = props
+  const { draggableId, text, isPending, isAnswerCorrect } = props
 
   const [, dragRef] = useDrag({
     type: blankDraggableAnswerDragType,
@@ -22,9 +23,10 @@ export function BlankDraggableAnswer(props: BlankDraggableAnswerProps) {
   return (
     <span
       className={cn(
-        'rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2',
+        'cursor-grab rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2',
         isAnswerCorrect && 'border-green-500',
-        isAnswerCorrect === false && 'border-red-500'
+        isAnswerCorrect === false && 'border-red-500',
+        isPending && 'mr-1'
       )}
       ref={dragRef}
     >

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-draggable-answer.tsx
@@ -26,7 +26,7 @@ export function BlankDraggableAnswer(props: BlankDraggableAnswerProps) {
         'cursor-grab rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2',
         isAnswerCorrect && 'border-green-500',
         isAnswerCorrect === false && 'border-red-500',
-        isPending && 'mr-1'
+        isPending && 'mr-2'
       )}
       ref={dragRef}
     >

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/droppable-blank.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/droppable-blank.tsx
@@ -37,12 +37,12 @@ export function DroppableBlank(props: DroppableBlankProps) {
     <span
       className={cn(
         !children &&
-          'rounded-full border border-editor-primary-300 bg-editor-primary-100 px-2',
+          'rounded-full border border-editor-primary-300 bg-editor-primary-100 px-6 text-editor-primary-100',
         isOver && !isDisabled && 'bg-slate-400'
       )}
       ref={dropRef}
     >
-      {children}
+      {children || '_'}
     </span>
   )
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -131,7 +131,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
           <BlankDraggableArea onDrop={handleDraggableAreaDrop}>
             {draggables.map((draggable, index) =>
               locationOfDraggables.get(draggable.draggableId) ? null : (
-                <BlankDraggableAnswer key={index} {...draggable} />
+                <BlankDraggableAnswer key={index} isPending {...draggable} />
               )
             )}
           </BlankDraggableArea>


### PR DESCRIPTION
- Padding increased to increase the width and make it easier to drop draggable blanks into it
- Underline added to prevent the default [white space collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space). A side effect is that, when selecting text that contains blanks, and copying, the copied content will contain underlines. This might not even be a bad thing, in my opinion. But in any case, we can try to think of a better solution in the next iteration.
- Space between pending draggable answers
- Cursor "grab" for draggable answers