### PR TITLE
feat(🦄): banner for day of mathematics (wip)

### DIFF
--- a/apps/web/src/components/entity-base.tsx
+++ b/apps/web/src/components/entity-base.tsx
@@ -146,6 +146,36 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
           </div>
         </div>
       )}
+      <div className="relatie fixed bottom-0 left-0 right-0 z-[200] border-t-2 border-gray-300 bg-brand-50">
+        <button
+          className="serlo-button-blue absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full"
+          onClick={() => {}}
+        >
+          <FaIcon icon={faTimes} className="text-2xl text-white"></FaIcon>
+        </button>
+        <div className="flex flex-row justify-center">
+          <div className="cursor-pointer ">
+            <div className="mt-5">
+              <p>
+                <button className="text-3xl">Einhorn der Mathematik</button>
+              </p>
+
+              <p className="mt-4 max-w-65">
+                Wir feiern den Tag der Mathematik! Erlebe einmal Mathematik von
+                einer unterhaltsamen Seite mit dem Einhorn.
+              </p>
+            </div>
+          </div>
+          <div>
+            {/* eslint-disable-next-line @next/next/no-img-element*/}
+            <img
+              src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
+              alt="Einhorn der Mathematik"
+              className="my-8 ml-8 h-32"
+            />
+          </div>
+        </div>
+      </div>
       {page.secondaryMenuData && (
         <SecondaryMenu data={page.secondaryMenuData} />
       )}

--- a/apps/web/src/components/entity-base.tsx
+++ b/apps/web/src/components/entity-base.tsx
@@ -109,18 +109,23 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
               className="group"
             >
               <div>
-                <div className="mt-10">
+                <div className="ml-2 mt-2 mobileExt:mt-6 sm:mt-10">
                   <p>
-                    <button className="text-3xl">
+                    <button className="mr-12 text-left text-3xl sm:mr-0">
                       Internationaler Tag der Mathematik
                     </button>
                   </p>
 
-                  <p className="mt-3 max-w-[400px] text-lg">
-                    Feiere zusammen mit uns diesen Tag und erlebe die Mathematik
-                    von ihrer spielerischen Seite.
-                  </p>
-                  <p className="mt-4">
+                  <div className="mt-3 flex justify-between">
+                    <p className="text-lg sm:max-w-[400px]">
+                      Feiere zusammen mit uns diesen Tag und erlebe die
+                      Mathematik von ihrer spielerischen Seite.
+                    </p>
+                    <div className="mr-4 mt-4 min-w-fit sm:hidden">
+                      {renderUnicorn()}
+                    </div>
+                  </div>
+                  <p className="mb-4 mt-4">
                     <button className="rounded-full bg-pink-600 px-4 py-2 font-bold text-white transition-colors group-hover:bg-pink-500">
                       Zum Einhorn der Mathematik
                     </button>
@@ -128,18 +133,7 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
                 </div>
               </div>
             </a>
-
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden">
-              <div>
-                {/* eslint-disable-next-line @next/next/no-img-element*/}
-                <img
-                  src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
-                  alt="Einhorn der Mathematik"
-                  className="mb-10 ml-8 mt-14 h-36"
-                />
-              </div>
-            </a>
+            <div className="hidden sm:block">{renderUnicorn()}</div>
           </div>
         </div>
       )}
@@ -202,6 +196,24 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
           page.entityData.typename === UuidType.GroupedExercise
         }
       />
+    )
+  }
+
+  function renderUnicorn() {
+    return (
+      <>
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden">
+          <div>
+            {/* eslint-disable-next-line @next/next/no-img-element*/}
+            <img
+              src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
+              alt="Einhorn der Mathematik"
+              className="h-20 mobileExt:h-28 sm:mb-10 sm:ml-8 sm:mt-14 sm:h-36"
+            />
+          </div>
+        </a>
+      </>
     )
   }
 

--- a/apps/web/src/components/entity-base.tsx
+++ b/apps/web/src/components/entity-base.tsx
@@ -1,5 +1,4 @@
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
-import Cookies from 'js-cookie'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { type ReactNode, useEffect, useState } from 'react'
@@ -25,8 +24,6 @@ import {
   UuidType,
 } from '@/data-types'
 import { Instance } from '@/fetcher/graphql-types/operations'
