### PR TITLE
chore(docs): Update readme and remove edtr-io type comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,25 @@ Add the environment variable `DATABASE_URL` to `apps/web/.env.local` (next.js). 
 
 ## Repository Overview
 
-Here are some useful places:
+This is a monorepo that contains the editor and the frontend platform. Here are some useful directories:
 
-- `/src/pages`: File-system routing root directory. Add new routes by creating files in this folder.
+- `/apps/web`: Serlo.org platform.
 
-- `/src/components`: Collection of react components for the frontend.
+- `/apps/web/src/pages`: File-system routing root directory. Add new routes by creating files in this folder.
 
-- `/src/fetcher`: Requesting data from the GraphQL backend and process it.
+- `/apps/web/src/components`: Collection of react components for the frontend.
 
-- `/src/schema`: Definition of the frontend content format, with renderer, and converter for edtr-io and legacy.
+- `/apps/web/src/fetcher`: Requesting data from the GraphQL backend and process it.
 
-- `/src/data`: Translations, entries for navigation
+- `/apps/web/src/data`: Translations, entries for navigation
 
-- `/public/_`: A place for public assets, served as static files under the path `/_assets/`. Don't use `import` from here, but use the path as `src` instead.
+- `/apps/web/public/_`: A place for public assets, served as static files under the path `/_assets/`. Don't use `import` from here, but use the path as `src` instead.
 
-- `/external`: Third-party code that is not maintained by the frontend.
+- `/apps/web/external`: Third-party code that is not maintained by the frontend.
+
+- `/packages/editor`: Serlo Editor. See [here](https://www.serlo.org/editor) for more information.
+
+- `/e2e-tests`: End to end tests in BDD style with CodeceptJS and playwright. More info on testing below and in the [readme](https://github.com/serlo/frontend/tree/staging/) of the directory.
 
 Some useful commands:
 

--- a/packages/editor/src/plugin/list.ts
+++ b/packages/editor/src/plugin/list.ts
@@ -11,13 +11,9 @@ import {
   ToStoreHelpers,
 } from './internal-plugin-state'
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/**
- * @param type - The {@link @edtr-io/internal__plugin-state#StateType | state type} of the list items
- * @param initialCount - The initial number of list items
- */
 export function list<D extends StateType>(
   type: D,
+  // Initial number of list items
   initialCount = 0
 ): ListStateType<D> {
   type S = StateTypeStaticType<D>

--- a/packages/editor/src/plugin/migration.ts
+++ b/packages/editor/src/plugin/migration.ts
@@ -6,10 +6,8 @@ import {
 
 // this file is currently unused
 
-/**
- * @param type - The initial {@link @edtr-io/internal__plugin-state#StateType | state type} to start the migration from
- */
 export function migratable<S, T, R>(
+  // Initial state type to start migration from
   type: StateType<S, T, R>
 ): MigratableStateType<S, S, S, T, R> {
   return migrate<S, never, S, S, T, R>(

--- a/packages/editor/src/plugin/object.ts
+++ b/packages/editor/src/plugin/object.ts
@@ -11,10 +11,6 @@ import {
   StateExecutor,
 } from './internal-plugin-state'
 
-/**
- * @param types - The {@link @edtr-io/internal__plugin-state#StateType | state types} of the properties of the object
- * @param getFocusableChildren - Allows to override the default order of focusable children
- */
 export function object<Ds extends Record<string, StateType>>(
   types: Ds
 ): ObjectStateType<Ds> {
@@ -101,6 +97,7 @@ export function object<Ds extends Record<string, StateType>>(
         return type.toStaticState(storeState[key], helpers)
       }, types) as S
     },
+    // Allows to override the default order of focusable children
     getFocusableChildren(state) {
       const children = R.mapObjIndexed((type, key) => {
         return type.getFocusableChildren(state[key])

--- a/packages/editor/src/plugin/optional.ts
+++ b/packages/editor/src/plugin/optional.ts
@@ -7,12 +7,10 @@ import {
   StateUpdater,
 } from './internal-plugin-state'
 
-/**
- * @param type - The {@link @edtr-io/internal__plugin-state#StateType | state type} for defined values
- * @param initiallyDefined - Whether the value should be defined initially
- */
 export function optional<D extends StateType>(
+  // State Type for defined values
   type: D,
+  // Whether the value should be defined initially
   initiallyDefined = false
 ): OptionalStateType<D> {
   type T = StateTypeValueType<D>

--- a/packages/editor/src/types/internal__plugin.ts
+++ b/packages/editor/src/types/internal__plugin.ts
@@ -107,7 +107,7 @@ export interface EditorPluginProps<
   config: Config
 
   /**
-   * Current state of the document, see {@link @edtr-io/internal__plugin-state#StateTypeReturnType}
+   * Current state of the document
    */
   state: StateTypeReturnType<S>
 


### PR DESCRIPTION
FYI: One of the files (packages/editor/src/plugin/migration.ts) is unused. I wonder if we should delete it entirely? 

In a follow-up PR, we could also change the `edtrIo` i18n string but I don't know if Crowdin lets us change the key easily https://github.com/serlo/frontend/blob/bba7d428b3fdc41d9629d69f178aa2a6f69377b7/apps/web/src/data/en/index.ts#L1056