### PR TITLE
Fix(geogebra): Make multiple geogebra work in `serlo-editor-for-edusharing`

### DIFF
--- a/packages/editor/src/plugins/geogebra/editor.tsx
+++ b/packages/editor/src/plugins/geogebra/editor.tsx
@@ -30,7 +30,7 @@ export function GeogebraEditor(props: GeogebraProps) {
           embedUrl={url}
           className={!focused ? 'pointer-events-none' : ''}
         >
-          <GeogebraRenderer url={url} geogebraId={cleanId} />
+          <GeogebraRenderer geogebraId={cleanId} />
         </EmbedWrapper>
       ) : (
         <div

--- a/packages/editor/src/plugins/geogebra/renderer.tsx
+++ b/packages/editor/src/plugins/geogebra/renderer.tsx
@@ -1,56 +1,88 @@
-import Script from 'next/script'
-import { useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { v4 as uuid_v4 } from 'uuid'
 
 import { cn } from '@/helper/cn'
 
 export interface GeogebraRendererProps {
   geogebraId: string
-  url: string
 }
 
-export function GeogebraRenderer({ geogebraId, url }: GeogebraRendererProps) {
+// Only re-render if props.geogebraId changes. Reason: Geogebra applet has its own state that is not managed by react. On re-render this state would get lost, meaning the applet would reset.
+export const GeogebraRenderer = memo(
+  GeogebraRenderer_,
+  (previousProps, nextProps) =>
+    previousProps.geogebraId === nextProps.geogebraId
+)
+
+function GeogebraRenderer_({ geogebraId }: GeogebraRendererProps) {
   const [uuid] = useState(uuid_v4())
   const elementId = `ggb-element-${uuid}`
   const containerId = `${elementId}-container`
 
+  // Inject geogebra applet into dom
+  useEffect(() => {
+    const geogebraAvailable = Object.hasOwn(globalThis, 'GGBApplet')
+    if (geogebraAvailable) {
+      injectGeogebra()
+    } else {
+      fetchScriptAndInitializeGeogebra()
+        .then(injectGeogebra)
+        .catch(() =>
+          // eslint-disable-next-line no-console
+          console.error(
+            'Failed to fetch Geogebra script deployggb.js. Geogebra applet will not be visible.'
+          )
+        )
+    }
+
+    function injectGeogebra() {
+      // https://wiki.geogebra.org/en/Reference:GeoGebra_App_Parameters
+      const params = {
+        appName: '…',
+        showToolBar: false,
+        showAlgebraInput: false,
+        showMenuBar: false,
+        material_id: geogebraId,
+        showResetIcon: true,
+        enableLabelDrags: false,
+        enableShiftDragZoom: false,
+        enableRightClick: false,
+        capturingThreshold: null,
+        showToolBarHelp: false,
+        errorDialogsActive: true,
+        useBrowserForJS: false,
+        enableFileFeatures: false,
+        borderColor: 'transparent',
+        scaleContainerClass: containerId,
+      }
+
+      //@ts-expect-error no types for Geogebra script
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const applet = new globalThis.GGBApplet(params, true)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      applet.inject(elementId)
+    }
+
+    async function fetchScriptAndInitializeGeogebra() {
+      return new Promise<void>((resolve, reject) => {
+        // deployggb.js will define 'GGBApplet' on the global object. We use 'globalThis' instead of 'global' or 'window' for compatibility.
+        // https://javascript.info/global-object
+        // Using 'global' lead to error 'global not defined' in editor package when using vite.
+        const scriptTag = document.createElement('script')
+        scriptTag.src = 'https://www.geogebra.org/apps/deployggb.js'
+        scriptTag.addEventListener('load', () => {
+          resolve()
+        })
+        scriptTag.addEventListener('error', () => {
+          reject()
+        })
+        document.body.appendChild(scriptTag)
+      })
+    }
+  }, [geogebraId, containerId, elementId])
+
   return (
     <>
-      <Script
-        src="https://www.geogebra.org/apps/deployggb.js"
-        onReady={() => {
-          // https://wiki.geogebra.org/en/Reference:GeoGebra_App_Parameters
-          const params = {
-            appName: '…',
-            showToolBar: false,
-            showAlgebraInput: false,
-            showMenuBar: false,
-            material_id: geogebraId,
-            showResetIcon: true,
-            enableLabelDrags: false,
-            enableShiftDragZoom: false,
-            enableRightClick: false,
-            capturingThreshold: null,
-            showToolBarHelp: false,
-            errorDialogsActive: true,
-            useBrowserForJS: false,
-            enableFileFeatures: false,
-            borderColor: 'transparent',
-            scaleContainerClass: containerId,
-          }
-
-          // deployggb.js will define 'GGBApplet' on the global object. We use 'globalThis' instead of 'global' or 'window' for compatibility.
-          // https://javascript.info/global-object
-          // Using 'global' lead to error 'global not defined' in editor package when using vite.
-          if (Object.hasOwn(globalThis, 'GGBApplet')) {
-            //@ts-expect-error no types for Geogebra script
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-            const applet = new globalThis.GGBApplet(params, true)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            applet.inject(elementId)
-          }
-        }}
-      />
       <div className="aspect-[16/9] w-full overflow-hidden rounded-xl bg-brand-50 p-1">
         <div
           className={cn(
@@ -58,13 +90,11 @@ export function GeogebraRenderer({ geogebraId, url }: GeogebraRendererProps) {
             'flex h-full w-full flex-col justify-center'
           )}
         >
-          {url ? (
-            <div
-              id={elementId}
-              data-ggb-id={geogebraId}
-              className="mx-auto"
-            ></div>
-          ) : null}
+          <div
+            id={elementId}
+            data-ggb-id={geogebraId}
+            className="mx-auto"
+          ></div>
         </div>
       </div>
     </>

--- a/packages/editor/src/plugins/geogebra/static.tsx
+++ b/packages/editor/src/plugins/geogebra/static.tsx
@@ -2,6 +2,6 @@ import { GeogebraRenderer, parseId } from '@editor/plugins/geogebra/renderer'
 import { EditorGeogebraDocument } from '@editor/types/editor-plugins'
 
 export function GeogebraStaticRenderer({ state: id }: EditorGeogebraDocument) {
-  const { url, cleanId } = parseId(id)
-  return <GeogebraRenderer url={url} geogebraId={cleanId} />
+  const { cleanId } = parseId(id)
+  return <GeogebraRenderer geogebraId={cleanId} />
 }


### PR DESCRIPTION
**Before**: `<Script>` from nextjs did not call `onReady` for each geogebra instance. This meant some geogebra applets did not load. Could not make it work this way.

**After**: Using `document.body.appendChild` to attach and load the necessary geogebra script and then injecting the geogebra applet in a `useEffect`. Also removed `url` from `GeogebraRendererProps` because it is not used / necessary. 