-import { isProduction } from '@/helper/is-production'
-import { shuffleArray } from '@/helper/shuffle-array'
 
 export interface EntityBaseProps {
   children: ReactNode
@@ -53,53 +50,37 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
   const { lang } = useInstanceData()
 
   const [survey, setSurvey] = useState(false)
-  const [answers] = useState(
-    shuffleArray([
-      <button
-        key="yes"
-        className="serlo-button-blue w-24"
-        onClick={() => {
-          handleModalInput('yes')
-        }}
-      >
-        JA
-      </button>,
-      <button
-        key="rarely"
-        className="serlo-button-blue w-24"
-        onClick={() => {
-          handleModalInput('rarely')
-        }}
-      >
-        SELTEN
-      </button>,
-      <button
-        key="no"
-        className="serlo-button-blue w-24"
-        onClick={() => {
-          handleModalInput('no')
-        }}
-      >
-        NEIN
-      </button>,
-    ])
-  )
-
-  function handler(e: KeyboardEvent) {
-    if (e.key === 'Escape' && survey) {
-      handleModalInput('exit')
-    }
-  }
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      triggerPopup()
-    }, 20000)
+    const threshold = 10
+    let lastScrollY = window.scrollY
+    let ticking = false
 
-    return () => {
-      clearTimeout(timer)
-      document.removeEventListener('keydown', handler)
+    const updateScrollDir = () => {
+      const scrollY = window.scrollY
+
+      if (Math.abs(scrollY - lastScrollY) < threshold) {
+        ticking = false
+        return
+      }
+      if (scrollY < lastScrollY) {
+        triggerPopup()
+        return // ticking stays true, so this is not retriggered
+      }
+      lastScrollY = scrollY > 0 ? scrollY : 0
+      ticking = false
     }
+
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateScrollDir)
+        ticking = true
+      }
+    }
+
+    window.addEventListener('scroll', onScroll)
+
+    return () => window.removeEventListener('scroll', onScroll)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -112,87 +93,56 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
   return (
     <ABProvider value={abValue}>
       {survey && (
-        <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/30">
-          <div className="relative z-[1200] mx-side w-[500px] rounded-xl bg-white text-center">
-            <button
-              className="serlo-button-blue absolute -right-3 -top-3 flex h-12 w-12 items-center justify-center rounded-full"
-              onClick={() => {
-                handleModalInput('exit')
-              }}
+        <div className="fixed bottom-0 left-0 right-0 z-[200] border-t-2 border-gray-300 bg-brand-50">
+          <button
+            className="serlo-button-blue absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full"
+            onClick={() => {
+              setSurvey(false)
+            }}
+          >
+            <FaIcon icon={faTimes} className="text-2xl text-white"></FaIcon>
+          </button>
+          <div className="flex flex-row justify-center">
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden"
+              className="group"
             >
-              <FaIcon icon={faTimes} className="text-2xl text-white"></FaIcon>
-            </button>
-            <p className="mx-side mt-4 italic text-almost-black">
-              Wir stellen regelmäßig Fragen auf der Plattform, um unser
-              Lernangebot für dich weiter zu verbessern.
-            </p>
-            <p className="serlo-p mt-6 text-2xl font-bold">
-              Bekommst du zu Hause Hilfe, wenn du beim Lernen nicht
-              weiterkommst?
-            </p>
+              <div>
+                <div className="mt-10">
+                  <p>
+                    <button className="text-3xl">
+                      Internationaler Tag der Mathematik
+                    </button>
+                  </p>
 
-            <p className="flex justify-around">{answers}</p>
+                  <p className="mt-3 max-w-[400px] text-lg">
+                    Feiere zusammen mit uns diesen Tag und erlebe die Mathematik
+                    von ihrer spielerischen Seite.
+                  </p>
+                  <p className="mt-4">
+                    <button className="rounded-full bg-pink-600 px-4 py-2 font-bold text-white transition-colors group-hover:bg-pink-500">
+                      Zum Einhorn der Mathematik
+                    </button>
+                  </p>
+                </div>
+              </div>
+            </a>
 
-            <p className="mb-8 mt-8">
-              <button
-                className="underline"
-                onClick={() => {
-                  handleModalInput('noStudent')
-                }}
-              >
-                Ich bin keine Schüler*in
-              </button>
-            </p>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden">
+              <div>
+                {/* eslint-disable-next-line @next/next/no-img-element*/}
+                <img
+                  src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
+                  alt="Einhorn der Mathematik"
+                  className="mb-10 ml-8 mt-14 h-36"
+                />
+              </div>
+            </a>
           </div>
         </div>
       )}
-      <div className="relatie fixed bottom-0 left-0 right-0 z-[200] border-t-2 border-gray-300 bg-brand-50">
-        <button
-          className="serlo-button-blue absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full"
-          onClick={() => {}}
-        >
-          <FaIcon icon={faTimes} className="text-2xl text-white"></FaIcon>
-        </button>
-        <div className="flex flex-row justify-center">
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a
-            href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden"
-            className="group"
-          >
-            <div>
-              <div className="mt-10">
-                <p>
-                  <button className="text-3xl">
-                    Internationaler Tag der Mathematik
-                  </button>
-                </p>
-
-                <p className="mt-3 max-w-[400px] text-lg">
-                  Feiere zusammen mit uns diesen Tag und erlebe die Mathematik
-                  von einer spielerischen Seite.
-                </p>
-                <p className="mt-4">
-                  <button className="rounded-full bg-pink-600 px-4 py-2 font-bold text-white transition-colors group-hover:bg-pink-500">
-                    Zum Einhorn der Mathematik
-                  </button>
-                </p>
-              </div>
-            </div>
-          </a>
-
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden">
-            <div>
-              {/* eslint-disable-next-line @next/next/no-img-element*/}
-              <img
-                src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
-                alt="Einhorn der Mathematik"
-                className="mb-10 ml-8 mt-14 h-36"
-              />
-            </div>
-          </a>
-        </div>
-      </div>
       {page.secondaryMenuData && (
         <SecondaryMenu data={page.secondaryMenuData} />
       )}
@@ -261,13 +211,23 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
       return
     }
 
