### PR TITLE
feat(blank): alternative answers

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -928,6 +928,9 @@ export const loggedInData = {
           dummyAnswers: 'Extra incorrect answers',
           addDummyAnswer: 'Add an incorrect answer',
           removeDummyAnswer: 'Remove extra answer',
+          addAlternativeAnswer: 'Add an alternative answer',
+          alternativeAnswers: 'Alternative answers',
+          acceptMathEquivalents: 'Accept all equivalent mathematical values',
         },
       },
       templatePlugins: {

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -929,6 +929,7 @@ export const loggedInData = {
           addDummyAnswer: 'Add an incorrect answer',
           removeDummyAnswer: 'Remove extra answer',
           addAlternativeAnswer: 'Add an alternative answer',
+          removeAlternativeAnswer: 'Remove alternative answer',
           alternativeAnswers: 'Alternative answers',
           acceptMathEquivalents: 'Accept all equivalent mathematical values',
         },

--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -12,8 +12,17 @@ import { v4 as uuid_v4 } from 'uuid'
 
 import { selectionHasElement, trimSelection } from './selection'
 
+function matchBlanks(node: Node) {
+  return Element.isElement(node) && node.type === 'textBlank'
+}
+
 export function isBlankActive(editor: SlateEditor) {
   return selectionHasElement((e) => e.type === 'textBlank', editor)
+}
+
+export function getBlankElement(editor: SlateEditor): Blank | undefined {
+  const [match] = Array.from(SlateEditor.nodes(editor, { match: matchBlanks }))
+  return match && (match[0] as Blank)
 }
 
 export function toggleBlank(editor: SlateEditor) {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -65,7 +65,7 @@ export function BlankRenderer({ element, focused }: BlankRendererProps) {
         onChange={handleChange}
         onKeyDown={handleMoveOut}
       />
-      {focused ? (
+      {focused && context.mode === 'typing' ? (
         <BlankControls
           blankId={element.blankId}
           correctAnswers={element.correctAnswers.map(({ answer }) => answer)}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -71,6 +71,7 @@ export function BlankRenderer({ element, focused }: BlankRendererProps) {
           correctAnswers={element.correctAnswers.map(({ answer }) => answer)}
           onAlternativeAnswerAdd={handleAlternativeAnswerAdd}
           onAlternativeAnswerChange={handleCorrectAnswerChange}
+          onAlternativeAnswerRemove={handleAlternativeAnswerRemove}
         />
       ) : null}
     </>
@@ -132,6 +133,14 @@ export function BlankRenderer({ element, focused }: BlankRendererProps) {
       // Rest is copied as is
       return { ...correctAnswer }
     })
+    Transforms.setNodes(editor, { correctAnswers }, { at })
+  }
+
+  function handleAlternativeAnswerRemove(targetIndex: number) {
+    const at = ReactEditor.findPath(editor, element)
+    const correctAnswers = element.correctAnswers.filter(
+      (_, i) => i !== targetIndex
+    )
     Transforms.setNodes(editor, { correctAnswers }, { at })
   }
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -16,12 +16,13 @@ import type { BlankInterface } from './types'
 
 interface BlankRendererProps {
   element: BlankInterface
+  focused: boolean
 }
 
-export function BlankRenderer({ element }: BlankRendererProps) {
+export function BlankRenderer({ element, focused }: BlankRendererProps) {
   const editor = useSlate()
   const selected = useSelected()
-  const focused = useFocused()
+  const slateFocused = useFocused()
 
   // Autofocus when adding and removing a blank
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -38,7 +39,7 @@ export function BlankRenderer({ element }: BlankRendererProps) {
       const shouldFocusInput =
         input &&
         document.activeElement !== input &&
-        focused &&
+        slateFocused &&
         selected &&
         editor.selection &&
         Range.isCollapsed(editor.selection)
@@ -50,7 +51,7 @@ export function BlankRenderer({ element }: BlankRendererProps) {
     document.addEventListener('keydown', handleDocumentKeydown)
 
     return () => document.removeEventListener('keydown', handleDocumentKeydown)
-  }, [editor, focused, inputRef, selected])
+  }, [editor, slateFocused, inputRef, selected])
 
   const context = useContext(FillInTheBlanksContext)
   if (context === null) return null
@@ -64,12 +65,14 @@ export function BlankRenderer({ element }: BlankRendererProps) {
         onChange={handleChange}
         onKeyDown={handleMoveOut}
       />
-      <BlankControls
-        isBlankFocused={document.activeElement === inputRef.current}
-        correctAnswers={element.correctAnswers.map(({ answer }) => answer)}
-        onAlternativeAnswerAdd={handleAlternativeAnswerAdd}
-        onAlternativeAnswerChange={handleCorrectAnswerChange}
-      />
+      {focused ? (
+        <BlankControls
+          blankId={element.blankId}
+          correctAnswers={element.correctAnswers.map(({ answer }) => answer)}
+          onAlternativeAnswerAdd={handleAlternativeAnswerAdd}
+          onAlternativeAnswerChange={handleCorrectAnswerChange}
+        />
+      ) : null}
     </>
   )
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -19,7 +19,10 @@ interface BlankRendererProps {
   focused: boolean
 }
 
-export function BlankRenderer({ element, focused }: BlankRendererProps) {
+export function BlankRenderer(props: BlankRendererProps) {
+  const { element, focused } = props
+  const { blankId, correctAnswers } = element
+
   const editor = useSlate()
   const selected = useSelected()
   const slateFocused = useFocused()
@@ -60,15 +63,15 @@ export function BlankRenderer({ element, focused }: BlankRendererProps) {
     <>
       <BlankRendererInput
         ref={inputRef}
-        blankId={element.blankId}
+        blankId={blankId}
         context={context}
         onChange={handleChange}
         onKeyDown={handleMoveOut}
       />
       {focused && context.mode === 'typing' ? (
         <BlankControls
-          blankId={element.blankId}
-          correctAnswers={element.correctAnswers.map(({ answer }) => answer)}
+          blankId={blankId}
+          correctAnswers={correctAnswers.map(({ answer }) => answer)}
           onAlternativeAnswerAdd={handleAlternativeAnswerAdd}
           onAlternativeAnswerChange={handleCorrectAnswerChange}
           onAlternativeAnswerRemove={handleAlternativeAnswerRemove}
@@ -120,27 +123,23 @@ export function BlankRenderer({ element, focused }: BlankRendererProps) {
   }
 
   function handleAlternativeAnswerAdd() {
-    const at = ReactEditor.findPath(editor, element)
-    const correctAnswers = [...element.correctAnswers, { answer: '' }]
-    Transforms.setNodes(editor, { correctAnswers }, { at })
+    setCorrectAnswers([...correctAnswers, { answer: '' }])
   }
 
   function handleCorrectAnswerChange(targetIndex: number, newValue: string) {
-    const at = ReactEditor.findPath(editor, element)
-    const correctAnswers = element.correctAnswers.map((correctAnswer, i) => {
-      // Changed element is set to new value
-      if (i === targetIndex) return { answer: newValue.trim() }
-      // Rest is copied as is
-      return { ...correctAnswer }
-    })
-    Transforms.setNodes(editor, { correctAnswers }, { at })
+    setCorrectAnswers(
+      correctAnswers.map(({ answer }, i) => ({
+        answer: i === targetIndex ? newValue.trim() : answer,
+      }))
+    )
   }
 
   function handleAlternativeAnswerRemove(targetIndex: number) {
+    setCorrectAnswers(correctAnswers.filter((_, i) => i !== targetIndex))
+  }
+
+  function setCorrectAnswers(correctAnswers: Array<{ answer: string }>) {
     const at = ReactEditor.findPath(editor, element)
-    const correctAnswers = element.correctAnswers.filter(
-      (_, i) => i !== targetIndex
-    )
     Transforms.setNodes(editor, { correctAnswers }, { at })
   }
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
@@ -1,6 +1,5 @@
 import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
 import { faCircleXmark } from '@fortawesome/free-regular-svg-icons'
-import { forwardRef } from 'react'
 
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
@@ -14,10 +13,7 @@ interface AlternativeAnswerProps {
   onRemove: (targetIndex: number) => void
 }
 
-export const AlternativeAnswer = forwardRef<
-  HTMLInputElement,
-  AlternativeAnswerProps
->(function AlternativeAnswer(props, ref) {
+export function AlternativeAnswer(props: AlternativeAnswerProps) {
   const { answer, index, onAdd, onChange, onRemove } = props
 
   const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
@@ -26,7 +22,6 @@ export const AlternativeAnswer = forwardRef<
     <div key={index} className="relative">
       <span className="serlo-autogrow-input" data-value={answer + '_ '}>
         <input
-          ref={ref}
           className="serlo-input-font-reset w-3/4 !min-w-[80px] rounded-full border border-brand bg-brand-50 focus:outline focus:outline-1"
           value={answer}
           size={4}
@@ -56,4 +51,4 @@ export const AlternativeAnswer = forwardRef<
       </button>
     </div>
   )
-})
+}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
@@ -1,0 +1,58 @@
+import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
+import { faCircleXmark } from '@fortawesome/free-regular-svg-icons'
+import { forwardRef } from 'react'
+
+import { FaIcon } from '@/components/fa-icon'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { cn } from '@/helper/cn'
+
+interface AlternativeAnswerProps {
+  answer: string
+  index: number
+  onAdd: () => void
+  onChange: (targetIndex: number, newValue: string) => void
+  onRemove: (targetIndex: number) => void
+}
+
+export const AlternativeAnswer = forwardRef<
+  HTMLInputElement,
+  AlternativeAnswerProps
+>(function AlternativeAnswer(props, ref) {
+  const { answer, index, onAdd, onChange, onRemove } = props
+
+  const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
+
+  return (
+    <div key={index} className="relative">
+      <span className="serlo-autogrow-input" data-value={answer + '_ '}>
+        <input
+          ref={ref}
+          className="serlo-input-font-reset w-3/4 !min-w-[80px] rounded-full border border-brand bg-brand-50 focus:outline focus:outline-1"
+          value={answer}
+          size={4}
+          onChange={(event) => {
+            onChange(index, event.target.value)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') onAdd()
+          }}
+        />
+      </span>
+      <button
+        className={cn(
+          `serlo-tooltip-trigger absolute right-1 top-1 h-6 w-6 rounded-full px-1 py-0.5 leading-none text-black
+          opacity-50 hover:bg-editor-primary-200 hover:opacity-100 focus:bg-editor-primary-200 focus:opacity-100`
+        )}
+        onClick={() => {
+          onRemove(index)
+        }}
+      >
+        <EditorTooltip
+          text={blanksExerciseStrings.removeAlternativeAnswer}
+          className="-top-10"
+        />
+        <FaIcon icon={faCircleXmark} className="text-sm" />
+      </button>
+    </div>
+  )
+})

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/alternative-answer.tsx
@@ -35,6 +35,7 @@ export const AlternativeAnswer = forwardRef<
           }}
           onKeyDown={(event) => {
             if (event.key === 'Enter') onAdd()
+            if (event.key === 'Backspace' && answer === '') onRemove(index)
           }}
         />
       </span>

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -1,0 +1,139 @@
+import {
+  getBlankElement,
+  isBlankActive,
+} from '@editor/editor-ui/plugin-toolbar/text-controls/utils/blank'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { useEffect, useRef, useState } from 'react'
+import { Range } from 'slate'
+import { ReactEditor, useSlate } from 'slate-react'
+
+import type { BlankInterface as Blank } from '../types'
+import { FaIcon } from '@/components/fa-icon'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+const wrapperWidth = 320
+
+interface BlankControlsProps {
+  isBlankFocused: boolean
+  correctAnswers: string[]
+  onAlternativeAnswerAdd: () => void
+  onAlternativeAnswerChange: (targetIndex: number, newValue: string) => void
+}
+
+export function BlankControls(props: BlankControlsProps) {
+  const {
+    isBlankFocused,
+    correctAnswers,
+    onAlternativeAnswerAdd,
+    onAlternativeAnswerChange,
+  } = props
+
+  const [element, setElement] = useState<Blank | null>(null)
+
+  const editor = useSlate()
+  const { selection } = editor
+
+  const wrapper = useRef<HTMLDivElement>(null)
+  const input = useRef<HTMLInputElement>(null)
+
+  const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
+
+  // Setting the element to serve as an anchor for overlay positioning
+  useEffect(() => {
+    if (!selection) return
+
+    const isCollapsed = selection && Range.isCollapsed(selection)
+
+    if (isCollapsed && isBlankActive(editor)) {
+      const blankElement = getBlankElement(editor) || null
+      setElement(blankElement)
+    } else {
+      setElement(null)
+    }
+  }, [selection, editor])
+
+  // Positioning of the overlay relative to the anchor
+  useEffect(() => {
+    if (!wrapper.current || !element) return
+
+    const anchorRect = ReactEditor.toDOMNode(
+      editor,
+      element
+    )?.getBoundingClientRect()
+
+    const parentRect = wrapper.current
+      .closest('.rows-editor-renderer-container')
+      ?.getBoundingClientRect()
+
+    const offsetRect = wrapper.current.offsetParent?.getBoundingClientRect()
+
+    if (!anchorRect || !parentRect || !offsetRect) return
+
+    const boundingLeft = anchorRect.left - 2 // wrapper starts at anchor's left
+
+    const boundingWrapperRight = boundingLeft + wrapperWidth
+    const overlap = boundingWrapperRight - parentRect.right
+    const fallbackBoundingLeft = boundingLeft - overlap // wrapper ends at editor's right
+
+    wrapper.current.style.left = `${
+      (overlap > 0 ? fallbackBoundingLeft : boundingLeft) - offsetRect.left - 5
+    }px`
+    wrapper.current.style.top = `${anchorRect.bottom + 6 - offsetRect.top}px`
+  }, [editor, element])
+
+  if (!isBlankFocused && document.activeElement !== input.current) return null
+
+  return (
+    <div ref={wrapper} className="absolute z-[95] whitespace-nowrap">
+      <div
+        className="w-[460px] rounded bg-white p-side text-start not-italic shadow-menu"
+        style={{ width: `${wrapperWidth}px` }}
+      >
+        {correctAnswers.length === 1 ? (
+          <button
+            onClick={onAlternativeAnswerAdd}
+            className="serlo-button-editor-secondary"
+          >
+            <FaIcon icon={faPlus} />{' '}
+            {blanksExerciseStrings.addAlternativeAnswer}
+          </button>
+        ) : null}
+        {correctAnswers.length > 1 ? (
+          <div>
+            <div>{blanksExerciseStrings.alternativeAnswers}</div>
+            {correctAnswers.map((answer, index) => {
+              if (index === 0) return null
+              return (
+                <span
+                  key={index}
+                  className="serlo-autogrow-input"
+                  data-value={answer + '_ '}
+                >
+                  <input
+                    ref={input}
+                    className="serlo-input-font-reset w-3/4 !min-w-[80px] rounded-full border border-brand bg-brand-50"
+                    value={answer}
+                    autoFocus
+                    size={4}
+                    onChange={(event) => {
+                      onAlternativeAnswerChange(index, event.target.value)
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') onAlternativeAnswerAdd()
+                    }}
+                  />
+                </span>
+              )
+            })}
+            <button
+              onClick={onAlternativeAnswerAdd}
+              className="serlo-button-editor-primary"
+            >
+              <FaIcon icon={faPlus} />
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Range } from 'slate'
 import { ReactEditor, useSlate } from 'slate-react'
 
+import { AlternativeAnswer } from './alternative-answer'
 import type { BlankInterface as Blank } from '../types'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
@@ -18,6 +19,7 @@ interface BlankControlsProps {
   correctAnswers: string[]
   onAlternativeAnswerAdd: () => void
   onAlternativeAnswerChange: (targetIndex: number, newValue: string) => void
+  onAlternativeAnswerRemove: (targetIndex: number) => void
 }
 
 export function BlankControls(props: BlankControlsProps) {
@@ -26,6 +28,7 @@ export function BlankControls(props: BlankControlsProps) {
     correctAnswers,
     onAlternativeAnswerAdd,
     onAlternativeAnswerChange,
+    onAlternativeAnswerRemove,
   } = props
   const [selectedElement, setSelectedElement] = useState<Blank | null>(null)
 
@@ -94,51 +97,45 @@ export function BlankControls(props: BlankControlsProps) {
         className="w-[460px] rounded bg-white p-side text-start not-italic shadow-menu"
         style={{ width: `${wrapperWidth}px` }}
       >
-        {correctAnswers.length === 1 ? (
+        {correctAnswers.length <= 1 ? (
           <button
             onClick={handleAddButtonClick}
-            className="serlo-button-editor-secondary"
+            className="serlo-button-editor-primary text-sm font-normal"
           >
-            <FaIcon icon={faPlus} />{' '}
+            <FaIcon className="mr-1" icon={faPlus} />
             {blanksExerciseStrings.addAlternativeAnswer}
           </button>
-        ) : null}
-        {correctAnswers.length > 1 ? (
+        ) : (
           <div>
-            <div>{blanksExerciseStrings.alternativeAnswers}</div>
-            {correctAnswers.map((answer, index) => {
-              const isAnswerFromBlankInput = index === 0
-              if (isAnswerFromBlankInput) return null
+            <div className="mb-4 text-sm font-bold">
+              {blanksExerciseStrings.alternativeAnswers}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {correctAnswers.map((answer, index) => {
+                const isAnswerFromBlankInput = index === 0
+                if (isAnswerFromBlankInput) return null
 
-              return (
-                <span
-                  key={index}
-                  className="serlo-autogrow-input"
-                  data-value={answer + '_ '}
-                >
-                  <input
+                return (
+                  <AlternativeAnswer
+                    key={index}
+                    answer={answer}
+                    index={index}
                     ref={input}
-                    className="serlo-input-font-reset w-3/4 !min-w-[80px] rounded-full border border-brand bg-brand-50"
-                    value={answer}
-                    size={4}
-                    onChange={(event) => {
-                      onAlternativeAnswerChange(index, event.target.value)
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') handleAddButtonClick()
-                    }}
+                    onAdd={handleAddButtonClick}
+                    onChange={onAlternativeAnswerChange}
+                    onRemove={onAlternativeAnswerRemove}
                   />
-                </span>
-              )
-            })}
-            <button
-              onClick={handleAddButtonClick}
-              className="serlo-button-editor-primary"
-            >
-              <FaIcon icon={faPlus} />
-            </button>
+                )
+              })}
+              <button
+                onClick={handleAddButtonClick}
+                className="serlo-button-editor-primary h-5 w-5 px-1 py-0 text-xs"
+              >
+                <FaIcon icon={faPlus} />
+              </button>
+            </div>
           </div>
-        ) : null}
+        )}
       </div>
     </div>
   )

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -81,7 +81,7 @@ export function BlankControls(props: BlankControlsProps) {
     wrapper.current.style.top = `${anchorRect.bottom + 6 - offsetRect.top}px`
   }, [editor, selectedElement])
 
-  function onAdd() {
+  function handleAddButtonClick() {
     onAlternativeAnswerAdd()
     setTimeout(() => input.current?.focus(), 10)
   }
@@ -95,7 +95,10 @@ export function BlankControls(props: BlankControlsProps) {
         style={{ width: `${wrapperWidth}px` }}
       >
         {correctAnswers.length === 1 ? (
-          <button onClick={onAdd} className="serlo-button-editor-secondary">
+          <button
+            onClick={handleAddButtonClick}
+            className="serlo-button-editor-secondary"
+          >
             <FaIcon icon={faPlus} />{' '}
             {blanksExerciseStrings.addAlternativeAnswer}
           </button>
@@ -104,7 +107,9 @@ export function BlankControls(props: BlankControlsProps) {
           <div>
             <div>{blanksExerciseStrings.alternativeAnswers}</div>
             {correctAnswers.map((answer, index) => {
-              if (index === 0) return null
+              const isAnswerFromBlankInput = index === 0
+              if (isAnswerFromBlankInput) return null
+
               return (
                 <span
                   key={index}
@@ -120,13 +125,16 @@ export function BlankControls(props: BlankControlsProps) {
                       onAlternativeAnswerChange(index, event.target.value)
                     }}
                     onKeyDown={(event) => {
-                      if (event.key === 'Enter') onAdd()
+                      if (event.key === 'Enter') handleAddButtonClick()
                     }}
                   />
                 </span>
               )
             })}
-            <button onClick={onAdd} className="serlo-button-editor-primary">
+            <button
+              onClick={handleAddButtonClick}
+              className="serlo-button-editor-primary"
+            >
               <FaIcon icon={faPlus} />
             </button>
           </div>

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Range } from 'slate'
 import { ReactEditor, useSlate } from 'slate-react'
 
-import type { BlankInterface } from '../types'
+import type { BlankInterface as Blank } from '../types'
 import { FaIcon } from '@/components/fa-icon'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 
@@ -27,9 +27,7 @@ export function BlankControls(props: BlankControlsProps) {
     onAlternativeAnswerAdd,
     onAlternativeAnswerChange,
   } = props
-  const [selectedElement, setSelectedElement] = useState<BlankInterface | null>(
-    null
-  )
+  const [selectedElement, setSelectedElement] = useState<Blank | null>(null)
 
   const editor = useSlate()
   const { selection } = editor
@@ -38,13 +36,6 @@ export function BlankControls(props: BlankControlsProps) {
   const input = useRef<HTMLInputElement>(null)
 
   const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
-
-  // const isBlankFocused = document.activeElement === blankRef.current
-  // console.log(document.activeElement)
-
-  // console.log({ selection })
-  // const isCollapsed = selection && Range.isCollapsed(selection)
-  // console.log({ isCollapsed })
 
   // Setting the element to serve as an anchor for overlay positioning
   useEffect(() => {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -81,6 +81,11 @@ export function BlankControls(props: BlankControlsProps) {
     wrapper.current.style.top = `${anchorRect.bottom + 6 - offsetRect.top}px`
   }, [editor, selectedElement])
 
+  function onAdd() {
+    onAlternativeAnswerAdd()
+    setTimeout(() => input.current?.focus(), 10)
+  }
+
   if (!selectedElement) return null
 
   return (
@@ -90,10 +95,7 @@ export function BlankControls(props: BlankControlsProps) {
         style={{ width: `${wrapperWidth}px` }}
       >
         {correctAnswers.length === 1 ? (
-          <button
-            onClick={onAlternativeAnswerAdd}
-            className="serlo-button-editor-secondary"
-          >
+          <button onClick={onAdd} className="serlo-button-editor-secondary">
             <FaIcon icon={faPlus} />{' '}
             {blanksExerciseStrings.addAlternativeAnswer}
           </button>
@@ -118,16 +120,13 @@ export function BlankControls(props: BlankControlsProps) {
                       onAlternativeAnswerChange(index, event.target.value)
                     }}
                     onKeyDown={(event) => {
-                      if (event.key === 'Enter') onAlternativeAnswerAdd()
+                      if (event.key === 'Enter') onAdd()
                     }}
                   />
                 </span>
               )
             })}
-            <button
-              onClick={onAlternativeAnswerAdd}
-              className="serlo-button-editor-primary"
-            >
+            <button onClick={onAdd} className="serlo-button-editor-primary">
               <FaIcon icon={faPlus} />
             </button>
           </div>

--- a/packages/editor/src/plugins/text/hooks/use-slate-render-handlers.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-slate-render-handlers.tsx
@@ -84,7 +84,7 @@ export const useSlateRenderHandlers = ({
       if (element.type === 'textBlank') {
         return (
           <span {...attributes} contentEditable={false}>
-            <BlankRenderer element={element} />
+            <BlankRenderer element={element} focused={focused} />
             {/* Because blank is a void element we need to render children here even though it will always be an empty text element. Slate will complain if this is not included here */}
             {children}
           </span>


### PR DESCRIPTION
Done:
- Display a "blank controls" overlay when a blank is focused in "typing" mode
- Add an alternative answer input on button click and Enter key + focus it
- Update an alternative answer when typing in its input
- Remove an alternative answer on button click and Backspace when answer is empty + focus another answer

Potential follow-ups:
- Make the overlay a re-usable component (currently copy-pasted from Text plugin link)
- Make the input + remove button a re-usable component (currently almost identical for extra incorrect answer and alternative answer)
- Make the autogrow-input a re-usable component