### PR TITLE
fix(geogebra): Make geogebra sizing work regardless of being wrapped in `PrivacyWrapper` / `EmbedWrapper` or not

### DIFF
--- a/apps/web/src/components/content/privacy-wrapper.tsx
+++ b/apps/web/src/components/content/privacy-wrapper.tsx
@@ -1,4 +1,4 @@
-import { faHeart, faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { faHeart } from '@fortawesome/free-solid-svg-icons'
 import Image from 'next/image'
 import { useState, KeyboardEvent, useEffect } from 'react'
 
@@ -33,7 +33,7 @@ export function PrivacyWrapper({
   twingleCallback,
   onLoad,
 }: PrivacyWrapperProps) {
-  const [showIframe, setShowIframe] = useState(false)
+  const [showContent, setShowContent] = useState(false)
   const isTwingle = provider === ExternalProvider.Twingle
   const { checkConsent, giveConsent } = useConsent()
   const [consentGiven, setConsentGiven] = useState(false)
@@ -44,29 +44,29 @@ export function PrivacyWrapper({
     giveConsent(provider)
     setConsentGiven(true)
     if (onLoad) onLoad()
-    if (showIframe) return
+    if (showContent) return
     if (isTwingle && twingleCallback) twingleCallback()
-    setShowIframe(true)
+    setShowContent(true)
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
-    if (!showIframe && (e.key === 'Enter' || e.key === ' ')) {
+    if (!showContent && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault()
       confirmLoad()
     }
   }
 
   useEffect(() => {
-    const consentGiven = checkConsent(provider)
-    if (isTwingle && twingleCallback && consentGiven) {
+    const isConsentGiven = checkConsent(provider)
+    if (isTwingle && twingleCallback && isConsentGiven) {
       confirmLoad()
     }
-    setConsentGiven(consentGiven)
+    setConsentGiven(isConsentGiven)
 
     // If we already have the consent (in localstorage, we can show the iframe
     // immediately)
-    if (consentGiven && provider === ExternalProvider.Vocaroo) {
-      setShowIframe(true)
+    if (isConsentGiven && provider === ExternalProvider.Vocaroo) {
+      setShowContent(true)
     }
 
     // only run on first load
@@ -84,8 +84,7 @@ export function PrivacyWrapper({
         `
       )}
     >
-      {renderPlaceholder()}
-      {showIframe && children}
+      {showContent ? children : renderPlaceholder()}
     </div>
   )
 
@@ -95,9 +94,6 @@ export function PrivacyWrapper({
       provider: provider,
     })
 
-    if (showIframe && provider === ExternalProvider.Vocaroo) return null
-    if (isTwingle && showIframe) return null
-
     const previewImageUrl = isTwingle
       ? '/_assets/img/donations-form.png'
       : `https://embed.serlo.org/thumbnail?url=${encodeURIComponent(
@@ -105,21 +101,43 @@ export function PrivacyWrapper({
         )}`
 
     return (
-      <div className="text-center">
-        <div className="relative rounded-xl bg-brand-100 pb-[56.2%]">
+      <div className="w-full">
+        <div className="relative aspect-[16/9] w-full rounded-xl bg-brand-100">
           <Image
             src={previewImageUrl}
             alt={`${strings.content.previewImage} ${provider}`}
             fill
             sizes="(max-width: 1023px) 100vw, 770px"
             className={cn(
-              'absolute left-0 h-full w-full rounded-xl object-cover',
+              'rounded-xl',
+              // video and twingle previews have empty white space at the top & bottom so object-cover works better here.
+              type === 'video' || type === 'twingle'
+                ? 'object-cover'
+                : 'object-contain',
               isTwingle ? 'opacity-50' : 'opacity-90'
             )}
           />
+          <div
+            className="absolute inset-0 flex items-center justify-around"
+            onClick={confirmLoad}
+          >
+            <button
+              className={cn(
+                isTwingle ? 'serlo-button-blue' : 'serlo-button-light',
+                'group-hover:bg-brand-500 group-hover:text-white'
+              )}
+              onKeyDown={onKeyDown}
+            >
+              <FaIcon
+                className="py-0.5"
+                icon={type === 'twingle' ? faHeart : entityIconMapping[type]}
+              />{' '}
+              {buttonLabel}
+            </button>
+          </div>
         </div>
         {!consentGiven && (
-          <div className="relative z-10 cursor-default bg-brand-100 px-side py-2 text-left text-brand-700">
+          <div className="cursor-default bg-brand-100 px-side py-2 text-left text-brand-700">
             {replacePlaceholders(strings.embed.text, {
               provider: <b>{provider}</b>,
               privacypolicy: (
@@ -130,33 +148,6 @@ export function PrivacyWrapper({
             })}
           </div>
         )}
-        <div
-          className={cn(
-            'absolute inset-0 flex items-center justify-around',
-            consentGiven ? '' : '-top-28 mobile:-top-12 sm:-top-24'
-          )}
-          onClick={confirmLoad}
-        >
-          <button
-            className={cn(
-              isTwingle ? 'serlo-button-blue' : 'serlo-button-light',
-              'group-hover:bg-brand-500 group-hover:text-white'
-            )}
-            onKeyDown={onKeyDown}
-          >
-            <FaIcon
-              className={cn('py-0.5', showIframe && 'animate-spin-slow')}
-              icon={
-                showIframe
-                  ? faSpinner
-                  : type === 'twingle'
-                    ? faHeart
-                    : entityIconMapping[type]
-              }
-            />{' '}
-            {buttonLabel}
-          </button>
-        </div>
       </div>
     )
   }

--- a/packages/editor/src/editor-ui/embed-wrapper.tsx
+++ b/packages/editor/src/editor-ui/embed-wrapper.tsx
@@ -1,4 +1,3 @@
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
@@ -26,20 +25,20 @@ export function EmbedWrapper({
   type,
   embedUrl,
 }: EmbedWrapperProps) {
-  const [showIframe, setShowIframe] = useState(false)
+  const [showContent, setShowContent] = useState(false)
 
   useEffect(() => {
-    setShowIframe(false)
+    setShowContent(false)
   }, [embedUrl])
 
   const { strings } = useInstanceData()
 
   const confirmLoad = () => {
-    if (!showIframe) setShowIframe(true)
+    if (!showContent) setShowContent(true)
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
-    if (!showIframe && (e.key === 'Enter' || e.key === ' ')) {
+    if (!showContent && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault()
       confirmLoad()
     }
@@ -55,8 +54,7 @@ export function EmbedWrapper({
         className
       )}
     >
-      {renderPlaceholder()}
-      {showIframe && children}
+      {showContent ? children : renderPlaceholder()}
     </div>
   )
 
@@ -66,10 +64,10 @@ export function EmbedWrapper({
     )}`
 
     return (
-      <div className="text-center">
-        <div className="relative bg-editor-primary-100 pb-[56.2%]">
+      <div className="w-full">
+        <div className="relative flex aspect-[16/9] w-full justify-center rounded-xl bg-editor-primary-100">
           <img
-            className="absolute left-0 h-full w-full object-cover opacity-50"
+            className="w-full object-contain opacity-50"
             src={previewImageUrl}
             alt={`${strings.content.previewImage}`}
           />
@@ -82,10 +80,7 @@ export function EmbedWrapper({
             className="serlo-button-editor-primary group-hover:bg-editor-primary"
             onKeyDown={onKeyDown}
           >
-            <FaIcon
-              className={cn('py-0.5', showIframe && 'animate-spin-slow')}
-              icon={showIframe ? faSpinner : entityIconMapping[type]}
-            />{' '}
+            <FaIcon className="py-0.5" icon={entityIconMapping[type]} />{' '}
             {strings.embed.general}
           </button>
         </div>

--- a/packages/editor/src/plugins/geogebra/renderer.tsx
+++ b/packages/editor/src/plugins/geogebra/renderer.tsx
@@ -1,7 +1,8 @@
-import { cn } from '@serlo/frontend/src/helper/cn'
 import Script from 'next/script'
 import { useState } from 'react'
 import { v4 as uuid_v4 } from 'uuid'
+
+import { cn } from '@/helper/cn'
 
 export interface GeogebraRendererProps {
   geogebraId: string
@@ -50,12 +51,21 @@ export function GeogebraRenderer({ geogebraId, url }: GeogebraRendererProps) {
           }
         }}
       />
-      <div
-        className={cn(
-          `${containerId} absolute top-0 flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-brand-50 p-0`
-        )}
-      >
-        {url ? <div id={`${elementId}`} className="mx-auto"></div> : null}
+      <div className="aspect-[16/9] w-full overflow-hidden rounded-xl bg-brand-50 p-1">
+        <div
+          className={cn(
+            containerId,
+            'flex h-full w-full flex-col justify-center'
+          )}
+        >
+          {url ? (
+            <div
+              id={elementId}
+              data-ggb-id={geogebraId}
+              className="mx-auto"
+            ></div>
+          ) : null}
+        </div>
       </div>
     </>
   )

--- a/packages/editor/src/plugins/video/renderer.tsx
+++ b/packages/editor/src/plugins/video/renderer.tsx
@@ -30,7 +30,7 @@ export function VideoRenderer({ src, type }: VideoRendererProps) {
   }
 
   return (
-    <div className="mx-side my-0  p-0">
+    <div className="my-0 aspect-[16/9] w-full p-0">
       {type === VideoType.WikimediaCommons ? (
         <video controls src={src} className={videoClassName} />
       ) : (
@@ -46,9 +46,7 @@ export function VideoRenderer({ src, type }: VideoRendererProps) {
   )
 }
 
-const videoClassName = cn(
-  `absolute left-0 top-0 z-20 h-full w-full border-none bg-black/30`
-)
+const videoClassName = cn(`h-full w-full border-none bg-black/30`)
 
 export function parseVideoUrl(
   inputSrc: string,


### PR DESCRIPTION
## Changes: 
- Before, geogebra renderer rendered differently if not in PrivacyWrapper or EmbedWrapper. Now, Geogebra renderer always renders in 16/9 aspect ratio regardless of wrapping component.
- Before, PrivacyWrapper and EmbedWrapper rendered placeholder all the time and rendered children on top of the placeholder. Now, PrivacyWrapper and EmbedWrapper stop rendering the placeholder after the button is clicked and replace it with `children`. This has one downside: If `children` render slowly it is not a seamless transition. 
- Before, some geogebra applets were not positioned correctly when first interacted with. Jumped up and were cropped. Now, this seem to be fixed. 
- Before, the placeholder appeared zoomed in compared to the loaded content. Now, they look the same. 

## Possible followup: 
- Merge PrivacyWrapper and EmbedWrapper code since they are doing very similar things. 