### PR TITLE
fix(plugin-text): suggestions - fix timing of deleting previous block

### DIFF
--- a/e2e-tests/tests/423-text-plugin-list.ts
+++ b/e2e-tests/tests/423-text-plugin-list.ts
@@ -4,7 +4,7 @@ Feature('Serlo Editor - Text plugin - list')
 
 Before(popupWarningFix)
 
-Scenario('Unordered list shortcuts (indentation missing)', async ({ I }) => {
+Scenario('Unordered list shortcuts', ({ I }) => {
   I.amOnPage('/entity/create/Article/1377')
 
   I.say('Add a new text plugin and delete the backslash')
@@ -49,7 +49,7 @@ Scenario('Unordered list shortcuts (indentation missing)', async ({ I }) => {
   })
 })
 
-Scenario('Ordered list shortcuts', async ({ I }) => {
+Scenario('Ordered list shortcuts', ({ I }) => {
   I.amOnPage('/entity/create/Article/1377')
 
   I.say('Add a new text plugin and delete the backslash')
@@ -94,3 +94,56 @@ Scenario('Ordered list shortcuts', async ({ I }) => {
     css: '.serlo-editor-hacks div[data-slate-editor="true"] ol:not(.unstyled-list)',
   })
 })
+
+Scenario("Don't show suggestions when '/' is inside of a list", ({ I }) => {
+  I.amOnPage('/entity/create/Article/1377')
+
+  I.say('Add a new text plugin, check for suggestions, delete the backslash')
+  I.click('$add-new-plugin-row-button')
+  I.see('Schreibe Text und Matheformeln, und formatiere sie.')
+  I.pressKey('Backspace')
+
+  I.say(
+    'Create an unordered list, type in a backslash, check that suggestions are not showing'
+  )
+  I.type('- Some text')
+  I.see('Some text', 'ul')
+  I.pressKey('Enter')
+  I.type('/')
+  I.dontSee('Schreibe Text und Matheformeln, und formatiere sie.')
+})
+
+Scenario.only(
+  'Inserting a plugin right after a list using suggestions',
+  ({ I }) => {
+    I.amOnPage('/entity/create/Article/1377')
+
+    I.say('Add a new text plugin and delete the backslash')
+    I.click('$add-new-plugin-row-button')
+    I.pressKey('Backspace')
+
+    I.say('Create an unordered list and add multiple list items')
+    I.type('- Some text')
+    I.see('Some text', 'ul')
+    I.pressKey('Enter')
+    I.type('Some more text')
+    I.see('Some more text', 'ul')
+    I.pressKey('Enter')
+    I.type('Some more extra text')
+    I.see('Some more extra text', 'ul')
+
+    I.say('Exit the list using double Enter')
+    I.pressKey('Enter')
+    I.pressKey('Enter')
+
+    I.say('Add a Spoiler plugin using suggestions')
+    I.type('/Spo')
+    I.pressKey('Enter')
+    I.seeElement(locate('input').withAttr({ placeholder: 'Titel eingeben' }))
+
+    I.say('Check that the list still exists')
+    I.see('Some text', 'ul')
+    I.see('Some more text', 'ul')
+    I.see('Some more extra text', 'ul')
+  }
+)

--- a/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
@@ -165,9 +165,11 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
       return
     }
 
-    // split the text-plugin and insert selected new plugin
+    // Split the text-plugin and insert selected new plugin,
+    // then remove the leftover empty line.
     setTimeout(() => {
       insertPlugin({ pluginType, editor, id, dispatch })
+      editor.deleteBackward('block')
     })
   }
 

--- a/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
@@ -1,3 +1,4 @@
+import { isSelectionWithinList } from '@editor/editor-ui/plugin-toolbar/text-controls/utils/list'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 import { AllowedChildPlugins } from '@editor/plugins/rows'
 import { checkIsAllowedNesting } from '@editor/plugins/rows/utils/check-is-allowed-nesting'
@@ -75,7 +76,8 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
     !isInlineChildEditor &&
     focused &&
     text.startsWith('/') &&
-    filteredOptions.length > 0
+    filteredOptions.length > 0 &&
+    !isSelectionWithinList(editor)
 
   const { enableScope, disableScope } = useHotkeysContext()
 

--- a/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
@@ -165,8 +165,6 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
       return
     }
 
-    editor.deleteBackward('block')
-
     // split the text-plugin and insert selected new plugin
     setTimeout(() => {
       insertPlugin({ pluginType, editor, id, dispatch })


### PR DESCRIPTION
This fixes the [disappearing list bug](https://trello.com/c/3fQ4mANW/563-spoiler-after-bulletpoint-list), but the focus issue is way deeper and harder to solve ([this is the problematic line](https://github.com/serlo/frontend/blob/staging/packages/editor/src/core/sub-document/editor.tsx#L67)), so it's out of scope of this bug.

In addition, opening suggestions with "/" while in a list is disabled in this PR.

E2E tests for both cases added.