### PR TITLE
layout: improve mobile, make more compact, some ux ideas

### DIFF
--- a/apps/web/src/components/math-skills/exercise-implementations/memory/memory-game.tsx
+++ b/apps/web/src/components/math-skills/exercise-implementations/memory/memory-game.tsx
@@ -119,7 +119,7 @@ export function MemoryGame({
         </h2>
         <nav
           className={cn(
-            'grid max-w-[350px] grid-cols-4 gap-2 text-center text-3xl font-bold',
+            'grid max-w-[350px] gap-2 text-center text-3xl font-bold',
             useSmallField ? 'grid-cols-3' : 'grid-cols-4'
           )}
           id="memory-game-cards"

--- a/apps/web/src/components/math-skills/exercises/all-exercises.tsx
+++ b/apps/web/src/components/math-skills/exercises/all-exercises.tsx
@@ -248,7 +248,7 @@ export const allExercises = {
         render={(inputs, data) => {
           return (
             <>
-              <h2 className="pb-5 text-2xl text-almost-black">
+              <h2 className="mr-12 pb-5 text-2xl text-almost-black">
                 Ergänze die fehlenden Zahlen:
               </h2>
               <div className="flex flex-col gap-3 text-sm font-bold text-almost-black mobile:flex-row">

--- a/apps/web/src/components/math-skills/feedback/execise-feedback.tsx
+++ b/apps/web/src/components/math-skills/feedback/execise-feedback.tsx
@@ -55,7 +55,7 @@ export function ExerciseFeedback({
   }, [isChecked, isCorrect, noUserInput])
 
   return (
-    <div className="mt-5 min-h-[120px] sm:flex sm:min-h-[80px] sm:items-center sm:justify-between">
+    <div className="mt-5 flex min-h-[120px] flex-col items-center sm:min-h-[80px] sm:flex-row sm:justify-between">
       <div className="text-almost-black">
         {isChecked ? (
           <p>

--- a/apps/web/src/components/math-skills/landing-animal.tsx
+++ b/apps/web/src/components/math-skills/landing-animal.tsx
@@ -18,7 +18,7 @@ export function LandingAnimal() {
   }
 
   return (
-    <figure className="relative mx-auto mt-4 w-fit self-start sm:mx-0 sm:-mt-1">
+    <figure className="relative mx-auto mt-1 w-fit self-start sm:mx-0 sm:-mt-6">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         alt="Tiermaskottchen"

--- a/apps/web/src/components/math-skills/landing/welcome-section.tsx
+++ b/apps/web/src/components/math-skills/landing/welcome-section.tsx
@@ -1,0 +1,54 @@
+import { LandingAnimal } from '../landing-animal'
+import { NameInput } from '../name-input'
+import { getPointsAmount } from '../utils/get-points-amount'
+import { useMathSkillsStorage } from '../utils/math-skills-data-context'
+
+export function WelcomeSection() {
+  const { data } = useMathSkillsStorage()
+  const allPoints = [...data.exercises.values()].reduce((all, current) => {
+    return (all += getPointsAmount(current.skillCent))
+  }, 0)
+
+  return (
+    <>
+      <LandingAnimal />
+      <div className="mx-auto mb-6 mt-2 text-lg sm:mx-0 sm:w-[26rem] sm:leading-relaxed">
+        {data?.name ? (
+          <>
+            Hallo <b>{data.name}</b>,
+            <br />
+            schön, dass du hier bist.
+            {allPoints ? (
+              <>
+                <br />
+                <br />
+                Du hast schon <b>{allPoints}</b> Skill-Punkte gesammelt 🎉
+              </>
+            ) : null}
+            <br />
+            <br />
+            <b>{allPoints ? "Jetzt geht's weiter" : 'Jetzt bist du dran'}:</b>
+            <br />
+            Zeige, welche Mathe-Skills du drauf hast!
+          </>
+        ) : (
+          <>
+            <b>Willkommen!</b>
+            <br />
+            <br />
+            Hier geht es darum, Mathe zu können und das zu zeigen. Das dürfen
+            auch kleine Sachen sein.
+            <br />
+            Jeder Skill gibt Vertrauen, weiterzulernen.
+            <br />
+            Schritt für Schritt.
+            <br />
+            <br />
+            <b>Wie heißt du?</b>
+            <NameInput />
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-header.tsx
+++ b/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-header.tsx
@@ -1,3 +1,5 @@
+import { FaIcon } from '@editor/package'
+import { faListDots } from '@fortawesome/free-solid-svg-icons'
 import { useRouter } from 'next/router'
 
 import { SkillPoints } from './skill-points'
@@ -8,7 +10,6 @@ import { cn } from '@/helper/cn'
 export function MathSkillsHeader() {
   const router = useRouter()
   const isExercise = !!router.query.exercise
-  const grade = String(router.query.grade)
   const { data } = useMathSkillsStorage()
   const isGradePage = !isExercise && !!router.query.grade
   const isLanding = !isGradePage && !isExercise
@@ -44,8 +45,7 @@ export function MathSkillsHeader() {
         href={`/meine-mathe-skills/${String(router.query.grade)}`}
         className={className}
       >
-        <span className="hidden sm:inline">zur </span>
-        Auswahl ({grade.replace('klasse', '')}.)
+        <FaIcon icon={faListDots} /> Aufgaben
       </Link>
     ) : (
       <Link href="/meine-mathe-skills" className={className}>

--- a/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-header.tsx
+++ b/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-header.tsx
@@ -1,10 +1,10 @@
-import { FaIcon } from '@editor/package'
 import { faListDots } from '@fortawesome/free-solid-svg-icons'
 import { useRouter } from 'next/router'
 
 import { SkillPoints } from './skill-points'
 import { Link } from '../../content/link'
 import { useMathSkillsStorage } from '../utils/math-skills-data-context'
+import { FaIcon } from '@/components/fa-icon'
 import { cn } from '@/helper/cn'
 
 export function MathSkillsHeader() {

--- a/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-wrapper.tsx
+++ b/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-wrapper.tsx
@@ -71,15 +71,7 @@ export function MathSkillsWrapper({ children }: { children: ReactNode }) {
             <div></div>
           ) : (
             <span>
-              <button
-                onClick={() => {
-                  deleteStored()
-                  setData(getEmptyData())
-                }}
-              >
-                (daten löschen)
-              </button>
-              <label className="ml-2">
+              <label className="mr-2">
                 <input
                   type="checkbox"
                   className="mr-2"
@@ -95,9 +87,26 @@ export function MathSkillsWrapper({ children }: { children: ReactNode }) {
                 />
                 Fortschritt auf diesem Gerät speichern
               </label>
+              <button
+                onClick={() => {
+                  deleteStored()
+                  setData(getEmptyData())
+                }}
+                className="text-gray-400"
+              >
+                (daten löschen)
+              </button>
             </span>
           )}
           <div>
+            <span className="group relative mr-4 text-gray-400 hover:underline">
+              <a href="https://www.freepik.com/free-vector/collection-cute-animals-wearing-graduation-cap-cartoon-style-vector_3780561.htm#query=animal%20illustration&position=1&from_view=keyword&track=ais&uuid=7991b85d-fd28-4da4-8e08-29af073982df">
+                Bildquelle
+              </a>
+              <span className="pointer-events-none absolute -right-1.5 -top-10 hidden w-max rounded-md bg-gray-200 px-2 py-1 text-almost-black group-focus-within:block group-hover:block">
+                Tierbilder von rawpixel.com (Freepik)
+              </span>
+            </span>
             <a className="hover:underline" href="https://de.serlo.org/legal">
               Impressum
             </a>
@@ -107,14 +116,6 @@ export function MathSkillsWrapper({ children }: { children: ReactNode }) {
             >
               Datenschutz
             </a>
-            {isLanding && (
-              <span className="ml-4 opacity-50 hover:underline">
-                <a href="https://www.freepik.com/free-vector/collection-cute-animals-wearing-graduation-cap-cartoon-style-vector_3780561.htm#query=animal%20illustration&position=1&from_view=keyword&track=ais&uuid=7991b85d-fd28-4da4-8e08-29af073982df">
-                  Bild von rawpixel.com
-                </a>{' '}
-                (Freepik){' '}
-              </span>
-            )}
           </div>
         </footer>
       </MathSkillsProvider>

--- a/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-wrapper.tsx
+++ b/apps/web/src/components/math-skills/math-skills-wrapper/math-skills-wrapper.tsx
@@ -62,11 +62,11 @@ export function MathSkillsWrapper({ children }: { children: ReactNode }) {
       />
       <MathSkillsProvider value={{ data, updateData }}>
         {/* This div here is for the outer flexbox */}
-        <div>
+        <div className="min-h-[calc(100vh-8.5rem)] text-almost-black">
           <MathSkillsHeader />
           {children}
         </div>
-        <footer className="mb-3 ml-3 mt-auto flex flex-col justify-between px-3 text-gray-700 sm:flex-row">
+        <footer className="mb-3 ml-3 mt-24 flex flex-col justify-between px-3 text-gray-700 sm:h-7 sm:flex-row">
           {isProduction || isExercise ? (
             <div></div>
           ) : (
@@ -121,17 +121,6 @@ export function MathSkillsWrapper({ children }: { children: ReactNode }) {
       <style jsx global>{`
         html {
           background-color: white !important;
-        }
-        body,
-        html,
-        #__next {
-          min-height: 100%;
-        }
-        #__next {
-          min-height: 100vh;
-          display: flex;
-          flex-direction: column;
-          justify-content: space-between;
         }
       `}</style>
     </>

--- a/apps/web/src/components/math-skills/name-input.tsx
+++ b/apps/web/src/components/math-skills/name-input.tsx
@@ -8,7 +8,7 @@ export function NameInput() {
   const [nameValue, setNameValue] = useState('')
 
   const trimmedName = nameValue.trim()
-  const hasName = trimmedName.length > 2
+  const hasName = trimmedName.length >= 2
 
   return (
     <>

--- a/apps/web/src/components/math-skills/topic-overview/grade-5-data.ts
+++ b/apps/web/src/components/math-skills/topic-overview/grade-5-data.ts
@@ -1,6 +1,6 @@
 import { SupportedExercisesId } from '../exercises/all-exercises'
 
-interface GradeTopicData {
+export interface GradeTopicData {
   title: string
   children: {
     title: string

--- a/apps/web/src/components/math-skills/topic-overview/todays-exercise.tsx
+++ b/apps/web/src/components/math-skills/topic-overview/todays-exercise.tsx
@@ -1,0 +1,27 @@
+import { grade5Data } from './grade-5-data'
+import { animalsData } from '../utils/animal-data'
+import { useMathSkillsStorage } from '../utils/math-skills-data-context'
+import { Link } from '@/components/content/link'
+
+export function TodaysExercise() {
+  const { data } = useMathSkillsStorage()
+  const selection = grade5Data[0].children
+  const index = Math.max(
+    Math.floor((new Date().getDate() * selection.length) / 31),
+    selection.length
+  )
+  const todaysTopic = selection.at(index) ?? selection[0]
+  const { id } = todaysTopic.children[0]
+  return (
+    <div className="h-fit w-full rounded-lg border border-brand-200 bg-newgreen bg-opacity-30 p-4 text-lg sm:basis-[33.2rem] lg:w-auto lg:basis-auto">
+      {data?.animal ? animalsData[data.animal].emoji : ''} Zu viel Auswahl?
+      <br /> Mach die Aufgabe des Tages:
+      <br />{' '}
+      <b>
+        <Link href={`/meine-mathe-skills/klasse5/${id}`}>
+          {todaysTopic.title}
+        </Link>
+      </b>
+    </div>
+  )
+}

--- a/apps/web/src/components/math-skills/topic-overview/topic-overview.tsx
+++ b/apps/web/src/components/math-skills/topic-overview/topic-overview.tsx
@@ -1,39 +1,55 @@
-import { grade5Data } from './grade-5-data'
+import { Fragment, useEffect } from 'react'
+
+import { GradeTopicData, grade5Data } from './grade-5-data'
+import { TodaysExercise } from './todays-exercise'
 import { TopicItem } from './topic-item'
 
 export function TopicOverview() {
+  useEffect(() => {
+    if (window.innerWidth > 1215) {
+      document.querySelectorAll('details').forEach((elem) => {
+        if (elem) elem.open = true
+      })
+    }
+  }, [])
+
   return (
-    <div className="flex flex-wrap justify-center gap-x-4 gap-y-8 pb-10 pt-3 mobileExt:flex-nowrap">
-      {grade5Data.map((area) => {
-        return (
-          <div
-            key={area.title}
-            className="h-fit w-72 rounded-lg border border-brand-200 p-5 shadow-menu"
-          >
-            <h3 className="pb-2 text-xl"> {area.title}</h3>
-            {area.children.map((subsection) => {
-              return (
-                <>
-                  <h4 className="mt-2 text-base font-bold">
-                    {subsection.title}
-                  </h4>
-                  <ul className="-ml-0.25 mt-1.5 flex flex-wrap gap-x-2 gap-y-0">
-                    {subsection.children.map((item) => {
-                      return (
-                        <TopicItem
-                          key={item.id}
-                          exerciseId={item.id}
-                          text={item.text}
-                        />
-                      )
-                    })}
-                  </ul>
-                </>
-              )
-            })}
-          </div>
-        )
-      })}
+    <div className="flex flex-col gap-4 pb-10 pt-3 sm:flex-row sm:flex-wrap">
+      {renderCard(grade5Data[0])}
+      {renderCard(grade5Data[1])}
+      <TodaysExercise />
+      {grade5Data.slice(2).map(renderCard)}
     </div>
   )
+
+  function renderCard(area: GradeTopicData) {
+    return (
+      <details
+        key={area.title}
+        className="h-fit w-full rounded-lg border border-brand-200 p-4 pb-3 shadow-menu sm:w-64 lg:w-60"
+      >
+        <summary>
+          <h3 className="inline-block pb-2 text-xl"> {area.title}</h3>
+        </summary>
+        {area.children.map((subsection) => {
+          return (
+            <Fragment key={subsection.title}>
+              <h4 className="mt-2 text-base font-bold">{subsection.title}</h4>
+              <ul className="-ml-0.25 mt-1.5 flex flex-wrap gap-x-2 gap-y-0">
+                {subsection.children.map((item) => {
+                  return (
+                    <TopicItem
+                      key={item.id}
+                      exerciseId={item.id}
+                      text={item.text}
+                    />
+                  )
+                })}
+              </ul>
+            </Fragment>
+          )
+        })}
+      </details>
+    )
+  }
 }

--- a/apps/web/src/pages/meine-mathe-skills/[grade]/[exercise].tsx
+++ b/apps/web/src/pages/meine-mathe-skills/[grade]/[exercise].tsx
@@ -52,8 +52,10 @@ function Content() {
   if (!data) return null
 
   return (
-    <div className="relative mx-4 mt-20 max-w-lg bg-white sm:mx-auto sm:w-full">
-      <h2 className="text-md mb-9 font-bold text-gray-400">
+    <div className="relative mx-4 mt-10 max-w-lg bg-white mobileExt:mx-auto sm:w-full">
+      {data.component}
+
+      <h2 className="text-md mb-5 mt-9 font-bold">
         {data.title}
         {data.level ? (
           <>
@@ -61,11 +63,8 @@ function Content() {
           </>
         ) : null}
       </h2>
-      {data.component}
       {data.smallprint ? (
-        <div className="mb-12 mt-14 hyphens-auto leading-snug">
-          {data.smallprint}
-        </div>
+        <div className="mb-12 hyphens-auto leading-snug">{data.smallprint}</div>
       ) : null}
     </div>
   )

--- a/apps/web/src/pages/meine-mathe-skills/[grade]/index.tsx
+++ b/apps/web/src/pages/meine-mathe-skills/[grade]/index.tsx
@@ -2,6 +2,7 @@ import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 
 import { FrontendClientBase } from '@/components/frontend-client-base'
+import { WelcomeSection } from '@/components/math-skills/landing/welcome-section'
 import { MathSkillsWrapper } from '@/components/math-skills/math-skills-wrapper/math-skills-wrapper'
 import { TopicOverview } from '@/components/math-skills/topic-overview/topic-overview'
 
@@ -27,18 +28,21 @@ function Content() {
   if (grade !== 'klasse5') return null
 
   return (
-    <div className="min-h-[80vh]">
-      <div className="text-center">
-        <div className="mt-16 flex justify-center text-2xl font-bold">
-          <div className="flex h-36 w-36 items-center justify-center rounded-full bg-brand-600 text-white">
-            <p className="text-2xl">5. Klasse</p>
-          </div>
+    <>
+      <div className="mx-4 max-w-md mobile:mx-auto sm:mt-10 lg:max-w-xl">
+        <div className="sm:flex sm:flex-row-reverse sm:items-center">
+          <WelcomeSection />
         </div>
-        <h2 className="mb-8 mt-5 text-2xl font-bold">Aufgabenauswahl</h2>
+        <h2 className="mt-10 text-xl">
+          {/* should be select when there are more grades to select */}
+          Übersicht <b className="text-newgreen">Klasse 5</b>:
+        </h2>
       </div>
-      <TopicOverview />
-      <div className="h-72"></div>
-    </div>
+      <div className="mx-4 max-w-md mobile:mx-auto sm:mt-2 sm:max-w-2xl sm:pl-28 lg:max-w-5xl lg:pl-[14.2rem]">
+        <TopicOverview />
+        <div className="h-24"></div>
+      </div>
+    </>
   )
 }
 

--- a/apps/web/src/pages/meine-mathe-skills/index.tsx
+++ b/apps/web/src/pages/meine-mathe-skills/index.tsx
@@ -1,13 +1,11 @@
-/* eslint-disable @next/next/no-before-interactive-script-outside-document */
 import { NextPage } from 'next'
+import { useRouter } from 'next/router'
 
-import { Link } from '@/components/content/link'
 import { FrontendClientBase } from '@/components/frontend-client-base'
-import { LandingAnimal } from '@/components/math-skills/landing-animal'
+import { WelcomeSection } from '@/components/math-skills/landing/welcome-section'
 import { MathSkillsWrapper } from '@/components/math-skills/math-skills-wrapper/math-skills-wrapper'
-import { NameInput } from '@/components/math-skills/name-input'
-import { getPointsAmount } from '@/components/math-skills/utils/get-points-amount'
 import { useMathSkillsStorage } from '@/components/math-skills/utils/math-skills-data-context'
+import { cn } from '@/helper/cn'
 
 const ContentPage: NextPage = () => {
   return (
@@ -25,70 +23,37 @@ const ContentPage: NextPage = () => {
 }
 
 function Content() {
+  const router = useRouter()
   const { data } = useMathSkillsStorage()
-  const allPoints = [...data.exercises.values()].reduce((all, current) => {
-    return (all += getPointsAmount(current.skillCent))
-  }, 0)
 
   return (
-    <div>
-      <div className="mx-4 justify-center sm:mt-10 sm:flex sm:flex-row-reverse sm:items-center">
-        <LandingAnimal />
-        <div className="mx-auto mb-6 mt-4 min-h-[22rem] max-w-[26rem] text-lg sm:mx-0 sm:w-[26rem] sm:leading-relaxed">
-          {data?.name ? (
-            <>
-              <br />
-              <br />
-              Hallo <b>{data.name}</b>,
-              <br />
-              schön, dass du hier bist.
-              {allPoints ? (
-                <>
-                  <br />
-                  <br />
-                  Du hast schon <b>{allPoints}</b> Skill-Punkte gesammelt 🎉
-                </>
-              ) : null}
-              <br />
-              <br />
-              <b>{allPoints ? "Jetzt geht's weiter" : 'Jetzt bist du dran'}:</b>
-              <br />
-              Zeige, welche Mathe-Skills du drauf hast!
-            </>
-          ) : (
-            <>
-              <b>Willkommen!</b>
-              <br />
-              <br />
-              Hier geht es darum, Mathematik zu können und das zu zeigen. Das
-              dürfen auch kleine Sachen sein.
-              <br />
-              Jeder Skill gibt Vertrauen, weiterzulernen.
-              <br />
-              Schritt für Schritt.
-              <br />
-              <br />
-              <b>Wie heißt du?</b>
-              <NameInput />
-            </>
-          )}
-        </div>
+    <div className="mx-4 max-w-md mobile:mx-auto sm:mt-10 lg:max-w-xl">
+      <div className="sm:flex sm:flex-row-reverse sm:items-center sm:justify-center">
+        <WelcomeSection />
       </div>
-      {data?.name && (
+      {data?.name ? (
         <>
-          <div className="mx-4 mt-2 text-2xl font-bold mobile:flex mobile:justify-center">
-            <h2>Wähle eine Klassenstufe</h2>
-          </div>
-          <div className="mb-8 mt-6 flex justify-center text-2xl font-bold sm:mt-8">
-            <Link
+          <h2 className="mt-10 text-lg font-bold">Wähle eine Klassenstufe:</h2>
+          <div className="mb-8 mt-4 flex pr-4 text-lg font-bold">
+            <a
               href="/meine-mathe-skills/klasse5"
-              className="flex h-36 w-36 items-center justify-center rounded-full bg-brand-600 text-center  text-white !no-underline transition-colors hover:bg-brand-500"
+              onClick={(e) => {
+                e.preventDefault()
+                void router.push('/meine-mathe-skills/klasse5', undefined, {
+                  shallow: true,
+                  scroll: false,
+                })
+              }}
+              className={cn(`
+                flex h-24 w-24 items-center justify-center rounded-full bg-newgreen bg-opacity-30
+              text-almost-black !no-underline transition-colors hover:bg-opacity-70 md:h-28 md:w-28
+              `)}
             >
-              <p className="text-2xl">5. Klasse</p>
-            </Link>
+              <p>5. Klasse</p>
+            </a>
           </div>
         </>
-      )}
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
I mostly worked on the mobile layout but threw in some ux ideas from the first user test.

changes:
- better use of screen space on mobile
- layout is more compact, but footer always stays at the bottom
- points always show (so it's easier to know that there will be three)
- "zur Übersicht" is now "☰ Aufgaben"
- points now replace the title in the header on mobile (more space for exercise)

topic overview:
- reuse welcome section for topic overview (makes it more personal) (could also be a state if we like it)
- cards use `<details>` now and are folded by default on smaller screens
- new feature: exercise of the day for an easy start

@Entkenntnis I did note merge it yet because it contains so many changes and I was not sure you'd like all of them :)