-    // pop-up already shown - but only for production
-    if (Cookies.get('serlo-survey-beta-123-shown')) {
+    if (lang !== Instance.De) {
       return
     }
 
-    // only in german version
-    if (lang !== Instance.De) {
+    if (!asPath.startsWith('/mathe/')) {
+      return
+    }
+
+    if (asPath.includes('einhorn-der-mathematik')) {
+      return
+    }
+
+    setSurvey(true)
+
+    /*
+    // pop-up already shown - but only for production
+    if (Cookies.get('serlo-survey-beta-123-shown')) {
       return
     }
 
@@ -292,33 +252,6 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
         sameSite: 'Lax',
       })
     }
-
-    setSurvey(true)
-    submitEvent('show')
-    document.addEventListener('keydown', handler)
-  }
-
-  function handleModalInput(
-    event: 'exit' | 'yes' | 'no' | 'rarely' | 'noStudent'
-  ) {
-    submitEvent(event)
-    setSurvey(false)
-    document.removeEventListener('keydown', handler)
-  }
-
-  function submitEvent(event: string) {
-    void (async () => {
-      await fetch('/api/frontend/survey-submission', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          event,
-          path: asPath,
-          isProduction,
-        }),
-      })
-    })()
+    */
   }
 }

--- a/apps/web/src/components/entity-base.tsx
+++ b/apps/web/src/components/entity-base.tsx
@@ -1,4 +1,5 @@
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
+import Cookies from 'js-cookie'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { type ReactNode, useEffect, useState } from 'react'
@@ -105,8 +106,10 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
           <div className="flex flex-row justify-center">
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a
-              href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden"
+              href="https://einhorn.arrrg.de/"
+              target="_blank"
               className="group"
+              rel="noreferrer"
             >
               <div>
                 <div className="ml-2 mt-2 mobileExt:mt-6 sm:mt-10">
