### PR TITLE
fix(blank): prevent blank controls close on triple click

### DIFF
--- a/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
+++ b/packages/editor/src/plugins/fill-in-the-blanks-exercise/components/blank-controls.tsx
@@ -128,6 +128,11 @@ export function BlankControls(props: BlankControlsProps) {
       <div
         className="w-[460px] rounded bg-white p-side text-start not-italic shadow-menu"
         style={{ width: `${wrapperWidth}px` }}
+        onClick={(event) => {
+          if (event.detail === 3) {
+            event.stopPropagation()
+          }
+        }}
       >
         {isBlankAnswerAlphabetical ? null : (
           <label className="items-top mb-6 flex cursor-pointer text-sm">


### PR DESCRIPTION
Slate seems to have some specific handler that changes `editor.selection` on triple click. Here, we stop the click event being propagated to Slate, in case of triple clicks.