### PR TITLE
feat(blank): accept math equivalents

### DIFF
--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -75,6 +75,7 @@ function addBlank(editor: SlateEditor) {
     type: 'textBlank',
     blankId: uuid_v4(),
     correctAnswers: [{ answer: SlateEditor.string(editor, selection).trim() }],
+    acceptMathEquivalents: false,
     children: [{ text: '' }],
   }
 

--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/utils/blank.ts
@@ -75,7 +75,7 @@ function addBlank(editor: SlateEditor) {
     type: 'textBlank',
     blankId: uuid_v4(),
     correctAnswers: [{ answer: SlateEditor.string(editor, selection).trim() }],
-    acceptMathEquivalents: false,
+    acceptMathEquivalents: true,
     children: [{ text: '' }],
   }
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -21,7 +21,7 @@ interface BlankRendererProps {
 
 export function BlankRenderer(props: BlankRendererProps) {
   const { element, focused } = props
-  const { blankId, correctAnswers } = element
+  const { blankId, correctAnswers, acceptMathEquivalents } = element
 
   const editor = useSlate()
   const selected = useSelected()
@@ -72,9 +72,11 @@ export function BlankRenderer(props: BlankRendererProps) {
         <BlankControls
           blankId={blankId}
           correctAnswers={correctAnswers.map(({ answer }) => answer)}
+          acceptMathEquivalents={acceptMathEquivalents}
           onAlternativeAnswerAdd={handleAlternativeAnswerAdd}
           onAlternativeAnswerChange={handleCorrectAnswerChange}
           onAlternativeAnswerRemove={handleAlternativeAnswerRemove}
+          onAcceptMathEquivalentsChange={handleAcceptMathEquivalentsChange}
         />
       ) : null}
     </>
@@ -141,5 +143,13 @@ export function BlankRenderer(props: BlankRendererProps) {
   function setCorrectAnswers(correctAnswers: Array<{ answer: string }>) {
     const at = ReactEditor.findPath(editor, element)
     Transforms.setNodes(editor, { correctAnswers }, { at })
+  }
+
+  function handleAcceptMathEquivalentsChange() {
+    Transforms.setNodes(
+      editor,
+      { acceptMathEquivalents: !acceptMathEquivalents },
+      { at: ReactEditor.findPath(editor, element) }
+    )
   }
 }

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -28,9 +28,9 @@ export function BlankRenderer(props: BlankRendererProps) {
   const selected = useSelected()
   const slateFocused = useFocused()
 
-  // The `acceptMathEquivalents` setting is on by default. However,
-  // some blanks in the DB are missing this property altogether, so
-  // we assume that `undefined` equalst to `true`.
+  // The `acceptMathEquivalents` setting is on by default.
+  // However, some blanks in the DB are missing this property altogether,
+  // so we set it to `true` if it is `undefined`.
   const acceptMathEquivalents = useMemo(() => {
     if (element.acceptMathEquivalents === undefined) return true
     return element.acceptMathEquivalents

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/blank-renderer.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useContext,
   useEffect,
+  useMemo,
 } from 'react'
 import { Range, Transforms } from 'slate'
 import { ReactEditor, useSelected, useSlate, useFocused } from 'slate-react'
@@ -21,11 +22,19 @@ interface BlankRendererProps {
 
 export function BlankRenderer(props: BlankRendererProps) {
   const { element, focused } = props
-  const { blankId, correctAnswers, acceptMathEquivalents } = element
+  const { blankId, correctAnswers } = element
 
   const editor = useSlate()
   const selected = useSelected()
   const slateFocused = useFocused()
+
+  // The `acceptMathEquivalents` setting is on by default. However,
+  // some blanks in the DB are missing this property altogether, so
+  // we assume that `undefined` equalst to `true`.
+  const acceptMathEquivalents = useMemo(() => {
+    if (element.acceptMathEquivalents === undefined) return true
+    return element.acceptMathEquivalents
+  }, [element.acceptMathEquivalents])
 
   // Autofocus when adding and removing a blank
   const inputRef = useRef<HTMLInputElement | null>(null)

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -2,8 +2,9 @@ import {
   getBlankElement,
   isBlankActive,
 } from '@editor/editor-ui/plugin-toolbar/text-controls/utils/blank'
-import { faPlus } from '@fortawesome/free-solid-svg-icons'
-import { useEffect, useRef, useState } from 'react'
+import { faSquare } from '@fortawesome/free-regular-svg-icons'
+import { faCheckSquare, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { Range } from 'slate'
 import { ReactEditor, useSlate } from 'slate-react'
 
@@ -17,18 +18,22 @@ const wrapperWidth = 320
 interface BlankControlsProps {
   blankId: string
   correctAnswers: string[]
+  acceptMathEquivalents?: boolean
   onAlternativeAnswerAdd: () => void
   onAlternativeAnswerChange: (targetIndex: number, newValue: string) => void
   onAlternativeAnswerRemove: (targetIndex: number) => void
+  onAcceptMathEquivalentsChange: () => void
 }
 
 export function BlankControls(props: BlankControlsProps) {
   const {
     blankId,
     correctAnswers,
+    acceptMathEquivalents,
     onAlternativeAnswerAdd,
     onAlternativeAnswerChange,
     onAlternativeAnswerRemove,
+    onAcceptMathEquivalentsChange,
   } = props
   const [selectedElement, setSelectedElement] = useState<Blank | null>(null)
 
@@ -87,6 +92,11 @@ export function BlankControls(props: BlankControlsProps) {
     }px`
   }, [editor, selectedElement])
 
+  const isBlankAnswerAlphabetical = useMemo(() => {
+    if (correctAnswers[0].length === 0) return true
+    return /^[a-zA-Z]+$/.test(correctAnswers[0])
+  }, [correctAnswers])
+
   function handleAlternativeAnswerAdd() {
     onAlternativeAnswerAdd()
     setTimeout(() => {
@@ -116,6 +126,27 @@ export function BlankControls(props: BlankControlsProps) {
         className="w-[460px] rounded bg-white p-side text-start not-italic shadow-menu"
         style={{ width: `${wrapperWidth}px` }}
       >
+        {isBlankAnswerAlphabetical ? null : (
+          <div className="mb-6 flex">
+            <input
+              className="w-0.25 opacity-0"
+              id={'acceptMathEquivalentCheckbox_' + blankId}
+              type="checkbox"
+              checked={acceptMathEquivalents || false}
+              onChange={onAcceptMathEquivalentsChange}
+            />
+            <label
+              className="text-wrap flex cursor-pointer items-center text-sm"
+              htmlFor={'acceptMathEquivalentCheckbox_' + blankId}
+            >
+              <FaIcon
+                icon={acceptMathEquivalents ? faCheckSquare : faSquare}
+                className="mr-1.5 text-xl text-editor-primary"
+              />
+              {blanksExerciseStrings.acceptMathEquivalents}
+            </label>
+          </div>
+        )}
         {correctAnswers.length <= 1 ? (
           <button
             onClick={handleAlternativeAnswerAdd}

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -127,25 +127,19 @@ export function BlankControls(props: BlankControlsProps) {
         style={{ width: `${wrapperWidth}px` }}
       >
         {isBlankAnswerAlphabetical ? null : (
-          <div className="mb-6 flex">
+          <label className="text-wrap mb-6 flex cursor-pointer items-center text-sm">
             <input
               className="w-0.25 opacity-0"
-              id={'acceptMathEquivalentCheckbox_' + blankId}
               type="checkbox"
               checked={acceptMathEquivalents || false}
               onChange={onAcceptMathEquivalentsChange}
             />
-            <label
-              className="text-wrap flex cursor-pointer items-center text-sm"
-              htmlFor={'acceptMathEquivalentCheckbox_' + blankId}
-            >
-              <FaIcon
-                icon={acceptMathEquivalents ? faCheckSquare : faSquare}
-                className="mr-1.5 text-xl text-editor-primary"
-              />
-              {blanksExerciseStrings.acceptMathEquivalents}
-            </label>
-          </div>
+            <FaIcon
+              icon={acceptMathEquivalents ? faCheckSquare : faSquare}
+              className="mr-1.5 text-xl text-editor-primary"
+            />
+            {blanksExerciseStrings.acceptMathEquivalents}
+          </label>
         )}
         {correctAnswers.length <= 1 ? (
           <button

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -226,6 +226,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
 
         // The submission is NOT identical to the solution, AND
         // `acceptMathEquivalents` is off, so the submission is incorrect.
+        // (if acceptMathEquivalents is `undefined` we default to `true`)
         if (blankState.acceptMathEquivalents === false) return false
 
         // The `acceptMathEquivalents` setting is on, so first normalize both

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -226,7 +226,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
 
         // The submission is NOT identical to the solution, AND
         // `acceptMathEquivalents` is off, so the submission is incorrect.
-        if (!blankState.acceptMathEquivalents) return false
+        if (blankState.acceptMathEquivalents === false) return false
 
         // The `acceptMathEquivalents` setting is on, so first normalize both
         // submission and solution. If either of them are invalid mathematical

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -65,7 +65,6 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   /** Maps blankId to the text that should be displayed in the blank.  */
   const textInBlanks = useMemo(() => {
     const newMap = new Map<BlankId, { text: string }>()
-    console.log(blanks)
     blanks.forEach((blankState) => {
       const firstCorrectAnswer = blankState.correctAnswers.at(0)?.answer ?? ''
       newMap.set(blankState.blankId, {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -65,6 +65,7 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
   /** Maps blankId to the text that should be displayed in the blank.  */
   const textInBlanks = useMemo(() => {
     const newMap = new Map<BlankId, { text: string }>()
+    console.log(blanks)
     blanks.forEach((blankState) => {
       const firstCorrectAnswer = blankState.correctAnswers.at(0)?.answer ?? ''
       newMap.set(blankState.blankId, {

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/renderer.tsx
@@ -205,9 +205,13 @@ export function FillInTheBlanksRenderer(props: FillInTheBlanksRendererProps) {
 
     blanks.forEach((blankState) => {
       const trimmedBlankText = getTrimmedBlankText(blankState.blankId)
-      const isCorrect = blankState.correctAnswers.some(
-        ({ answer }) => answer === trimmedBlankText
-      )
+      const isCorrect = blankState.correctAnswers.some(({ answer }) => {
+        if (!blankState.acceptMathEquivalents) {
+          return answer === trimmedBlankText
+        }
+
+        // TODO: Check for mathematical equivalents here
+      })
       newBlankAnswersCorrectList.set(blankState.blankId, { isCorrect })
     })
 

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
@@ -9,6 +9,7 @@ export const Blank = t.type({
   children: t.unknown,
   blankId: t.string,
   correctAnswers: t.array(Answer),
+  acceptMathEquivalents: t.boolean,
   // Here we could specify incorrect answers for this blank with specific learner feedback
   // incorrectAnswers?: Answer[]
   // Here we could add a default feedback for the learner

--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/types.ts
@@ -4,17 +4,24 @@ import type { CustomText } from '../text'
 
 export const Answer = t.type({ answer: t.string })
 
-export const Blank = t.type({
-  type: t.literal('textBlank'),
-  children: t.unknown,
-  blankId: t.string,
-  correctAnswers: t.array(Answer),
-  acceptMathEquivalents: t.boolean,
-  // Here we could specify incorrect answers for this blank with specific learner feedback
-  // incorrectAnswers?: Answer[]
-  // Here we could add a default feedback for the learner
-  // defaultIncorrectAnswerFeedback: string
-})
+export const Blank = t.intersection([
+  // These props have been present from the beginning, and are therefore required
+  t.type({
+    type: t.literal('textBlank'),
+    children: t.unknown,
+    blankId: t.string,
+    correctAnswers: t.array(Answer),
+  }),
+  // These props have been added later, and are therefore optional. They could be
+  // made required, if a DB migration was done to populate all Blanks with them.
+  t.partial({
+    acceptMathEquivalents: t.boolean,
+    // Here we could specify incorrect answers for this blank with specific learner feedback
+    // incorrectAnswers?: Answer[]
+    // Here we could add a default feedback for the learner
+    // defaultIncorrectAnswerFeedback: string
+  }),
+])
 // BlankType is used internally within the BlanksExercise, in order to satisfy io-ts.
 // BlankInterface is used within Slate, as io-ts can't convert CustomText interface.
 // A long term solution would be to switch Text plugin's types/interfaces to io-ts completely.


### PR DESCRIPTION
Done:
- A checkbox for choosing if a mathematical equivalent of an answer should be accepted
- Display the checkbox only if the answer has numbers or symbols
- Check for mathematical equivalents when checking for correct answers
- Accept mathematical equivalents option is on by default (if the property does not exist on the object from DB, it's assumed to be true)

Potential follow-ups:
- Extract math equivalent checking functions into a utility hook OR
- Extract all answer checking functions into a utility hook

# [DEMO](https://frontend-git-feat-blank-accept-math-equivalents-serlo.vercel.app/___editor_preview?state=%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"exercise"%2C"state"%3A%7B"content"%3A%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"e2c8eeaa-1e17-4cd3-9659-36921efc8e4c"%7D%5D%2C"id"%3A"c032b0bf-d6f6-4439-8c45-c17e330cc457"%7D%2C"interactive"%3A%7B"plugin"%3A"blanksExercise"%2C"state"%3A%7B"text"%3A%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A"accept+equivalents+for+these%3A+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"a9703fa8-9050-4059-a4b2-95a2e0b7f2ad"%2C"correctAnswers"%3A%5B%7B"answer"%3A"2"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+three+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"5af3fe73-ae53-4ad5-a5bd-80d53737c331"%2C"correctAnswers"%3A%5B%7B"answer"%3A"1%2F4"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+five+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"5f4a59ad-9383-45ef-aeed-efaca649d008"%2C"correctAnswers"%3A%5B%7B"answer"%3A"0.75"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+"%7D%5D%7D%2C%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A"but+don%27t+accept+them+for+these%3A++"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"69c2c386-32a7-4623-a80e-061406299ecf"%2C"correctAnswers"%3A%5B%7B"answer"%3A"2"%7D%5D%2C"acceptMathEquivalents"%3Afalse%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+three+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"1b42a6e0-0662-4b70-b0da-2975d0e05a35"%2C"correctAnswers"%3A%5B%7B"answer"%3A"1%2F4"%7D%5D%2C"acceptMathEquivalents"%3Afalse%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+five+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"090cf216-d225-4ba7-8668-362ea6037d4d"%2C"correctAnswers"%3A%5B%7B"answer"%3A"0.75"%7D%5D%2C"acceptMathEquivalents"%3Afalse%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+"%7D%5D%7D%2C%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A"some+edge+cases%3A+dollar+sign+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"c98266c2-2d13-4ac3-9a99-ebe07fa1c8e3"%2C"correctAnswers"%3A%5B%7B"answer"%3A"%24"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+dollar+sign+and+number+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"a9b83aff-5f53-41c0-9a5a-e98778c4be31"%2C"correctAnswers"%3A%5B%7B"answer"%3A"%243"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A"+curly+bracket+"%7D%2C%7B"type"%3A"textBlank"%2C"blankId"%3A"cd9a5861-83f5-4413-b723-b184c930883a"%2C"correctAnswers"%3A%5B%7B"answer"%3A"%7B"%7D%5D%2C"acceptMathEquivalents"%3Atrue%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%2C%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"79f3fc23-b750-4deb-964a-a1404f3978f0"%7D%2C"mode"%3A"typing"%7D%2C"id"%3A"b83045b8-39cd-4fbf-8653-1bf862e3feb9"%7D%7D%2C"id"%3A"d9b8d7d2-7902-4bab-9440-4091325d42a4"%7D%5D%7D)