### PR TITLE
feat(plugin-spoiler): add slate editor in title

### DIFF
--- a/packages/editor/src/plugins/spoiler/editor.tsx
+++ b/packages/editor/src/plugins/spoiler/editor.tsx
@@ -5,7 +5,7 @@ import { selectIsFocused, useAppSelector } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import type { SpoilerProps } from '.'
 import { SpoilerRenderer } from './renderer'
@@ -21,8 +21,13 @@ export function SpoilerEditor(props: SpoilerProps) {
   const { state, id, focused } = props
   const { title, richTitle, content } = state
   const editorStrings = useEditorStrings()
+  const richTitleId = useMemo(() => {
+    return richTitle.defined ? richTitle.id : ''
+    // richTitle.id should never change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [richTitle.defined])
   const isTitleFocused = useAppSelector((state) =>
-    selectIsFocused(state, richTitle.defined ? richTitle.id : '')
+    selectIsFocused(state, richTitleId)
   )
   const showToolbar = focused || isTitleFocused
 

--- a/packages/editor/src/plugins/spoiler/editor.tsx
+++ b/packages/editor/src/plugins/spoiler/editor.tsx
@@ -26,7 +26,8 @@ export function SpoilerEditor(props: SpoilerProps) {
   )
   const showToolbar = focused || isTitleFocused
 
-  // migrate old state
+  // Spoiler title used to be a string (`title`) and we now use an inline text-plugin instead (to allow math fomulas etc.)
+  // This effect migrates the old state to the new state, for entities that don't have the new state (`richText`) at load time.
   useEffect(() => {
     if (richTitle.defined) return
 

--- a/packages/editor/src/plugins/spoiler/editor.tsx
+++ b/packages/editor/src/plugins/spoiler/editor.tsx
@@ -1,40 +1,75 @@
 import { PluginToolbar } from '@editor/editor-ui/plugin-toolbar'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
+import { TextEditorFormattingOption } from '@editor/editor-ui/plugin-toolbar/text-controls/types'
+import { selectIsFocused, useAppSelector } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
+import { useEffect } from 'react'
 
 import type { SpoilerProps } from '.'
 import { SpoilerRenderer } from './renderer'
 
+const titleFormattingOptions = [
+  TextEditorFormattingOption.code,
+  TextEditorFormattingOption.math,
+  TextEditorFormattingOption.richTextBold,
+  TextEditorFormattingOption.richTextItalic,
+]
+
 export function SpoilerEditor(props: SpoilerProps) {
   const { state, id, focused } = props
+  const { title, richTitle, content } = state
   const editorStrings = useEditorStrings()
+  const isTitleFocused = useAppSelector((state) =>
+    selectIsFocused(state, richTitle.defined ? richTitle.id : '')
+  )
+  const showToolbar = focused || isTitleFocused
+
+  // migrate old state
+  useEffect(() => {
+    if (richTitle.defined) return
+
+    const newTitle = title.defined
+      ? {
+          plugin: EditorPluginType.Text,
+          state: [{ type: 'p', children: [{ text: title.value }] }],
+        }
+      : { plugin: EditorPluginType.Text }
+
+    richTitle.create(newTitle)
+  })
+
+  if (!richTitle.defined) return null
+
+  const titleConfig = {
+    config: {
+      placeholder: editorStrings.plugins.spoiler.enterATitle,
+      formattingOptions: titleFormattingOptions,
+      isInlineChildEditor: true,
+    },
+  }
 
   return (
     <>
       {renderPluginToolbar()}
       <div
         className={cn(
-          focused && '[&>div]:rounded-t-none',
+          showToolbar && '[&>div]:rounded-t-none',
+          // making space for first toolbar, not wysiwyg
+          '[&>div>button]:!mb-[17px]',
+          // toolbar finetuning
           `
-            [&>div>div]:mt-4
-            [&_.plugin-toolbar]:ml-[2px]
             [&_.plugin-toolbar]:rounded-none
             [&_.rows-child:first-child_.plugin-toolbar:before]:hidden
           `
         )}
       >
         <SpoilerRenderer
-          title={
-            <input
-              onChange={(e) => state.title.set(e.target.value)}
-              value={state.title.value}
-              placeholder={editorStrings.plugins.spoiler.enterATitle}
-              className="-my-1 w-full rounded-md bg-transparent p-1 focus:bg-brand-100 focus:outline-none"
-            />
-          }
-          content={state.content.render()}
+          title={<div className="grow">{richTitle.render(titleConfig)}</div>}
+          content={content.render({
+            config: { isInlineChildEditor: true },
+          })}
           openOverwrite // should check focused but that's unreliable atm.
         />
       </div>
@@ -42,7 +77,7 @@ export function SpoilerEditor(props: SpoilerProps) {
   )
 
   function renderPluginToolbar() {
-    if (!focused) return null
+    if (!showToolbar) return null
 
     return (
       <PluginToolbar

--- a/packages/editor/src/plugins/spoiler/index.ts
+++ b/packages/editor/src/plugins/spoiler/index.ts
@@ -7,11 +7,18 @@ import {
   type EditorPluginProps,
   object,
   string,
+  optional,
 } from '../../plugin'
 
 function createSpoilerState(config: SpoilerConfig) {
   return object({
-    title: string(''),
+    title: optional(string('')),
+    richTitle: optional(
+      child({
+        plugin: EditorPluginType.Text,
+        config: { noLinebreaks: true },
+      })
+    ),
     content: child({
       plugin: EditorPluginType.Rows,
       ...(config.allowedPlugins !== undefined && {

--- a/packages/editor/src/plugins/spoiler/renderer.tsx
+++ b/packages/editor/src/plugins/spoiler/renderer.tsx
@@ -34,7 +34,7 @@ export function SpoilerRenderer({
         onClick={() => handleSpoilerClick()}
         className={cn(
           `
-            serlo-input-font-reset z-10 m-0 border-none px-side py-2.5
+            serlo-input-font-reset m-0 border-none px-side py-2.5
             text-left text-lg leading-normal text-almost-black transition-colors
           `,
           isOpen ? 'bg-brand-200' : 'bg-brand-100'

--- a/packages/editor/src/plugins/spoiler/static.tsx
+++ b/packages/editor/src/plugins/spoiler/static.tsx
@@ -8,11 +8,17 @@ export function SpoilerStaticRenderer({
   openOverwrite,
   onOpen,
 }: EditorSpoilerDocument & { openOverwrite?: boolean; onOpen?: () => void }) {
-  const { title, content } = state
+  const { title, richTitle, content } = state
+
+  const renderedTitle = richTitle ? (
+    <StaticRenderer document={richTitle} />
+  ) : (
+    <>{title}</>
+  )
 
   return (
     <SpoilerRenderer
-      title={<>{title}</>}
+      title={renderedTitle}
       content={<StaticRenderer document={content} />}
       openOverwrite={openOverwrite}
       onOpen={onOpen}


### PR DESCRIPTION
requested some … years ago, 
should work without a db-migration (but would clean up code of course)

### [demo](https://frontend-git-spoiler-add-rich-title-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22spoiler%22%2C%22state%22%3A%7B%22richTitle%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22Spoilertitel+mit+%22%7D%2C%7B%22text%22%3A%22Bold%22%2C%22strong%22%3Atrue%7D%2C%7B%22text%22%3A%22%2C+%22%7D%2C%7B%22text%22%3A%22Italic%22%2C%22em%22%3Atrue%7D%2C%7B%22text%22%3A%22%2C+Formel+%22%7D%2C%7B%22type%22%3A%22math%22%2C%22src%22%3A%22%5C%5Cleft%28%5C%5Cfrac%7Bx%7D%7B2%7D%3D3%5C%5Cright%29%22%2C%22inline%22%3Atrue%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%2C%7B%22text%22%3A%22+und+%22%7D%2C%7B%22text%22%3A%22Code%22%2C%22code%22%3Atrue%7D%5D%7D%5D%2C%22id%22%3A%22a99a8034-dd44-49c9-8a3e-b08363d4c3ed%22%7D%2C%22content%22%3A%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22Inhalt%22%7D%5D%7D%5D%2C%22id%22%3A%22d77d0e73-7976-4f35-8b97-610df238bee2%22%7D%5D%2C%22id%22%3A%2218893e3a-a73d-4c44-946d-f8dd422cb876%22%7D%7D%2C%22id%22%3A%2295b091a6-6151-4078-9d65-ef37674e5faf%22%7D%5D%7D)
### [demo (normal editor)](https://frontend-git-spoiler-add-rich-title-serlo.vercel.app/entity/repository/add-revision/277232)