### PR TITLE
feat(packages/editor): Expose `SerloRenderer` for editor integrations

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/editor",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0-beta.7",
   "homepage": "https://de.serlo.org/editor",
   "bugs": {
     "url": "https://github.com/serlo/frontend/issues"

--- a/packages/editor/src/package/index.ts
+++ b/packages/editor/src/package/index.ts
@@ -1,4 +1,5 @@
 export { SerloEditor, type SerloEditorProps } from './editor'
+export { SerloRenderer, type SerloRendererProps } from './serlo-renderer'
 
 export { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 export { editorRenderers } from '@editor/plugin/helpers/editor-renderer'

--- a/packages/editor/src/package/serlo-renderer.tsx
+++ b/packages/editor/src/package/serlo-renderer.tsx
@@ -1,0 +1,29 @@
+import { StaticRenderer } from '@editor/static-renderer/static-renderer'
+import type { AnyEditorDocument } from '@editor/types/editor-plugins'
+
+import { InstanceDataProvider } from '@/contexts/instance-context'
+import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
+import type { InstanceData, LoggedInData } from '@/data-types'
+
+export interface SerloRendererProps {
+  instanceData: InstanceData
+  loggedInData: LoggedInData
+  documentState: AnyEditorDocument | AnyEditorDocument[]
+}
+
+export function SerloRenderer({
+  instanceData,
+  loggedInData,
+  documentState,
+  ...props
+}: SerloRendererProps) {
+  return (
+    <InstanceDataProvider value={instanceData}>
+      <LoggedInDataProvider value={loggedInData}>
+        <div className="serlo-editor-hacks">
+          <StaticRenderer document={documentState} {...props} />
+        </div>
+      </LoggedInDataProvider>
+    </InstanceDataProvider>
+  )
+}

--- a/packages/editor/src/package/serlo-renderer.tsx
+++ b/packages/editor/src/package/serlo-renderer.tsx
@@ -8,20 +8,19 @@ import type { InstanceData, LoggedInData } from '@/data-types'
 export interface SerloRendererProps {
   instanceData: InstanceData
   loggedInData: LoggedInData
-  documentState: AnyEditorDocument | AnyEditorDocument[]
+  document?: AnyEditorDocument | AnyEditorDocument[]
 }
 
 export function SerloRenderer({
   instanceData,
   loggedInData,
-  documentState,
   ...props
 }: SerloRendererProps) {
   return (
     <InstanceDataProvider value={instanceData}>
       <LoggedInDataProvider value={loggedInData}>
         <div className="serlo-editor-hacks">
-          <StaticRenderer document={documentState} {...props} />
+          <StaticRenderer {...props} />
         </div>
       </LoggedInDataProvider>
     </InstanceDataProvider>


### PR DESCRIPTION
Problem: In the RLP editor integration `instanceData` and `loggedInData` are not provided in static renderer view leading to an error. 

For the editor view the editor package exposes `SerloEditor` that internally provides these. 

Solution: Now, the editor package exposes `SerloRenderer` that pretty much does the exact same thing for the static renderer view.

For the future: Maybe change the editor API so that things like language can be configured. For now there is only German. 