### PR TITLE
feat: call kratos api endpoint manually after registering

### DIFF
--- a/apps/web/src/components/pages/auth/registration.tsx
+++ b/apps/web/src/components/pages/auth/registration.tsx
@@ -91,7 +91,6 @@ export function Registration() {
       })
       .then(() => {
         setIsSuccessfullySubmitted(true)
-        window.scrollTo({ top: 0, behavior: 'smooth' })
       })
       .catch(
         handleFlowError(
@@ -103,6 +102,7 @@ export function Registration() {
       )
       .finally(() => {
         nProgress.done()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
       })
   }
 

--- a/apps/web/src/pages/api/.ory/[...paths].ts
+++ b/apps/web/src/pages/api/.ory/[...paths].ts
@@ -53,12 +53,19 @@ export default async function customCreateApiHandler(
     if (userId) {
       void fetch(API_KRATOS_WEBHOOK_URL, {
         method: 'POST',
-        headers: { 'x-kratos-key': process.env.API_KRATOS_SECRET },
+        headers: {
+          'x-kratos-key': process.env.API_KRATOS_SECRET,
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ userId }),
       })
         .then(async (result) => {
           const text = await result.text()
-          console.log(text)
+          if (result.status !== 200) {
+            console.log(result.status)
+            console.log({ userId })
+            console.log(text)
+          }
         })
         .catch((e) => {
           console.error(e)

--- a/apps/web/src/pages/api/.ory/[...paths].ts
+++ b/apps/web/src/pages/api/.ory/[...paths].ts
@@ -43,7 +43,8 @@ export default async function customCreateApiHandler(
     if (
       req.method !== 'POST' ||
       !req.url?.startsWith('/api/.ory/self-service/registration?flow=') ||
-      !process.env.API_KRATOS_SECRET
+      !process.env.API_KRATOS_SECRET ||
+      process.env.NEXT_PUBLIC_ENV === 'production'
     ) {
       return
     }

--- a/apps/web/src/pages/api/.ory/[...paths].ts
+++ b/apps/web/src/pages/api/.ory/[...paths].ts
@@ -60,11 +60,11 @@ export default async function customCreateApiHandler(
         body: JSON.stringify({ userId }),
       })
         .then(async (result) => {
-          const text = await result.text()
           if (result.status !== 200) {
+            const text = await result.text()
             console.log(result.status)
             console.log({ userId })
-            console.log(text)
+            console.error(text)
           }
         })
         .catch((e) => {

--- a/apps/web/src/pages/api/.ory/[...paths].ts
+++ b/apps/web/src/pages/api/.ory/[...paths].ts
@@ -1,4 +1,5 @@
 import { createApiHandler, config } from '@ory/integrations/next-edge'
+import { NextApiRequest, NextApiResponse } from 'next/types'
 
 export { config }
 
@@ -7,6 +8,11 @@ const COOKIE_DOMAINS = {
   staging: 'serlo-staging.dev',
   local: 'localhost',
 }
+
+const API_KRATOS_WEBHOOK_URL =
+  process.env.NEXT_PUBLIC_ENV === 'production'
+    ? 'https://api.serlo.org/kratos/register'
+    : 'https://api.serlo-staging.dev/kratos/register'
 
 export const COOKIE_DOMAIN =
   process.env.NEXT_PUBLIC_ENV === 'production'
@@ -27,8 +33,49 @@ const KRATOS_HOST =
     process.env.NEXT_PUBLIC_ENV ? process.env.NEXT_PUBLIC_ENV : 'staging'
   ]
 
-export default createApiHandler({
-  apiBaseUrlOverride: KRATOS_HOST,
-  forceCookieSecure: true,
-  forceCookieDomain: COOKIE_DOMAIN,
-})
+export default async function customCreateApiHandler(
+  req: NextApiRequest,
+  res: NextApiResponse<string>
+): Promise<void> {
+  // injecting a function here to trigger an api call because
+  // unfortunately the kratos webhook ist not reliable atm.
+  function afterRegisterApiCall(body: string) {
+    if (
+      req.method !== 'POST' ||
+      !req.url?.startsWith('/api/.ory/self-service/registration?flow=') ||
+      !process.env.API_KRATOS_SECRET
+    ) {
+      return
+    }
+
+    const result = JSON.parse(body) as { identity: { id: string } }
+    const userId = result?.identity?.id
+    if (userId) {
+      void fetch(API_KRATOS_WEBHOOK_URL, {
+        method: 'POST',
+        headers: { 'x-kratos-key': process.env.API_KRATOS_SECRET },
+        body: JSON.stringify({ userId }),
+      })
+        .then(async (result) => {
+          const text = await result.text()
+          console.log(text)
+        })
+        .catch((e) => {
+          console.error(e)
+        })
+    }
+  }
+
+  function sendOverwrite(body: string) {
+    afterRegisterApiCall(body)
+    res.send(body)
+  }
+
+  // continue with default kratos handler
+  return createApiHandler({
+    apiBaseUrlOverride: KRATOS_HOST,
+    forceCookieSecure: true,
+    forceCookieDomain: COOKIE_DOMAIN,
+    // @ts-expect-error missing the correct type
+  })(req, { ...res, send: sendOverwrite })
+}

--- a/apps/web/src/pages/api/.ory/mail-templates/[[...templateSlug]].ts
+++ b/apps/web/src/pages/api/.ory/mail-templates/[[...templateSlug]].ts
@@ -1,9 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import {
-  langTemplatesSelector,
-  createLangTemplates,
-} from '@/helper/kratos-mail-templates/fragments'
+import { createLangTemplates } from '@/helper/kratos-mail-templates/fragments'
 
 export default function de(req: NextApiRequest, res: NextApiResponse) {
   if (!Array.isArray(req.query.templateSlug)) res.send('invalid template url')


### PR DESCRIPTION
not the nicest code because I have to inject this into the kratos handler but this way it's only happening on the server side and we don't need an additional (unprotected) nextjs endpoint.

(currently not working because of missing secret)

So far it only took 28 new users 😅 