### PR TITLE
fix(equations): Reduce vertical space between arrow and explanation for long equations

### DIFF
--- a/packages/editor/src/plugins/equations/editor/editor.tsx
+++ b/packages/editor/src/plugins/equations/editor/editor.tsx
@@ -219,30 +219,44 @@ export function EquationsEditor(props: EquationsProps) {
                     })
                   }
                 >
-                  {transformationTarget === TransformationTarget.Equation && (
-                    <td />
-                  )}
-                  {!selectIsDocumentEmpty(
-                    store.getState(),
-                    step.explanation.id
-                  ) ? (
-                    renderDownArrow()
+                  <td />
+                  {transformationTarget === 'term' ? (
+                    <td colSpan={2}>
+                      <div className="flex">
+                        {renderArrow()}
+                        {renderExplanation()}
+                      </div>
+                    </td>
                   ) : (
-                    <td />
+                    <>
+                      <td>{renderArrow()}</td>
+                      <td colSpan={2}>{renderExplanation()}</td>
+                    </>
                   )}
-                  <td colSpan={2} className="min-w-[10rem]">
-                    {step.explanation.render({
-                      config: {
-                        isInlineChildEditor: true,
-                        placeholder:
-                          row === 0 &&
-                          transformationTarget === TransformationTarget.Term
-                            ? equationsStrings.combineLikeTerms
-                            : equationsStrings.explanation,
-                      },
-                    })}
-                  </td>
                 </tr>
+              )
+            }
+
+            function renderArrow() {
+              if (!selectIsDocumentEmpty(store.getState(), step.explanation.id))
+                return <div className="text-center">{renderDownArrow()}</div>
+              return null
+            }
+
+            function renderExplanation() {
+              return (
+                <div className=" min-w-[10rem]">
+                  {step.explanation.render({
+                    config: {
+                      isInlineChildEditor: true,
+                      placeholder:
+                        row === 0 &&
+                        transformationTarget === TransformationTarget.Term
+                          ? equationsStrings.combineLikeTerms
+                          : equationsStrings.explanation,
+                    },
+                  })}
+                </div>
               )
             }
           })}
@@ -270,9 +284,12 @@ export function EquationsEditor(props: EquationsProps) {
         </tr>
         <tr className="h-8">
           <td />
-          {!selectIsDocumentEmpty(store.getState(), state.firstExplanation.id)
-            ? renderDownArrow()
-            : null}
+          {!selectIsDocumentEmpty(
+            store.getState(),
+            state.firstExplanation.id
+          ) ? (
+            <div className="text-center">{renderDownArrow()}</div>
+          ) : null}
         </tr>
       </tbody>
     )

--- a/packages/editor/src/plugins/equations/renderer.tsx
+++ b/packages/editor/src/plugins/equations/renderer.tsx
@@ -64,10 +64,19 @@ export function EquationsRenderer({
         {step.explanation ? (
           <tr className="text-brandgreen-darker whitespace-normal">
             <td />
-            {renderDownArrow()}
-            <td colSpan={2} className="relative -left-side px-1 pb-3 pt-1">
-              {step.explanation}
-            </td>
+            {transformationTarget === 'term' ? (
+              <td colSpan={2}>
+                <div className="flex">
+                  {renderDownArrow()}
+                  {step.explanation}
+                </div>
+              </td>
+            ) : (
+              <>
+                <td className="text-center">{renderDownArrow()}</td>
+                <td colSpan={2}>{step.explanation}</td>
+              </>
+            )}
           </tr>
         ) : null}
       </Fragment>
@@ -101,7 +110,7 @@ export function EquationsRenderer({
         </tr>
         <tr className="text-brandgreen-darker">
           <td />
-          {renderDownArrow()}
+          <td className="text-center">{renderDownArrow()}</td>
         </tr>
       </>
     )
@@ -109,9 +118,5 @@ export function EquationsRenderer({
 }
 
 export function renderDownArrow() {
-  return (
-    <td className="text-center font-[serif] text-4xl">
-      <div className="-mt-3">&darr;</div>
-    </td>
-  )
+  return <div className="self-center font-[serif] text-4xl">&darr;</div>
 }


### PR DESCRIPTION
## Before: 
![image](https://github.com/serlo/frontend/assets/59921805/f4eebe2a-28e2-4488-ac33-879ddf340815)

## After: 
![image](https://github.com/serlo/frontend/assets/59921805/00a1a018-3972-4672-9300-1ec088a799ef)

Not a super pretty solution but it works. If we want to do more in the future it might be easier to use css grids to position and align the individual elements. 

## Review: 
I tested a lot but maybe you can have a look if you find layout issues. 