### PR TITLE
feat(editor): MVP for BlanksTable

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -682,6 +682,21 @@ export const loggedInData = {
           identifier: 'Identifier (e.g. "long-explanation")',
           anchorId: 'ID of the anchor',
         },
+        blanksTable: {
+          title: 'Blanks Table',
+          description: 'Create tables with blanks',
+          mode: 'Mode',
+          columnHeaders: 'Only column headers',
+          rowHeaders: 'Only row headers',
+          columnAndRowHeaders: 'Column and row headers',
+          row: 'row',
+          column: 'column',
+          addType: 'Add %type%',
+          addTypeBefore: 'Add %type% before',
+          deleteType: 'Delete %type%',
+          confirmDelete:
+            'Are you sure you want to delete this %type% and the content in it?',
+        },
         box: {
           title: 'Container',
           description:

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -14,6 +14,7 @@ import type { PluginsWithData } from '@editor/plugin/helpers/editor-plugins'
 import { anchorPlugin } from '@editor/plugins/anchor'
 import { articlePlugin } from '@editor/plugins/article'
 import { audioPlugin } from '@editor/plugins/audio'
+import { createBlanksTablePlugin } from '@editor/plugins/blanks-table'
 import { createBoxPlugin } from '@editor/plugins/box'
 import { equationsPlugin } from '@editor/plugins/equations'
 import { exercisePlugin } from '@editor/plugins/exercise'
@@ -95,6 +96,12 @@ export function createPlugins({
       plugin: createBoxPlugin({}),
       visibleInSuggestions: true,
       icon: <IconBox />,
+    },
+    {
+      type: EditorPluginType.BlanksTable,
+      plugin: createBlanksTablePlugin(),
+      visibleInSuggestions: true,
+      icon: <IconTable />,
     },
     {
       type: EditorPluginType.SerloTable,

--- a/apps/web/src/serlo-editor-integration/create-renderers.tsx
+++ b/apps/web/src/serlo-editor-integration/create-renderers.tsx
@@ -28,6 +28,7 @@ import type {
   EditorSpoilerDocument,
   EditorTemplateExerciseGroupDocument,
   EditorExerciseGroupDocument,
+  EditorBlanksTableDocument,
 } from '@editor/types/editor-plugins'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
 import dynamic from 'next/dynamic'
@@ -68,6 +69,11 @@ const FillInTheBlanksSerloStaticRenderer =
       '@/serlo-editor-integration/serlo-plugin-wrappers/fill-in-the-blanks-serlo-static-renderer'
     ).then((mod) => mod.FillInTheBlanksSerloStaticRenderer)
   )
+const BlanksTableSerloStaticRenderer = dynamic<EditorBlanksTableDocument>(() =>
+  import(
+    '@/serlo-editor-integration/serlo-plugin-wrappers/blanks-table-serlo-static-renderer'
+  ).then((mod) => mod.BlanksTableSerloStaticRenderer)
+)
 const InjectionStaticRenderer = dynamic<EditorInjectionDocument>(() =>
   import('@editor/plugins/injection/static').then(
     (mod) => mod.InjectionStaticRenderer
@@ -228,6 +234,10 @@ export function createRenderers(): InitRenderersArgs {
       {
         type: EditorPluginType.FillInTheBlanksExercise,
         renderer: FillInTheBlanksSerloStaticRenderer,
+      },
+      {
+        type: EditorPluginType.BlanksTable,
+        renderer: BlanksTableSerloStaticRenderer,
       },
       {
         type: EditorPluginType.Solution,

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-table-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-table-serlo-static-renderer.tsx
@@ -1,0 +1,31 @@
+import { BlanksTableStaticRenderer } from '@editor/plugins/blanks-table/static'
+import type { EditorBlanksTableDocument } from '@editor/types/editor-plugins'
+import { useRouter } from 'next/router'
+
+import { useAB } from '@/contexts/ab'
+import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { exerciseSubmission } from '@/helper/exercise-submission'
+
+export function BlanksTableSerloStaticRenderer(
+  props: EditorBlanksTableDocument
+) {
+  const { asPath } = useRouter()
+  const ab = useAB()
+  const entityId = useEntityId()
+  const revisionId = useRevisionId()
+
+  return <BlanksTableStaticRenderer {...props} onEvaluate={onEvaluate} />
+
+  function onEvaluate(correct: boolean) {
+    exerciseSubmission(
+      {
+        path: asPath,
+        entityId,
+        revisionId,
+        result: correct ? 'correct' : 'wrong',
+        type: 'blanks',
+      },
+      ab
+    )
+  }
+}

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -6,6 +6,7 @@ import IconMultimedia from '@editor/editor-ui/assets/plugin-icons/icon-multimedi
 import IconSpoiler from '@editor/editor-ui/assets/plugin-icons/icon-spoiler.svg'
 import IconTable from '@editor/editor-ui/assets/plugin-icons/icon-table.svg'
 import IconText from '@editor/editor-ui/assets/plugin-icons/icon-text.svg'
+import { createBlanksTablePlugin } from '@editor/plugins/blanks-table'
 import { createBoxPlugin } from '@editor/plugins/box'
 import { equationsPlugin } from '@editor/plugins/equations'
 import { exercisePlugin } from '@editor/plugins/exercise'
@@ -79,6 +80,12 @@ export function createBasicPlugins({
     {
       type: EditorPluginType.SerloTable,
       plugin: createSerloTablePlugin({ allowImageInTableCells }),
+      visibleInSuggestions: true,
+      icon: <IconTable />,
+    },
+    {
+      type: EditorPluginType.BlanksTable,
+      plugin: createBlanksTablePlugin(),
       visibleInSuggestions: true,
       icon: <IconTable />,
     },

--- a/packages/editor/src/editor-integration/create-renderers.tsx
+++ b/packages/editor/src/editor-integration/create-renderers.tsx
@@ -4,6 +4,7 @@ import {
 } from '@editor/plugin/helpers/editor-renderer'
 import { AnchorStaticRenderer } from '@editor/plugins/anchor/static'
 import { ArticleStaticRenderer } from '@editor/plugins/article/static'
+import { BlanksTableStaticRenderer } from '@editor/plugins/blanks-table/static'
 import { BoxStaticRenderer } from '@editor/plugins/box/static'
 import { EquationsStaticRenderer } from '@editor/plugins/equations/static'
 import { ExerciseStaticRenderer } from '@editor/plugins/exercise/static'
@@ -48,6 +49,10 @@ export function createRenderers(): InitRenderersArgs {
         renderer: SpoilerStaticRenderer,
       },
       { type: EditorPluginType.Box, renderer: BoxStaticRenderer },
+      {
+        type: EditorPluginType.BlanksTable,
+        renderer: BlanksTableStaticRenderer,
+      },
       { type: EditorPluginType.SerloTable, renderer: SerloTableStaticRenderer },
       { type: EditorPluginType.Equations, renderer: EquationsStaticRenderer },
       {

--- a/packages/editor/src/plugins/blanks-table/components/extra-incorrect-answers.tsx
+++ b/packages/editor/src/plugins/blanks-table/components/extra-incorrect-answers.tsx
@@ -1,0 +1,98 @@
+import { AutogrowInput } from '@editor/editor-ui/autogrow-input'
+import { RemovableInputWrapper } from '@editor/editor-ui/removable-input-wrapper'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
+import { useRef } from 'react'
+
+import type { BlanksTableProps } from '..'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+interface ExtraIncorrectAnswersProps {
+  extraDraggableAnswers: BlanksTableProps['state']['extraDraggableAnswers']
+}
+
+export function ExtraIncorrectAnswers(props: ExtraIncorrectAnswersProps) {
+  const { extraDraggableAnswers } = props
+
+  const areaWrapper = useRef<HTMLDivElement>(null)
+  // TODO: use blanksTable strings
+  const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
+
+  const incorrectAnswers = extraDraggableAnswers.defined
+    ? extraDraggableAnswers.map(({ answer }) => answer.value)
+    : []
+
+  function handleExtraIncorrectAnswerAdd() {
+    if (extraDraggableAnswers.defined) {
+      extraDraggableAnswers.insert()
+    } else {
+      extraDraggableAnswers.create([{ answer: '' }])
+    }
+    setTimeout(() => {
+      const inputs = areaWrapper.current?.querySelectorAll('input')
+      inputs?.[inputs.length - 1].focus()
+    }, 10)
+  }
+
+  function handleExtraIncorrectAnswerRemove(index: number) {
+    if (!extraDraggableAnswers.defined) return
+    // The editor overwrites the remove function of a `list` if
+    // it's inside a `optional`. This removes the value at the index
+    extraDraggableAnswers.set((currentList) =>
+      currentList.filter((_, itemIndex) => itemIndex !== index)
+    )
+    // Focus new last input to persist focus
+    const allInputs = areaWrapper.current?.querySelectorAll('input')
+    if (allInputs) {
+      void [...allInputs]?.at(-2)?.focus()
+    }
+  }
+
+  return (
+    <div className="mt-8 px-8" ref={areaWrapper}>
+      {incorrectAnswers.length > 0 && extraDraggableAnswers.defined ? (
+        <>
+          {blanksExerciseStrings.dummyAnswers}:
+          <div className="mb-4 mt-1 flex flex-wrap gap-2">
+            {incorrectAnswers.map((answer, index) => (
+              <RemovableInputWrapper
+                key={index}
+                tooltipText={blanksExerciseStrings.removeDummyAnswer}
+                onRemoveClick={() => {
+                  handleExtraIncorrectAnswerRemove(index)
+                }}
+              >
+                <AutogrowInput
+                  value={answer}
+                  className="serlo-input-font-reset focus:border-red-400 focus:outline-red-400"
+                  onChange={(event) => {
+                    extraDraggableAnswers[index].answer.set(event.target.value)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      extraDraggableAnswers.insert()
+                    }
+                  }}
+                  onBlur={() => {
+                    extraDraggableAnswers.forEach(({ answer }, index) => {
+                      const trimmedAnswer = answer.value.trim()
+                      if (!trimmedAnswer.length) {
+                        handleExtraIncorrectAnswerRemove(index)
+                      } else answer.set(trimmedAnswer)
+                    })
+                  }}
+                />
+              </RemovableInputWrapper>
+            ))}
+          </div>
+        </>
+      ) : null}
+      <button
+        onClick={handleExtraIncorrectAnswerAdd}
+        className="serlo-button-editor-secondary"
+      >
+        <FaIcon icon={faPlus} /> {blanksExerciseStrings.addDummyAnswer}
+      </button>
+    </div>
+  )
+}

--- a/packages/editor/src/plugins/blanks-table/editor.tsx
+++ b/packages/editor/src/plugins/blanks-table/editor.tsx
@@ -1,0 +1,390 @@
+import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
+import { TextEditorFormattingOption } from '@editor/editor-ui/plugin-toolbar/text-controls/types'
+import {
+  store,
+  selectFocused,
+  selectIsDocumentEmpty,
+  focus,
+  useAppSelector,
+  useAppDispatch,
+  selectStaticDocument,
+  selectDocument,
+} from '@editor/store'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+import type { EditorBlanksTableDocument } from '@editor/types/editor-plugins'
+import { faCirclePlus, faTrashCan } from '@fortawesome/free-solid-svg-icons'
+import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
+import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
+import { cn } from '@serlo/frontend/src/helper/cn'
+import { KeyboardEvent, useState } from 'react'
+
+import type { BlanksTableProps } from '.'
+import { ExtraIncorrectAnswers } from './components/extra-incorrect-answers'
+import { BlanksTableRenderer } from './renderer'
+import { BlanksTableToolbar } from './toolbar'
+import { BlanksMode, TableType } from './types'
+import { getTableType } from './utils/get-table-type'
+import { TextEditorConfig } from '../text'
+import { instanceStateStore } from '../text/utils/instance-state-store'
+
+const headerTextFormattingOptions = [
+  TextEditorFormattingOption.code,
+  TextEditorFormattingOption.links,
+  TextEditorFormattingOption.math,
+]
+const cellTextFormattingOptions = [
+  TextEditorFormattingOption.code,
+  TextEditorFormattingOption.colors,
+  TextEditorFormattingOption.links,
+  TextEditorFormattingOption.lists,
+  TextEditorFormattingOption.math,
+  TextEditorFormattingOption.richTextBold,
+  TextEditorFormattingOption.richTextItalic,
+  TextEditorFormattingOption.textBlank,
+]
+
+const newCell = {
+  content: { plugin: EditorPluginType.Text },
+}
+
+export function BlanksTableEditor(props: BlanksTableProps) {
+  const { id, state, focused } = props
+  const { rows, mode, extraDraggableAnswers } = state
+
+  const [, setUpdateHack] = useState(0)
+
+  const dispatch = useAppDispatch()
+  const focusedElement = useAppSelector(selectFocused)
+  const { focusedRowIndex, focusedColIndex, nestedFocus } = findFocus()
+
+  // Rerender if table state changes
+  const tableState = useAppSelector((state) => {
+    return selectDocument(state, id)
+  })
+
+  const staticDocument = useAppSelector(
+    (storeState) =>
+      selectStaticDocument(storeState, id) as EditorBlanksTableDocument
+  )
+
+  const tableStrings = useEditorStrings().plugins.blanksTable
+
+  const tableType = getTableType(state.tableType.value)
+  const showRowHeader =
+    tableType === TableType.OnlyRowHeader ||
+    tableType === TableType.ColumnAndRowHeader
+  const showColumnHeader =
+    tableType === TableType.OnlyColumnHeader ||
+    tableType === TableType.ColumnAndRowHeader
+
+  const rowsJSX = renderActiveCellsIntoObject()
+
+  if (!tableState || !staticDocument) return null
+
+  return (
+    <>
+      {focused || nestedFocus ? <BlanksTableToolbar {...props} /> : null}
+
+      <div className="relative pt-[19px]">
+        <div className="flex">
+          <div className="flex grow flex-col">
+            <BlanksTableRenderer
+              rows={rowsJSX}
+              tableType={tableType}
+              isEditing
+              tableState={staticDocument.state.rows}
+              extraDraggableAnswers={staticDocument.state.extraDraggableAnswers}
+              mode={mode.value as BlanksMode}
+              initialTextInBlank="correct-answer"
+            />
+            {nestedFocus ? renderAddRowButton() : null}
+          </div>
+
+          {nestedFocus ? renderAddColButton() : null}
+        </div>
+      </div>
+
+      {mode.value === 'drag-and-drop' ? (
+        <ExtraIncorrectAnswers extraDraggableAnswers={extraDraggableAnswers} />
+      ) : null}
+    </>
+  )
+
+  function renderActiveCellsIntoObject() {
+    return rows.map((row, rowIndex) => {
+      return {
+        cells: row.columns.map((cell, colIndex) => {
+          const isColHead = showColumnHeader && rowIndex === 0
+          const isRowHead = showRowHeader && colIndex === 0
+          const isHead = isRowHead || isColHead
+          const isLast =
+            rowIndex === rows.length - 1 &&
+            colIndex === rows[0].columns.length - 1
+          const isClear = selectIsDocumentEmpty(
+            store.getState(),
+            cell.content.id
+          )
+
+          const onKeyUpHandler = (e: KeyboardEvent<HTMLDivElement>) => {
+            // hack: redraw when isEmpty changes. (onKeyUp bc. keyDown is captured for some keys)
+            if (e.key === 'Delete' || e.key === 'Backspace') {
+              if (!isClear) setUpdateHack((count) => count + 1)
+            } else {
+              if (isClear) setUpdateHack((count) => count + 1)
+            }
+          }
+          const onKeyDownHandler = (e: KeyboardEvent<HTMLDivElement>) => {
+            if (
+              e.key === 'Tab' &&
+              (e.target as HTMLElement).tagName === 'BUTTON' &&
+              isLast
+            ) {
+              insertRow()
+            }
+          }
+
+          return (
+            <div
+              key={colIndex}
+              onKeyUp={onKeyUpHandler} // keyUp because some onKeyDown keys are not bubbling
+              onKeyDown={onKeyDownHandler}
+              className={cn(
+                '[&>div>[data-slate-editor]]:pr-2',
+                '[&>div>[data-slate-editor]]:pb-block'
+              )}
+            >
+              {renderInlineNav(rowIndex, colIndex)}
+              {cell.content.render({
+                config: {
+                  isInlineChildEditor: true,
+                  placeholder: '',
+                  formattingOptions: isHead
+                    ? headerTextFormattingOptions
+                    : cellTextFormattingOptions,
+                } as TextEditorConfig,
+              })}
+            </div>
+          )
+        }),
+      }
+    })
+  }
+
+  function renderInlineNav(rowIndex: number, colIndex: number) {
+    const showRowButtons =
+      colIndex === 0 &&
+      rowIndex === focusedRowIndex &&
+      !(showColumnHeader && focusedRowIndex === 0)
+
+    const showColButtons =
+      rowIndex === 0 &&
+      colIndex === focusedColIndex &&
+      !(showRowHeader && focusedColIndex === 0)
+
+    return (
+      <>
+        <nav className="absolute -ml-7 -mt-2 flex flex-col">
+          {showRowButtons ? (
+            <>
+              {renderInlineAddButton(true)}
+              {renderRemoveButton(true)}
+            </>
+          ) : null}
+        </nav>
+        <nav className="absolute -top-2 z-20">
+          {showColButtons ? (
+            <>
+              {renderInlineAddButton(false)}
+              {renderRemoveButton(false)}
+            </>
+          ) : null}
+        </nav>
+      </>
+    )
+
+    function renderInlineAddButton(isRow: boolean) {
+      const onInlineAdd = () => {
+        if (isRow) insertRow(rowIndex)
+        else insertCol(colIndex)
+      }
+
+      return (
+        <button
+          className={cn(
+            'serlo-tooltip-trigger text-gray-300 transition-colors hover:text-editor-primary focus:text-editor-primary',
+            isRow ? '' : 'mr-2'
+          )}
+          onMouseDown={(e) => e.stopPropagation()} // hack to stop edtr from stealing events
+          onClick={onInlineAdd}
+        >
+          <EditorTooltip
+            text={replaceWithType(tableStrings.addTypeBefore, isRow)}
+            className="top-6"
+          />
+          <FaIcon icon={faCirclePlus} />
+        </button>
+      )
+    }
+
+    function renderRemoveButton(isRow: boolean) {
+      if (isRow && rows.length === 2) return null
+      if (!isRow && rows[0].columns.length === 2) return null
+
+      if (isRow && showColumnHeader && focusedRowIndex === 0) return null
+      if (!isRow && showRowHeader && focusedColIndex === 0) return null
+
+      const confirmString = replaceWithType(tableStrings.confirmDelete, isRow)
+
+      const onRemove = () => {
+        const empty = isRow ? isEmptyRow(rowIndex) : isEmptyCol(colIndex)
+
+        if (!empty && !window.confirm(confirmString)) {
+          // Regain focus after canceling popup
+          // We need this (slight) hack because the editor is not tracking the focus if
+          // an alert happens, to the text-plugin will not refocus itself
+          // More a proof of concept that such a patch is possible, but not a good
+          // general solution ...
+          const cellPluginState =
+            instanceStateStore[
+              rows[focusedRowIndex ?? 0].columns[focusedColIndex ?? 0].content
+                .id
+            ]
+          if (cellPluginState) cellPluginState.needRefocus++
+          setUpdateHack((count) => count + 1)
+          return
+        }
+        if (isRow) removeRow(rowIndex)
+        else removeCol(colIndex)
+
+        // dispatch focus
+        const rowToFocusAfter = isRow
+          ? rowIndex + 1 < rows.length
+            ? rowIndex + 1
+            : rowIndex - 1
+          : focusedRowIndex ?? 0
+
+        const colToFocusAfter = isRow
+          ? focusedColIndex ?? 0
+          : colIndex + 1 < rows[0].columns.length
+            ? colIndex + 1
+            : colIndex - 1
+
+        dispatch(
+          focus(rows[rowToFocusAfter].columns[colToFocusAfter].content.id)
+        )
+      }
+
+      return (
+        <button
+          className="serlo-tooltip-trigger text-gray-300 transition-colors hover:text-editor-primary focus:text-editor-primary"
+          onMouseDown={(e) => e.stopPropagation()} // hack to stop edtr from stealing events
+          onClick={onRemove}
+        >
+          <EditorTooltip
+            text={replaceWithType(tableStrings.deleteType, isRow)}
+            className="top-6"
+          />
+          <FaIcon icon={faTrashCan} />
+        </button>
+      )
+    }
+  }
+
+  function insertRow(beforeIndex?: number) {
+    const pos = beforeIndex ?? rows.length
+    rows.insert(pos, {
+      columns: rows[0].columns.map(() => newCell),
+    })
+  }
+
+  function insertCol(beforeIndex?: number) {
+    for (const row of rows) {
+      const pos = beforeIndex ?? row.columns.length
+      row.columns.insert(pos, newCell)
+    }
+  }
+
+  function isEmptyRow(rowIndex: number) {
+    return rows[rowIndex].columns.every((cell) =>
+      selectIsDocumentEmpty(store.getState(), cell.content.id)
+    )
+  }
+
+  function isEmptyCol(colIndex: number) {
+    return rows.every((row) => {
+      const cell = row.columns[colIndex]
+      return selectIsDocumentEmpty(store.getState(), cell.content.id)
+    })
+  }
+
+  function removeCol(colIndex: number) {
+    for (const row of rows) {
+      row.columns.remove(colIndex)
+    }
+  }
+
+  function removeRow(rowIndex: number) {
+    rows.remove(rowIndex)
+  }
+
+  function renderAddRowButton() {
+    return (
+      <div className="relative">
+        <button
+          className={cn(
+            'serlo-button-editor-secondary serlo-tooltip-trigger',
+            'absolute -bottom-1.5 z-20 mx-side w-[calc(100%-1.9rem)]'
+          )}
+          onClick={() => insertRow()}
+        >
+          <EditorTooltip
+            text={replaceWithType(tableStrings.addType, true)}
+            className="-left-0.5 -top-9"
+          />
+          +
+        </button>
+      </div>
+    )
+  }
+
+  function renderAddColButton() {
+    return (
+      <button
+        className={cn(
+          'serlo-button-editor-secondary serlo-tooltip-trigger -ml-1 mb-8 px-2.5'
+        )}
+        onClick={() => insertCol()}
+      >
+        <EditorTooltip
+          text={replaceWithType(tableStrings.addType, false)}
+          className="left-8 top-0"
+        />
+        +
+      </button>
+    )
+  }
+
+  function findFocus() {
+    let focusedRowIndex: number | undefined = undefined
+    let focusedColIndex: number | undefined = undefined
+
+    rows.some((row, rowIndex) =>
+      row.columns.some((cell, colIndex) => {
+        if (cell.content.id === focusedElement) {
+          focusedRowIndex = rowIndex
+          focusedColIndex = colIndex
+          return true
+        }
+      })
+    )
+    const nestedFocus =
+      focused ||
+      (focusedRowIndex !== undefined && focusedColIndex !== undefined)
+
+    return { focusedRowIndex, focusedColIndex, nestedFocus }
+  }
+
+  function replaceWithType(input: string, isRow: boolean) {
+    return input.replace('%type%', tableStrings[isRow ? 'row' : 'column'])
+  }
+}

--- a/packages/editor/src/plugins/blanks-table/index.tsx
+++ b/packages/editor/src/plugins/blanks-table/index.tsx
@@ -1,0 +1,43 @@
+import {
+  type EditorPlugin,
+  type EditorPluginProps,
+  child,
+  list,
+  object,
+  string,
+  optional,
+} from '@editor/plugin'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+
+import { BlanksTableEditor } from './editor'
+import { BlanksMode, TableType } from './types'
+
+const defaultMode: BlanksMode = 'typing'
+
+const tableState = object({
+  rows: list(
+    object({
+      columns: list(
+        object({
+          content: child({ plugin: EditorPluginType.Text }),
+        }),
+        2
+      ),
+    }),
+    4
+  ),
+  tableType: string(TableType.OnlyColumnHeader),
+  mode: string(defaultMode),
+  extraDraggableAnswers: optional(list(object({ answer: string() }))),
+})
+
+export function createBlanksTablePlugin(): EditorPlugin<BlanksTablePluginState> {
+  return {
+    Component: BlanksTableEditor,
+    config: {},
+    state: tableState,
+  }
+}
+
+export type BlanksTablePluginState = typeof tableState
+export type BlanksTableProps = EditorPluginProps<BlanksTablePluginState>

--- a/packages/editor/src/plugins/blanks-table/renderer.tsx
+++ b/packages/editor/src/plugins/blanks-table/renderer.tsx
@@ -1,0 +1,302 @@
+import { cn } from '@serlo/frontend/src/helper/cn'
+import { Fragment, useEffect, useMemo, useState } from 'react'
+import { v4 as uuid_v4 } from 'uuid'
+
+import { type BlanksMode, TableType, Blank, type BlankType } from './types'
+import { BlankCheckButton } from '../fill-in-the-blanks-exercise/components/blank-check-button'
+import { FillInTheBlanksContext } from '../fill-in-the-blanks-exercise/context/blank-context'
+
+type MathjsImport = typeof import('mathjs')
+
+interface BlanksTableRow {
+  cells: JSX.Element[]
+}
+
+export interface BlanksTableRendererProps {
+  tableType: TableType
+  rows: BlanksTableRow[]
+  tableState: Array<object>
+  mode: BlanksMode
+  initialTextInBlank: 'empty' | 'correct-answer'
+  extraDraggableAnswers?: Array<{ answer: string }>
+  isEditing?: boolean
+  onEvaluate?: (correct: boolean) => void
+}
+
+export function BlanksTableRenderer(props: BlanksTableRendererProps) {
+  const {
+    tableType,
+    rows,
+    tableState,
+    mode,
+    initialTextInBlank,
+    extraDraggableAnswers,
+    isEditing,
+    onEvaluate,
+  } = props
+
+  const showRowHeader =
+    tableType === TableType.OnlyRowHeader ||
+    tableType === TableType.ColumnAndRowHeader
+  const showColumnHeader =
+    tableType === TableType.OnlyColumnHeader ||
+    tableType === TableType.ColumnAndRowHeader
+
+  const [isFeedbackVisible, setIsFeedbackVisible] = useState<boolean>(false)
+
+  // Maps blankId to the learner feedback after clicking solution check button
+  // isCorrect === undefined -> no feedback
+  const [feedbackForBlanks, setFeedbackForBlanks] = useState(
+    new Map<string, { isCorrect?: boolean }>()
+  )
+
+  // Array of blank elements extracted from text editor state
+  const blanks: BlankType[] = useMemo(() => {
+    return getBlanksWithinObject(tableState)
+  }, [tableState])
+
+  // Maps blankId to the text entered by the user. Modified when user types into a blank and causes rerender.
+  const [textUserTypedIntoBlanks, setTextUserTypedIntoBlanks] = useState(
+    new Map<string, { text: string }>()
+  )
+
+  const [mathjs, setMathjs] = useState<MathjsImport | null>(null)
+  useEffect(() => void import('mathjs').then((math) => setMathjs(math)), [])
+
+  /** Maps blankId to the text that should be displayed in the blank.  */
+  const textInBlanks = useMemo(() => {
+    const newMap = new Map<string, { text: string }>()
+    blanks.forEach((blankState) => {
+      const firstCorrectAnswer = blankState.correctAnswers.at(0)?.answer ?? ''
+      newMap.set(blankState.blankId, {
+        text: initialTextInBlank === 'correct-answer' ? firstCorrectAnswer : '',
+      })
+    })
+    textUserTypedIntoBlanks.forEach((textUserTypedIntoBlank, blankId) =>
+      newMap.set(blankId, { text: textUserTypedIntoBlank.text })
+    )
+    return newMap
+  }, [blanks, textUserTypedIntoBlanks, initialTextInBlank])
+
+  const draggables = useMemo(() => {
+    const sorted = blanks.map(({ blankId, correctAnswers }) => ({
+      draggableId: `solution-${blankId}`,
+      text: correctAnswers[0].answer,
+    }))
+    if (isEditing) return sorted
+
+    const extraIncorrectAnswers =
+      extraDraggableAnswers?.map(({ answer }) => ({
+        draggableId: uuid_v4(),
+        text: answer,
+      })) ?? []
+    const withExtraIncorrectAnswers = [...sorted, ...extraIncorrectAnswers]
+    const shuffled = withExtraIncorrectAnswers
+      .map((draggable) => ({ draggable, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ draggable }) => draggable)
+    return shuffled
+  }, [extraDraggableAnswers, blanks, isEditing])
+
+  // Maps DraggableId to the BlankId where this draggable element is currently located
+  const [locationOfDraggables, setLocationOfDraggables] = useState(
+    new Map<string, string>()
+  )
+
+  const shouldShowCheckButton = useMemo(() => {
+    if (blanks.length < 1) return false
+    if (mode === 'typing') {
+      return [...textInBlanks.values()].every(({ text }) => text.length > 0)
+    }
+    return blanks.length === locationOfDraggables.size
+  }, [blanks.length, locationOfDraggables.size, mode, textInBlanks])
+
+  return (
+    <FillInTheBlanksContext.Provider
+      value={{
+        mode,
+        feedbackForBlanks: {
+          value: feedbackForBlanks,
+          set: setFeedbackForBlanks,
+        },
+        textInBlanks,
+        textUserTypedIntoBlanks: {
+          value: textUserTypedIntoBlanks,
+          set: setTextUserTypedIntoBlanks,
+        },
+        draggables,
+        locationOfDraggables: {
+          value: locationOfDraggables,
+          set: setLocationOfDraggables,
+        },
+        isFeedbackVisible: {
+          value: isFeedbackVisible,
+          set: setIsFeedbackVisible,
+        },
+      }}
+    >
+      <table className="serlo-table mb-8">
+        {showColumnHeader ? (
+          <>
+            <thead>{renderRows([rows[0]])}</thead>
+            <tbody>{renderRows(rows.slice(1), 1)}</tbody>
+          </>
+        ) : (
+          <tbody>{renderRows(rows)}</tbody>
+        )}
+      </table>
+
+      {/* {mode === 'drag-and-drop' ? (
+        <BlankDraggableArea onDrop={handleDraggableAreaDrop}>
+          {draggables.map((draggable, index) =>
+            locationOfDraggables.get(draggable.draggableId) ? null : (
+              <BlankDraggableAnswer key={index} {...draggable} />
+            )
+          )}
+        </BlankDraggableArea>
+      ) : null} */}
+
+      {!isEditing ? (
+        <BlankCheckButton
+          isVisible={shouldShowCheckButton}
+          feedback={feedbackForBlanks}
+          isFeedbackVisible={isFeedbackVisible}
+          onClick={checkAnswers}
+        />
+      ) : null}
+    </FillInTheBlanksContext.Provider>
+  )
+
+  function renderRows(rows: BlanksTableRow[], startIndex = 0) {
+    return rows.map((row, rowIndex) => {
+      return (
+        <tr key={startIndex + rowIndex}>
+          {row.cells.map((cell, colIndex) =>
+            renderCell(cell, startIndex + rowIndex, colIndex)
+          )}
+        </tr>
+      )
+    })
+  }
+
+  function renderCell(cell: JSX.Element, rowIndex: number, colIndex: number) {
+    const firstRow = rowIndex === 0
+    const lastRow = rowIndex === rows.length - 1
+    const isColHead = showColumnHeader && firstRow
+    const isRowHead = showRowHeader && colIndex === 0
+    const isHead = isRowHead || isColHead
+    const scope = isColHead ? 'col' : 'row'
+
+    const borderClass = cn(
+      'first:border-l-3',
+      firstRow && 'border-t-3 first:rounded-tl-xl last:rounded-tr-xl',
+      lastRow && 'first:rounded-bl-xl last:rounded-br-xl'
+    )
+
+    return (
+      <Fragment key={colIndex}>
+        {isHead ? (
+          <th
+            scope={scope}
+            className={cn('serlo-th px-0 align-top', borderClass)}
+          >
+            {cell}
+          </th>
+        ) : (
+          <td className={cn('serlo-td px-0', borderClass)}>{cell}</td>
+        )}
+      </Fragment>
+    )
+  }
+
+  function checkAnswers() {
+    const newBlankAnswersCorrectList = new Map<
+      string,
+      { isCorrect: boolean | undefined }
+    >()
+
+    blanks.forEach((blankState) => {
+      const trimmedBlankText = getTrimmedBlankText(blankState.blankId)
+
+      // Go through all solutions and evaluate the submission against them
+      const isCorrect = blankState.correctAnswers.some(({ answer }) => {
+        // The submission is identical to the solution, so it's correct
+        // regardless of the `acceptMathEquivalents` setting.
+        if (answer === trimmedBlankText) return true
+
+        // The submission is NOT identical to the solution, AND
+        // `acceptMathEquivalents` is off, so the submission is incorrect.
+        // (if acceptMathEquivalents is `undefined` we default to `true`)
+        if (blankState.acceptMathEquivalents === false) return false
+
+        // The `acceptMathEquivalents` setting is on, so first normalize both
+        // submission and solution. If either of them are invalid mathematical
+        // expressions, the submission is incorrect.
+        const solution = normalize(answer)
+        const submission = normalize(trimmedBlankText)
+        if (!solution || !submission) return false
+
+        // Both submission and solution are valid mathematical expressions.
+        // Subtract the submission from the solution. If the result is 0,
+        // submission and solution are mathematical equivalents.
+        return solution - submission === 0
+      })
+
+      newBlankAnswersCorrectList.set(blankState.blankId, { isCorrect })
+    })
+
+    if (onEvaluate) {
+      onEvaluate(
+        [...newBlankAnswersCorrectList].every((entry) => entry[1].isCorrect)
+      )
+    }
+
+    setFeedbackForBlanks(newBlankAnswersCorrectList)
+    setIsFeedbackVisible(true)
+  }
+
+  function getTrimmedBlankText(blankId: string) {
+    if (mode === 'typing') return textInBlanks.get(blankId)?.text.trim() ?? ''
+
+    const draggableLocationInThisBlank = [...locationOfDraggables].find(
+      ([, draggableBlankId]) => blankId === draggableBlankId
+    )
+    const draggableInThisBlank = draggables.find(
+      ({ draggableId }) => draggableId === draggableLocationInThisBlank?.[0]
+    )
+
+    return draggableInThisBlank?.text.trim() ?? ''
+  }
+
+  function normalize(value: string) {
+    const _value = collapseWhitespace(value)
+    // mathjs throws when certain symbols are passed to its `evaluate` method.
+    // In this case, return `undefined` as the result of the normalization.
+    try {
+      return mathjs?.evaluate(normalizeNumber(_value)) as number
+    } catch {
+      return undefined
+    }
+  }
+
+  function collapseWhitespace(val: string): string {
+    return val.replace(/[\s\xa0]+/g, ' ').trim()
+  }
+
+  function normalizeNumber(val: string) {
+    return val.replace(/,/g, '.').replace(/^[+]/, '')
+  }
+}
+
+/** Searches for blank objects in text plugin state. They can be at varying depths. */
+function getBlanksWithinObject(obj: object): BlankType[] {
+  if (Blank.is(obj)) return [obj]
+
+  // Recursively search this object's values for blank objects
+  return Object.values(obj).reduce((blanks: BlankType[], value: unknown) => {
+    if (typeof value === 'object' && value !== null) {
+      return [...blanks, ...getBlanksWithinObject(value)]
+    }
+    return blanks
+  }, [])
+}

--- a/packages/editor/src/plugins/blanks-table/static.tsx
+++ b/packages/editor/src/plugins/blanks-table/static.tsx
@@ -1,0 +1,44 @@
+import {
+  BlanksTableRenderer,
+  BlanksTableRendererProps,
+} from '@editor/plugins/blanks-table/renderer'
+import { type BlanksMode, TableType } from '@editor/plugins/blanks-table/types'
+import { StaticRenderer } from '@editor/static-renderer/static-renderer'
+import { EditorBlanksTableDocument } from '@editor/types/editor-plugins'
+
+export function BlanksTableStaticRenderer({
+  state,
+  onEvaluate,
+}: EditorBlanksTableDocument & {
+  onEvaluate?: BlanksTableRendererProps['onEvaluate']
+}) {
+  const { rows, tableType, mode, extraDraggableAnswers } = state
+  if (!rows || rows.length === 0) return null
+
+  const rowsData = rows.map((row, rowIndex) => {
+    return {
+      cells: (row.columns?.map(({ content }, colIndex) => {
+        return content ? (
+          <div key={`${rowIndex}:${colIndex}`}>
+            <StaticRenderer document={content} />
+          </div>
+        ) : null
+      }) as JSX.Element[]) ?? <></>,
+    }
+  })
+
+  return (
+    <div className="overflow-x-auto">
+      <BlanksTableRenderer
+        rows={rowsData}
+        tableType={tableType as TableType}
+        // TODO: Should not be hard-coded
+        tableState={rows}
+        mode={mode as BlanksMode}
+        initialTextInBlank="empty"
+        extraDraggableAnswers={extraDraggableAnswers}
+        onEvaluate={onEvaluate}
+      />
+    </div>
+  )
+}

--- a/packages/editor/src/plugins/blanks-table/toolbar.tsx
+++ b/packages/editor/src/plugins/blanks-table/toolbar.tsx
@@ -1,0 +1,44 @@
+import { PluginToolbar } from '@editor/editor-ui/plugin-toolbar'
+import { ToolbarSelect } from '@editor/editor-ui/plugin-toolbar/components/toolbar-select'
+import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
+
+import type { BlanksTableProps } from '.'
+import { TableType } from './types'
+import { getTableType } from './utils/get-table-type'
+
+export const BlanksTableToolbar = ({ id, state }: BlanksTableProps) => {
+  const blanksTableStrings = useEditorStrings().plugins.blanksTable
+
+  const tableType = getTableType(state.tableType.value)
+
+  return (
+    <PluginToolbar
+      pluginType={EditorPluginType.BlanksTable}
+      pluginSettings={
+        <ToolbarSelect
+          tooltipText=""
+          value={tableType}
+          changeValue={(value) => state.tableType.set(value)}
+          options={[
+            {
+              value: TableType.OnlyColumnHeader,
+              text: blanksTableStrings.columnHeaders,
+            },
+            {
+              value: TableType.OnlyRowHeader,
+              text: blanksTableStrings.rowHeaders,
+            },
+            {
+              value: TableType.ColumnAndRowHeader,
+              text: blanksTableStrings.columnAndRowHeaders,
+            },
+          ]}
+        />
+      }
+      pluginControls={<PluginDefaultTools pluginId={id} />}
+      className="-mt-1.5"
+    />
+  )
+}

--- a/packages/editor/src/plugins/blanks-table/types.ts
+++ b/packages/editor/src/plugins/blanks-table/types.ts
@@ -1,0 +1,39 @@
+import * as t from 'io-ts'
+
+import type { CustomText } from '../text'
+
+export const Answer = t.type({ answer: t.string })
+
+export const Blank = t.intersection([
+  // These props have been present from the beginning, and are therefore required
+  t.type({
+    type: t.literal('textBlank'),
+    children: t.unknown,
+    blankId: t.string,
+    correctAnswers: t.array(Answer),
+  }),
+  // These props have been added later, and are therefore optional. They could be
+  // made required, if a DB migration was done to populate all Blanks with them.
+  t.partial({
+    acceptMathEquivalents: t.boolean,
+    // Here we could specify incorrect answers for this blank with specific learner feedback
+    // incorrectAnswers?: Answer[]
+    // Here we could add a default feedback for the learner
+    // defaultIncorrectAnswerFeedback: string
+  }),
+])
+// BlankType is used internally within the BlanksExercise, in order to satisfy io-ts.
+// BlankInterface is used within Slate, as io-ts can't convert CustomText interface.
+// A long term solution would be to switch Text plugin's types/interfaces to io-ts completely.
+export type BlankType = t.TypeOf<typeof Blank>
+export interface BlankInterface extends t.TypeOf<typeof Blank> {
+  children: CustomText[]
+}
+
+export type BlanksMode = 'typing' | 'drag-and-drop'
+
+export enum TableType {
+  OnlyColumnHeader = 'OnlyColumnHeader',
+  OnlyRowHeader = 'OnlyRowHeader',
+  ColumnAndRowHeader = 'RowAndColumnHeader',
+}

--- a/packages/editor/src/plugins/blanks-table/utils/get-table-type.ts
+++ b/packages/editor/src/plugins/blanks-table/utils/get-table-type.ts
@@ -1,0 +1,6 @@
+import { isTableType } from './is-table-type'
+import { TableType } from '../types'
+
+export function getTableType(text: string): TableType {
+  return isTableType(text) ? text : TableType.OnlyColumnHeader
+}

--- a/packages/editor/src/plugins/blanks-table/utils/is-table-type.ts
+++ b/packages/editor/src/plugins/blanks-table/utils/is-table-type.ts
@@ -1,0 +1,5 @@
+import { TableType } from '../types'
+
+export function isTableType(text: string): text is TableType {
+  return Object.values<string>(TableType).includes(text)
+}

--- a/packages/editor/src/plugins/box/index.tsx
+++ b/packages/editor/src/plugins/box/index.tsx
@@ -39,6 +39,7 @@ const defaultAllowedPlugins: (EditorPluginType | string)[] = [
   EditorPluginType.Equations,
   EditorPluginType.Multimedia,
   EditorPluginType.SerloTable,
+  EditorPluginType.BlanksTable,
   EditorPluginType.Highlight,
 ]
 

--- a/packages/editor/src/plugins/multimedia/index.ts
+++ b/packages/editor/src/plugins/multimedia/index.ts
@@ -29,6 +29,7 @@ const defaultConfig: MultimediaConfig = {
         EditorPluginType.Equations,
         EditorPluginType.Image,
         EditorPluginType.SerloTable,
+        EditorPluginType.BlanksTable,
       ],
     },
   },

--- a/packages/editor/src/plugins/page-layout/index.ts
+++ b/packages/editor/src/plugins/page-layout/index.ts
@@ -11,6 +11,7 @@ import { PageLayoutEditor } from './editor'
 
 const allowedPlugins = [
   EditorPluginType.Text,
+  EditorPluginType.BlanksTable,
   EditorPluginType.Box,
   EditorPluginType.Geogebra,
   EditorPluginType.Highlight,

--- a/packages/editor/src/plugins/paste-hack/editor.tsx
+++ b/packages/editor/src/plugins/paste-hack/editor.tsx
@@ -29,6 +29,7 @@ const StateDecoder = t.strict({
         t.literal(EditorPluginType.Video),
         t.literal(EditorPluginType.Audio),
         t.literal(EditorPluginType.SerloTable),
+        t.literal(EditorPluginType.BlanksTable),
         t.literal(EditorPluginType.Highlight),
         t.literal(EditorPluginType.Injection),
         t.literal(EditorPluginType.Multimedia),

--- a/packages/editor/src/plugins/rows/editor-renderer.tsx
+++ b/packages/editor/src/plugins/rows/editor-renderer.tsx
@@ -30,6 +30,7 @@ const pluginsWithOwnBorder = [
   EditorPluginType.Geogebra,
   EditorPluginType.Highlight,
   EditorPluginType.SerloTable,
+  EditorPluginType.BlanksTable,
   EditorPluginType.Spoiler,
   EditorPluginType.Video,
 ]

--- a/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -14,7 +14,10 @@ export function checkIsAllowedNesting(
   }
 
   // Restrict Box->Multimedia->Table nesting
-  if (pluginType === EditorPluginType.SerloTable) {
+  if (
+    pluginType === EditorPluginType.SerloTable ||
+    pluginType === EditorPluginType.BlanksTable
+  ) {
     const multimediaAncestorIndex = typesOfAncestors.findLastIndex(
       (ancestorType) => ancestorType === EditorPluginType.Multimedia
     )

--- a/packages/editor/src/static-renderer/helper/get-children-of-static-document.tsx
+++ b/packages/editor/src/static-renderer/helper/get-children-of-static-document.tsx
@@ -51,6 +51,8 @@ export function getChildrenOfStaticDocument(
   // ignoring for now
   // Equations
   // SerloTable
+  // BlanksTable
   // ScMcExercise
   // InputExercise
+  // BlanksExercise
 }

--- a/packages/editor/src/types/editor-plugin-type.ts
+++ b/packages/editor/src/types/editor-plugin-type.ts
@@ -3,6 +3,7 @@ export enum EditorPluginType {
   Article = 'article',
   Audio = 'audio',
   ArticleIntroduction = 'articleIntroduction',
+  BlanksTable = 'blanksTable',
   Box = 'box',
   Equations = 'equations',
   Geogebra = 'geogebra',

--- a/packages/editor/src/types/editor-plugins.ts
+++ b/packages/editor/src/types/editor-plugins.ts
@@ -2,6 +2,7 @@ import type { PrettyStaticState } from '@editor/plugin'
 import type { AnchorPluginState } from '@editor/plugins/anchor'
 import type { ArticlePluginState } from '@editor/plugins/article'
 import { AudioPluginState } from '@editor/plugins/audio'
+import { BlanksTablePluginState } from '@editor/plugins/blanks-table'
 import { BoxPluginState } from '@editor/plugins/box'
 import { EquationsPluginState } from '@editor/plugins/equations'
 import type { ExercisePluginState } from '@editor/plugins/exercise'
@@ -166,6 +167,11 @@ export interface EditorSerloTableDocument {
   state: PrettyStaticState<SerloTablePluginState>
   id?: string
 }
+export interface EditorBlanksTableDocument {
+  plugin: EditorPluginType.BlanksTable
+  state: PrettyStaticState<BlanksTablePluginState>
+  id?: string
+}
 export interface EditorTextDocument {
   plugin: EditorPluginType.Text
   state: PrettyStaticState<TextEditorState>
@@ -250,6 +256,7 @@ export type SupportedEditorDocument =
   | EditorVideoDocument
   | EditorAudioDocument
   | EditorSerloTableDocument
+  | EditorBlanksTableDocument
   | EditorHighlightDocument
   | EditorSerloInjectionDocument
   | EditorMultimediaDocument

--- a/packages/editor/src/types/plugin-type-guards.ts
+++ b/packages/editor/src/types/plugin-type-guards.ts
@@ -28,6 +28,7 @@ import type {
   EditorUnsupportedDocument,
   EditorVideoDocument,
   EditorTemplateExerciseGroupDocument,
+  EditorBlanksTableDocument,
 } from './editor-plugins'
 import { TemplatePluginType } from './template-plugin-type'
 
@@ -45,6 +46,11 @@ export function isArticleIntroductionDocument(
   document: AnyEditorDocument
 ): document is EditorArticleIntroductionDocument {
   return document.plugin === EditorPluginType.ArticleIntroduction
+}
+export function isBlanksTableDocument(
+  document: AnyEditorDocument
+): document is EditorBlanksTableDocument {
+  return document.plugin === EditorPluginType.BlanksTable
 }
 export function isBoxDocument(
   document: AnyEditorDocument


### PR DESCRIPTION
Another approach for having blanks in tables - a new BlanksTable plugin.

The difference to [the first MVP](https://github.com/serlo/frontend/pull/3386) is that with BlanksTable, the whole table could be treated as a blanks area, with draggable answers for the whole table, and checking for correct answers for the whole table.

Disadvantage is way more complexity in the code.

### [Demo](https://frontend-git-feat-mvp-blanks-table-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22blanksTable%22%2C%22state%22%3A%7B%22rows%22%3A%5B%7B%22columns%22%3A%5B%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22b7ebaeb2-331f-4920-8c3a-868b4a06d5da%22%7D%7D%2C%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%2240bec4e2-4c60-4460-8abe-fe63d45197dd%22%7D%7D%5D%7D%2C%7B%22columns%22%3A%5B%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22one+two+three+four+%22%7D%2C%7B%22type%22%3A%22textBlank%22%2C%22blankId%22%3A%22d821aa90-0fbf-40dd-bc48-6c76722a9ba3%22%2C%22correctAnswers%22%3A%5B%7B%22answer%22%3A%22five%22%7D%2C%7B%22answer%22%3A%225%22%7D%5D%2C%22acceptMathEquivalents%22%3Atrue%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%2C%7B%22text%22%3A%22+six%22%7D%5D%7D%5D%2C%22id%22%3A%22c00cff3b-45f6-4997-a07b-04c487a06386%22%7D%7D%2C%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22one+%22%7D%2C%7B%22type%22%3A%22textBlank%22%2C%22blankId%22%3A%224ac17b32-52a8-497a-ae39-b43bc43a1fdd%22%2C%22correctAnswers%22%3A%5B%7B%22answer%22%3A%22two%22%7D%2C%7B%22answer%22%3A%222%22%7D%5D%2C%22acceptMathEquivalents%22%3Atrue%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%2C%7B%22text%22%3A%22+three%22%7D%5D%7D%5D%2C%22id%22%3A%223524488e-d022-4610-8b5d-f9d24e2d751f%22%7D%7D%5D%7D%5D%2C%22tableType%22%3A%22OnlyColumnHeader%22%2C%22mode%22%3A%22typing%22%7D%2C%22id%22%3A%22daab90b1-c40c-48d9-9448-915c43682b2b%22%7D%5D%7D) (Note: Did not test drag-and-drop at all yet, probably doesn't work)