### PR TITLE
refactor(editor-export): Simplify API by using default values for config

### DIFF
--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -34,20 +34,20 @@ import { TemplatePluginType } from '@editor/types/template-plugin-type'
 export interface CreateBasicPluginsConfig {
   language?: SupportedLanguage
   allowedChildPlugins?: string[]
-  exerciseVisibleInSuggestion: boolean
+  exerciseVisibleInSuggestion?: boolean
   enableTextAreaExercise?: boolean
-  allowImageInTableCells: boolean
+  allowImageInTableCells?: boolean
   multimediaConfig?: MultimediaConfig
 }
 
 export function createBasicPlugins({
   language = 'de',
   enableTextAreaExercise = false,
-  exerciseVisibleInSuggestion,
+  exerciseVisibleInSuggestion = true,
+  allowImageInTableCells = true,
   allowedChildPlugins,
-  allowImageInTableCells,
   multimediaConfig,
-}: CreateBasicPluginsConfig) {
+}: CreateBasicPluginsConfig = {}) {
   const editorStrings = editorData[language].loggedInData.strings.editor
 
   return [

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -25,7 +25,7 @@ import '@/assets-webkit/styles/serlo-tailwind.css'
 // Custom plugins and renderers are an Edusharing specific feature,
 // and will not be supported in the future
 export interface PluginsConfig {
-  basicPluginsConfig: CreateBasicPluginsConfig
+  basicPluginsConfig?: CreateBasicPluginsConfig
   customPlugins?: Array<PluginWithData & PluginStaticRenderer>
 }
 

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -31,7 +31,7 @@ export interface PluginsConfig {
 
 export interface SerloEditorProps {
   children: EditorProps['children']
-  pluginsConfig: PluginsConfig
+  pluginsConfig?: PluginsConfig
   initialState?: EditorProps['initialState']
   language?: SupportedLanguage
 }
@@ -49,7 +49,7 @@ const emptyState = {
 /** For exporting the editor */
 export function SerloEditor(props: SerloEditorProps) {
   const { children, pluginsConfig, initialState, language = 'de' } = props
-  const { basicPluginsConfig, customPlugins = [] } = pluginsConfig
+  const { basicPluginsConfig, customPlugins = [] } = pluginsConfig || {}
   const { instanceData, loggedInData } = editorData[language]
 
   const basicPlugins = createBasicPlugins(basicPluginsConfig)

--- a/packages/editor/src/package/serlo-renderer.tsx
+++ b/packages/editor/src/package/serlo-renderer.tsx
@@ -10,7 +10,7 @@ import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
 
 export interface SerloRendererProps {
-  pluginsConfig: PluginsConfig
+  pluginsConfig?: PluginsConfig
   language?: SupportedLanguage
   document?: AnyEditorDocument | AnyEditorDocument[]
 }
@@ -20,7 +20,7 @@ export function SerloRenderer({
   language = 'de',
   ...props
 }: SerloRendererProps) {
-  const { customPlugins = [] } = pluginsConfig
+  const { customPlugins = [] } = pluginsConfig || {}
   const { instanceData, loggedInData } = editorData[language]
 
   const basicRenderers = createRenderers(customPlugins)


### PR DESCRIPTION
Default values should allow us to change the API from

```TSX
<SerloEditor
  initialState={initialState}
  pluginsConfig={{
    basicPluginsConfig: {
      allowImageInTableCells: true,
      exerciseVisibleInSuggestion: true,
    },
  }}
>
```

to:

```TSX
<SerloEditor
  initialState={initialState}
>
```