### PR TITLE
fix(article): Check for empty introductions in articles

### DIFF
--- a/apps/web/src/components/content/entity.tsx
+++ b/apps/web/src/components/content/entity.tsx
@@ -1,6 +1,6 @@
 // Temporary file while working on unified renderer
 import { editorRenderers } from '@editor/plugin/helpers/editor-renderer'
-import { isEmptyRowsDocument } from '@editor/plugins/rows/utils/static-is-empty'
+import { isEmptyArticle } from '@editor/plugins/rows/utils/static-is-empty'
 import { CourseNavigation } from '@editor/plugins/serlo-template-plugins/course/course-navigation'
 import { StaticRenderer } from '@editor/static-renderer/static-renderer'
 import { isArticleDocument } from '@editor/types/plugin-type-guards'
@@ -211,7 +211,7 @@ export function Entity({ data }: EntityProps) {
     // this check could be more exact, but I guess empty articles are the most important case
     const hasContent = data.content
       ? !Array.isArray(data.content) && isArticleDocument(data.content)
-        ? !isEmptyRowsDocument(data.content.state.content)
+        ? !isEmptyArticle(data.content)
         : true
       : !!data.title
 

--- a/apps/web/src/components/content/entity.tsx
+++ b/apps/web/src/components/content/entity.tsx
@@ -1,6 +1,6 @@
 // Temporary file while working on unified renderer
 import { editorRenderers } from '@editor/plugin/helpers/editor-renderer'
-import { isEmptyArticle } from '@editor/plugins/rows/utils/static-is-empty'
+import { isEmptyArticle } from '@editor/plugins/article/utils/static-is-empty'
 import { CourseNavigation } from '@editor/plugins/serlo-template-plugins/course/course-navigation'
 import { StaticRenderer } from '@editor/static-renderer/static-renderer'
 import { isArticleDocument } from '@editor/types/plugin-type-guards'

--- a/packages/editor/src/plugins/article/utils/static-is-empty.ts
+++ b/packages/editor/src/plugins/article/utils/static-is-empty.ts
@@ -1,0 +1,25 @@
+import { isEmptyRowsDocument } from '@editor/plugins/rows/utils/static-is-empty'
+import { isEmptyTextDocument } from '@editor/plugins/text/utils/static-is-empty'
+import {
+  EditorArticleDocument,
+  EditorArticleIntroductionDocument,
+} from '@editor/types/editor-plugins'
+
+export function isEmptyArticle(article: EditorArticleDocument): boolean {
+  const articleIntroduction = article.state
+    .introduction as EditorArticleIntroductionDocument
+
+  const introductionTextState = articleIntroduction?.state?.explanation
+  if (!isEmptyTextDocument(introductionTextState)) {
+    return false
+  }
+
+  // If no text content is found in the introduction, proceed to check if the
+  // rows have content
+  if (article.state.content) {
+    return isEmptyRowsDocument(article.state.content)
+  }
+
+  // If there's no content to check or it's not a rows document, consider it empty
+  return true
+}

--- a/packages/editor/src/plugins/rows/utils/static-is-empty.ts
+++ b/packages/editor/src/plugins/rows/utils/static-is-empty.ts
@@ -1,10 +1,33 @@
 // eslint-disable-next-line import/no-cycle
-import type { AnyEditorDocument } from '@editor/types/editor-plugins'
+import type {
+  AnyEditorDocument,
+  EditorArticleDocument,
+  EditorArticleIntroductionDocument,
+} from '@editor/types/editor-plugins'
 import { isRowsDocument } from '@editor/types/plugin-type-guards'
 
 import { isEmptyTextDocument } from '../../text/utils/static-is-empty'
 
-export function isEmptyRowsDocument(rows: AnyEditorDocument) {
+export function isEmptyArticle(article: EditorArticleDocument): boolean {
+  const articleIntroduction = article.state
+    .introduction as EditorArticleIntroductionDocument
+
+  const introductionTextState = articleIntroduction?.state?.explanation
+  if (!isEmptyTextDocument(introductionTextState)) {
+    return false
+  }
+
+  // If no text content is found in the introduction, proceed to check if the
+  // rows have content
+  if (article.state.content) {
+    return isEmptyRowsDocument(article.state.content)
+  }
+
+  // If there's no content to check or it's not a rows document, consider it empty
+  return true
+}
+
+export function isEmptyRowsDocument(rows: AnyEditorDocument): boolean {
   if (!isRowsDocument(rows)) return false
 
   // only checks for initial empty state,

--- a/packages/editor/src/plugins/rows/utils/static-is-empty.ts
+++ b/packages/editor/src/plugins/rows/utils/static-is-empty.ts
@@ -1,31 +1,8 @@
 // eslint-disable-next-line import/no-cycle
-import type {
-  AnyEditorDocument,
-  EditorArticleDocument,
-  EditorArticleIntroductionDocument,
-} from '@editor/types/editor-plugins'
+import type { AnyEditorDocument } from '@editor/types/editor-plugins'
 import { isRowsDocument } from '@editor/types/plugin-type-guards'
 
 import { isEmptyTextDocument } from '../../text/utils/static-is-empty'
-
-export function isEmptyArticle(article: EditorArticleDocument): boolean {
-  const articleIntroduction = article.state
-    .introduction as EditorArticleIntroductionDocument
-
-  const introductionTextState = articleIntroduction?.state?.explanation
-  if (!isEmptyTextDocument(introductionTextState)) {
-    return false
-  }
-
-  // If no text content is found in the introduction, proceed to check if the
-  // rows have content
-  if (article.state.content) {
-    return isEmptyRowsDocument(article.state.content)
-  }
-
-  // If there's no content to check or it's not a rows document, consider it empty
-  return true
-}
 
 export function isEmptyRowsDocument(rows: AnyEditorDocument): boolean {
   if (!isRowsDocument(rows)) return false


### PR DESCRIPTION
Fixes bug reported by Anne in Slack, showing the following warning on articles that have an introduction.

![image](https://github.com/serlo/frontend/assets/28842311/d03490d8-1b6d-4d1c-a5bc-3a3bdf23ae66)
