### PR TITLE
feat(editor-integration): add license chooser to save modal (keep)

### DIFF
--- a/apps/web/src/serlo-editor-integration/components/license-chooser.tsx
+++ b/apps/web/src/serlo-editor-integration/components/license-chooser.tsx
@@ -44,7 +44,7 @@ export function LicenseChooser({ licenseId }: LicenseChooserProps) {
         key={license.id}
         value={license.id}
       >
-        {license.id} {license.title}
+        {license.id} {license.shortTitle}
       </option>
     )
   }

--- a/apps/web/src/serlo-editor-integration/components/license-chooser.tsx
+++ b/apps/web/src/serlo-editor-integration/components/license-chooser.tsx
@@ -1,0 +1,51 @@
+import type { StateTypeReturnType } from '@editor/plugin'
+import { entity } from '@editor/plugins/serlo-template-plugins/common/common'
+
+import { useInstanceData } from '@/contexts/instance-context'
+import { useLoggedInData } from '@/contexts/logged-in-data-context'
+import { getDefaultLicense } from '@/data/licenses/licenses-helpers'
+import { LicenseData } from '@/data-types.js'
+
+export interface LicenseChooserProps {
+  licenseId?: StateTypeReturnType<(typeof entity)['licenseId']>
+}
+
+export function LicenseChooser({ licenseId }: LicenseChooserProps) {
+  const { licenses } = useInstanceData()
+  const loggedInData = useLoggedInData()
+  if (!loggedInData) return null
+
+  return (
+    <label className="mb-4 block">
+      <b>{loggedInData.strings.authorMenu.changeLicense}:</b>
+      <br />
+      <select
+        value={
+          licenseId?.defined ? licenseId.value : getDefaultLicense(licenses).id
+        }
+        className="serlo-button-light serlo-input-font-reset -ml-1 max-w-xl"
+        onChange={(e) => {
+          if (licenseId?.defined) {
+            licenseId.set(parseInt(e.target.value))
+          } else {
+            licenseId?.create(parseInt(e.target.value))
+          }
+        }}
+      >
+        {licenses.map(renderOption)}
+      </select>
+    </label>
+  )
+
+  function renderOption(license: LicenseData) {
+    return (
+      <option
+        className="bg-brand-200 text-brand"
+        key={license.id}
+        value={license.id}
+      >
+        {license.id} {license.title}
+      </option>
+    )
+  }
+}


### PR DESCRIPTION
works quite well, unfortunately the backend currently ignores the setting 🤌