### PR TITLE
fix(rows): harden static renderer

### DIFF
--- a/packages/editor/src/plugins/rows/static.tsx
+++ b/packages/editor/src/plugins/rows/static.tsx
@@ -3,6 +3,9 @@ import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import type { EditorRowsDocument } from '@editor/types/editor-plugins'
 
 export function RowsStaticRenderer({ state }: EditorRowsDocument) {
+  // handle malformed documents, fix for https://github.com/serlo/frontend/issues/3391
+  if (!state) return null
+
   return (
     <>
       {state.map((row, index) => {


### PR DESCRIPTION
In #3391 we encouter malformed states liek `{plugin: "rows"}` (state is missing).

Maybe this is happening somewhere else too. Harden the static renderer to not throw an error.