### PR TITLE
fix(editor): insert plugin on first of two empty lines

### DIFF
--- a/e2e-tests/tests/400-serlo-editor.ts
+++ b/e2e-tests/tests/400-serlo-editor.ts
@@ -86,6 +86,53 @@ Scenario('Add plugin via slash command', async ({ I }) => {
   I.seeElement('.serlo-table')
 })
 
+Scenario(
+  'Feature compatibility: "suggestions" and "empty lines restriction"',
+  ({ I }) => {
+    I.amOnPage('/entity/create/Article/1377')
+
+    I.say(
+      'Add a Text plugin with two paragraphs and an empty line between them'
+    )
+    I.click(locate('$plugin-text-editor').inside('.plugin-rows'))
+    I.type('First paragraph')
+    I.pressKey('Enter')
+    I.pressKey('Enter')
+    I.type('Second paragraph')
+
+    I.say('Add an Image plugin in place of the empty line using suggestions')
+    I.pressKey('ArrowUp')
+    I.type('/Bild')
+    I.pressKey('Enter')
+
+    I.see('First paragraph')
+    I.seeElement('$plugin-image-editor')
+    I.see('Second paragraph')
+
+    I.say('Remove the Image plugin and merge the split Text plugin')
+    I.click(locate('$plugin-image-editor').inside('.plugin-rows'))
+    I.moveCursorTo(
+      locate('[data-radix-collection-item]').inside('.plugin-toolbar')
+    )
+    I.click('$remove-plugin-button')
+    I.click(locate('$plugin-text-editor').inside('.plugin-rows'))
+    I.pressKey('Delete')
+
+    I.say(
+      'Add two empty lines between the paragraphs, and then add an Image plugin in place of the first empty line using suggestions'
+    )
+    I.pressKey('Enter')
+    I.pressKey('Enter')
+    I.pressKey('ArrowUp')
+    I.type('/Bild')
+    I.pressKey('Enter')
+
+    I.see('First paragraph')
+    I.seeElement('$plugin-image-editor')
+    I.see('Second paragraph')
+  }
+)
+
 /**
  * Most of the input of the editor happens within the editor contenteditable
  * div. However, there are some input fields whose undo/redo behavior could

--- a/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
@@ -171,7 +171,9 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
     // then remove the leftover empty line.
     setTimeout(() => {
       insertPlugin({ pluginType, editor, id, dispatch })
-      editor.deleteBackward('block')
+      if (selection && editor.children[selection.anchor.path[0]]) {
+        editor.deleteBackward('block')
+      }
     })
   }
 

--- a/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-suggestions.tsx
@@ -167,10 +167,11 @@ export const useSuggestions = (args: useSuggestionsArgs) => {
       return
     }
 
-    // Split the text-plugin and insert selected new plugin,
-    // then remove the leftover empty line.
     setTimeout(() => {
+      // Split the text-plugin and insert selected new plugin
       insertPlugin({ pluginType, editor, id, dispatch })
+
+      // If there is an empty line on the initial selection point, remove it
       if (selection && editor.children[selection.anchor.path[0]]) {
         editor.deleteBackward('block')
       }


### PR DESCRIPTION
Fixes the reported bug: https://trello.com/c/waIxL0Mn/570-adding-image-deletes-above-paragraph