### PR TITLE
feat(plugin-injection): temporarily make injections work with the migrated injection state

### DIFF
--- a/packages/editor/src/plugins/injection/static.tsx
+++ b/packages/editor/src/plugins/injection/static.tsx
@@ -102,10 +102,14 @@ export function InjectionStaticRenderer({
   >('loading')
   const { strings } = useInstanceData()
   const [base, hash] = href.split('#')
-  const cleanedHref = base
-    ? base.startsWith('/')
-      ? base
-      : `/${base}`
+
+  // TODO: Temporary until migration is done
+  const baseRelacedWithHash = hash ? hash.replace(/\D/g, '') : base
+
+  const cleanedHref = baseRelacedWithHash
+    ? baseRelacedWithHash.startsWith('/')
+      ? baseRelacedWithHash
+      : `/${baseRelacedWithHash}`
     : undefined
 
   useEffect(() => {

--- a/packages/editor/src/plugins/injection/static.tsx
+++ b/packages/editor/src/plugins/injection/static.tsx
@@ -104,12 +104,12 @@ export function InjectionStaticRenderer({
   const [base, hash] = href.split('#')
 
   // TODO: Temporary until migration is done
-  const baseRelacedWithHash = hash ? hash.replace(/\D/g, '') : base
+  const baseReplacedWithHash = hash && /^[0-9]+$/.test(hash) ? hash : base
 
-  const cleanedHref = baseRelacedWithHash
-    ? baseRelacedWithHash.startsWith('/')
-      ? baseRelacedWithHash
-      : `/${baseRelacedWithHash}`
+  const cleanedHref = baseReplacedWithHash
+    ? baseReplacedWithHash.startsWith('/')
+      ? baseReplacedWithHash
+      : `/${baseReplacedWithHash}`
     : undefined
 
   useEffect(() => {


### PR DESCRIPTION
quickfix so we can migrate the injection migrations first without breaking something in production.

this basically parses the new format (`/{exercise-group-uuid}#{grouped-exercise-id}`) and loads the groupedExercise entity.