@@ -235,35 +238,29 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
       return
     }
 
-    setSurvey(true)
-
-    /*
-    // pop-up already shown - but only for production
-    if (Cookies.get('serlo-survey-beta-123-shown')) {
+    // pop-up already shown
+    if (Cookies.get('serlo-international-day-of-mathematics-banner')) {
       return
     }
 
-    const startDate = new Date('2023-07-22T00:00:00+02:00')
-    const endDate = new Date('2023-07-24T00:00:00+02:00')
+    const startDate = new Date('2024-03-14T00:00:00+02:00')
+    const endDate = new Date('2024-03-15T00:00:00+02:00')
 
     // pop-up will vanish after survey run
     if (Date.now() > endDate.getTime()) {
       return
     }
 
-    if (isProduction) {
-      // don't show in production before the start date
-      if (Date.now() < startDate.getTime()) {
-        return
-      }
+    // don't show before the start date
+    if (Date.now() < startDate.getTime()) {
+      return
     }
 
-    if (isProduction) {
-      Cookies.set('serlo-survey-beta-123-shown', '1', {
-        expires: 7,
-        sameSite: 'Lax',
-      })
-    }
-    */
+    Cookies.set('serlo-international-day-of-mathematics-banner', '1', {
+      expires: 2,
+      sameSite: 'Lax',
+    })
+
+    setSurvey(true)
   }
 }

--- a/apps/web/src/components/entity-base.tsx
+++ b/apps/web/src/components/entity-base.tsx
@@ -154,26 +154,43 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
           <FaIcon icon={faTimes} className="text-2xl text-white"></FaIcon>
         </button>
         <div className="flex flex-row justify-center">
-          <div className="cursor-pointer ">
-            <div className="mt-5">
-              <p>
-                <button className="text-3xl">Einhorn der Mathematik</button>
-              </p>
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a
+            href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden"
+            className="group"
+          >
+            <div>
+              <div className="mt-10">
+                <p>
+                  <button className="text-3xl">
+                    Internationaler Tag der Mathematik
+                  </button>
+                </p>
 
-              <p className="mt-4 max-w-65">
-                Wir feiern den Tag der Mathematik! Erlebe einmal Mathematik von
-                einer unterhaltsamen Seite mit dem Einhorn.
-              </p>
+                <p className="mt-3 max-w-[400px] text-lg">
+                  Feiere zusammen mit uns diesen Tag und erlebe die Mathematik
+                  von einer spielerischen Seite.
+                </p>
+                <p className="mt-4">
+                  <button className="rounded-full bg-pink-600 px-4 py-2 font-bold text-white transition-colors group-hover:bg-pink-500">
+                    Zum Einhorn der Mathematik
+                  </button>
+                </p>
+              </div>
             </div>
-          </div>
-          <div>
-            {/* eslint-disable-next-line @next/next/no-img-element*/}
-            <img
-              src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
-              alt="Einhorn der Mathematik"
-              className="my-8 ml-8 h-32"
-            />
-          </div>
+          </a>
+
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a href="/mathe/298181/einhorn-der-mathematik-%C3%BCbersicht-aller-episoden">
+            <div>
+              {/* eslint-disable-next-line @next/next/no-img-element*/}
+              <img
+                src="https://assets.serlo.org/e16a66c0-c26b-11ee-b6d8-a1dea02dc7c7/einhorndermathematikC3BCbersichtallerepisoden.png"
+                alt="Einhorn der Mathematik"
+                className="mb-10 ml-8 mt-14 h-36"
+              />
+            </div>
+          </a>
         </div>
       </div>
       {page.secondaryMenuData && (


### PR DESCRIPTION
[sneak peak](https://frontend-git-easter-egg-international-day-of-mathematics-serlo.vercel.app/mathe/1717/gleichung)

todos:

- [x] only trigger on 2024-03-14
- [x] mobile view + responsive design
- [x] only trigger on de
- [x] only trigger on scroll-up
- [x] only trigger if path starts with `/mathe/` but does not contain `einhorn-der-mathematik`
- [x] implement closing
- [x] remember closing for session (implicitly by using client side routing)