### PR TITLE
fix(exams-info-box): Fix layout

### DIFF
--- a/apps/web/shared/tailwind-base.js
+++ b/apps/web/shared/tailwind-base.js
@@ -163,6 +163,7 @@ export default {
       md: '1024px',
       lg: '1216px',
       xl: '1300px',
+      '2xl': '1436px',
       print: { raw: 'print' },
     },
   },

--- a/apps/web/src/components/exams-info-box.tsx
+++ b/apps/web/src/components/exams-info-box.tsx
@@ -14,8 +14,8 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
       <div
         className={cn(
           'mt-8 sm:-ml-side',
-          'lg:absolute lg:left-side lg:top-9 lg:z-10 lg:w-[225px]',
-          'xl:left-side xl:w-[270px]'
+          'xl:absolute xl:left-side xl:top-9 xl:z-10 xl:w-[200px]',
+          '2xl:w-[270px]'
         )}
       >
         <BoxRenderer
@@ -33,7 +33,7 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
                 <br />
                 <br />
               </p>
-              <div className="sm:flex md:block">
+              <div className="sm:flex xl:block">
                 <p className="serlo-p !text-sm">
                   <b>
                     Weitere Bundesländer{' '}
@@ -52,7 +52,7 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
                       className={cn(
                         'mr-1 text-brand-400',
                         'xl:mr-2 xl:mt-3 xl:text-3xl',
-                        'md:hidden xl:block'
+                        'xl:hidden'
                       )}
                     />
                     <span>
@@ -77,7 +77,7 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
                       className={cn(
                         'mr-1 text-brand-400',
                         'xl:mr-2 xl:mt-1 xl:text-3xl',
-                        'md:hidden xl:block'
+                        'xl:block xl:hidden'
                       )}
                     />
                     <span>Prüfungen-Discord</span>
@@ -86,7 +86,7 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
               </div>
             </div>
             {!isInBYTax ? ( // only for niedersachsen
-              <div className="serlo-p mb-1 mt-10 border-t pt-2 text-sm font-normal">
+              <div className="serlo-p mb-1 border-t pt-2 text-sm font-normal xl:mt-10">
                 Wichtig: Für die Aufgaben hier gelten{' '}
                 <Link href="/license/detail/26">andere Nutzungbedingungen</Link>
                 .

--- a/apps/web/src/components/exams-info-box.tsx
+++ b/apps/web/src/components/exams-info-box.tsx
@@ -14,12 +14,15 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
       <div
         className={cn(
           'mt-8 sm:-ml-side',
-          'md:absolute md:left-side md:top-9 md:z-10 md:w-[180px]',
-          'lg:w-[220px]',
-          'bg-white xl:left-side xl:w-[245px]'
+          'lg:absolute lg:left-side lg:top-9 lg:z-10 lg:w-[225px]',
+          'xl:left-side xl:w-[270px]'
         )}
       >
-        <BoxRenderer boxType="blank" anchorId="exams-info-box">
+        <BoxRenderer
+          boxType="blank"
+          anchorId="exams-info-box"
+          className="bg-white"
+        >
           <>
             <div className="">
               <p className="serlo-p mb-0 max-w-lg font-normal leading-normal">

--- a/apps/web/src/components/exams-info-box.tsx
+++ b/apps/web/src/components/exams-info-box.tsx
@@ -14,9 +14,9 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
       <div
         className={cn(
           'mt-8 sm:-ml-side',
-          'md:absolute md:left-side md:top-9 md:z-10 md:w-[200px]',
+          'md:absolute md:left-side md:top-9 md:z-10 md:w-[180px]',
           'lg:w-[220px]',
-          'xl:left-side xl:w-[245px]'
+          'bg-white xl:left-side xl:w-[245px]'
         )}
       >
         <BoxRenderer boxType="blank" anchorId="exams-info-box">

--- a/apps/web/src/helper/breakpoints.ts
+++ b/apps/web/src/helper/breakpoints.ts
@@ -5,4 +5,5 @@ export const breakpoints = {
   md: '1024px',
   lg: '1216px',
   xl: '1300px',
+  '2xl': '1436px',
 }

--- a/packages/editor/src/plugins/box/renderer.tsx
+++ b/packages/editor/src/plugins/box/renderer.tsx
@@ -34,9 +34,16 @@ interface BoxProps {
   anchorId: string
   children: JSX.Element
   title?: JSX.Element | string
+  className?: string
 }
 
-export function BoxRenderer({ boxType, title, anchorId, children }: BoxProps) {
+export function BoxRenderer({
+  boxType,
+  title,
+  anchorId,
+  children,
+  className,
+}: BoxProps) {
   const { strings } = useInstanceData()
   if (!children || !boxType) return null
 
@@ -57,7 +64,8 @@ export function BoxRenderer({ boxType, title, anchorId, children }: BoxProps) {
           [&>div.my-block]:first:mt-3.5
           [&>div.my-block]:last:mb-3.5
         `,
-        isAttention ? 'border-red-100' : 'border-brand-200'
+        isAttention ? 'border-red-100' : 'border-brand-200',
+        className
       )}
     >
       <figcaption className="px-side pt-2.5 text-lg">


### PR DESCRIPTION
Quick fix for two layout issues with the exams-info-box, see: 
![image](https://github.com/serlo/frontend/assets/59921805/4a84ab94-908f-4feb-836c-be033df1b689)
![image](https://github.com/serlo/frontend/assets/59921805/0fce85b5-fef5-47d3-b12e-947ee1f15c9d)
