### PR TITLE
fix(geogebra): Use `globalThis` and fix issue with having two geogebra with the same id

### DIFF
--- a/packages/editor/src/plugins/geogebra/editor.tsx
+++ b/packages/editor/src/plugins/geogebra/editor.tsx
@@ -30,7 +30,7 @@ export function GeogebraEditor(props: GeogebraProps) {
           embedUrl={url}
           className={!focused ? 'pointer-events-none' : ''}
         >
-          <GeogebraRenderer url={url} id={cleanId} />
+          <GeogebraRenderer url={url} geogebraId={cleanId} />
         </EmbedWrapper>
       ) : (
         <div

--- a/packages/editor/src/plugins/geogebra/static.tsx
+++ b/packages/editor/src/plugins/geogebra/static.tsx
@@ -3,5 +3,5 @@ import { EditorGeogebraDocument } from '@editor/types/editor-plugins'
 
 export function GeogebraStaticRenderer({ state: id }: EditorGeogebraDocument) {
   const { url, cleanId } = parseId(id)
-  return <GeogebraRenderer url={url} id={cleanId} />
+  return <GeogebraRenderer url={url} geogebraId={cleanId} />
 }


### PR DESCRIPTION
## A) Issue with `global`

Trying to access `global` in combination with using vite to build the editor package lead to error `global not defined` in the RLP integration. Vite apparently does not provide these like webpack does, see https://github.com/vitejs/vite/issues/2778#issuecomment-810086159

Using `globalThis` instead fixes the issue and should work in different environments. 
https://javascript.info/global-object
Browser Support for `globalThis`: https://caniuse.com/?search=globalThis

## B) A page with two geogebra plugins with the same id caused problems

Works now. Previously, this would create two html element with the same id `ggb-element-erru542i` and `applet.inject(...)` would inject only into the first. Now, they get a id with a uuid. 