### PR TITLE
fix(plugin-equations): hide transformation for term equation

### DIFF
--- a/packages/editor/src/plugins/equations/renderer.tsx
+++ b/packages/editor/src/plugins/equations/renderer.tsx
@@ -54,7 +54,7 @@ export function EquationsRenderer({
             'text-left'
           )}
           {renderTD(
-            step.transform ? (
+            transformationTarget !== 'term' && step.transform ? (
               <span className="border-l border-black pl-1">
                 {renderStepFormula('transform')}
               </span>


### PR DESCRIPTION
Fix for: https://trello.com/c/T7wsqBqh/627-kleiner-bug-bei-termumformungs-pluggin

@kulla @elbotho Could you please check [the preview](https://frontend-git-fix-transformation-visible-in-term-eq-b6a90d-serlo.vercel.app/entity/repository/add-revision/304018) to confirm if I fixed this properly, as I'm still not 100% sure that I understood the problem.