### PR TITLE
fix(plugin-blanks): alternative answers safari focus bug

### DIFF
--- a/packages/editor/src/plugins/blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/blank-renderer.tsx
@@ -154,6 +154,7 @@ export function BlankRenderer(props: BlankRendererProps) {
   }
 
   function handleAlternativeAnswerAdd() {
+    ReactEditor.blur(editor)
     setCorrectAnswers([...correctAnswers, { answer: '' }])
   }
 

--- a/packages/editor/src/store/focus/slice.ts
+++ b/packages/editor/src/store/focus/slice.ts
@@ -24,9 +24,9 @@ export const focusSlice = createSlice({
     },
     focusPrevious(state, action: PayloadAction<ChildTreeNode | null>) {
       if (!state || !action.payload) return state
-      const next = findPreviousChildTreeNode(action.payload, state)
-      if (!next) return state
-      return next
+      const previous = findPreviousChildTreeNode(action.payload, state)
+      if (!previous) return state
+      return previous
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
Slate focus management didn't work reliably in Safari, so blurring the Slate editor manually when adding an alternative answer.

Fix for: https://trello.com/c/u7osCXuw/626-bug-vom-editor-auf-ipad