### PR TITLE
feat(plugin-injection): cleanup and validate state string

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -758,7 +758,9 @@ export const loggedInData = {
           illegalInjectionFound: 'Illegal injection found',
           serloEntitySrc: 'Serlo entity {{src}}',
           serloId: 'Serlo ID',
-          placeholder: 'Serlo ID (e.g. 1565)',
+          placeholder: 'Serlo ID (e.g. /1565)',
+          invalidStateWarning:
+            "Please use a valid Serlo ID (just numbers). E.g. '/1555'",
         },
         multimedia: {
           title: 'Multimedia content associated with text',

--- a/packages/editor/src/plugins/text/utils/link.ts
+++ b/packages/editor/src/plugins/text/utils/link.ts
@@ -1,4 +1,4 @@
-export function getCleanUrl(inputUrl: string, instance: string) {
+export function getCleanUrl(inputUrl: string, instance?: string) {
   const testId = parseInt(inputUrl.match(/[1-9]?[0-9]+/)?.[0] ?? 'NaN')
 
   const hashPart = inputUrl.split('#')[1]
@@ -7,10 +7,12 @@ export function getCleanUrl(inputUrl: string, instance: string) {
   if (!isNaN(testId) && inputUrl.includes('serlo.org/'))
     return `/${testId}${hash}`
 
-  const cleanedUrl = inputUrl
-    .replace('https://serlo.org/', '')
-    .replace(`https://${instance}.serlo.org/`, '')
-    .replace(/^serlo\.org\//, '')
+  const cleanedUrl = instance
+    ? inputUrl
+        .replace('https://serlo.org/', '')
+        .replace(`https://${instance}.serlo.org/`, '')
+        .replace(/^serlo\.org\//, '')
+    : inputUrl.replace(/(https:\/\/)?([a-z]+\.)?serlo.org/, '')
 
   return inputUrl !== cleanedUrl ? `/${cleanedUrl}${hash}` : inputUrl
 }


### PR DESCRIPTION
### [DEMO](https://frontend-git-injection-cleanup-validate-state-serlo.vercel.app//___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22injection%22%2C%22state%22%3A%22%22%2C%22id%22%3A%22ac0ae842-ba85-460b-99ab-e87021e78bcc%22%7D%5D%7D)

- should only allow `/{uuid}` and
- `/{uuid}#{valid-editor-id}` (can be numbers and strings mixed)
- pasting serlo links should work (e.g. https://de.serlo.org/mathe/1555/zylinder)