### PR TITLE
fix(editor-package): Omit `Lazy` wrapper and prevent "next router not mounted" issue in rlp integration

### DIFF
--- a/packages/editor/src/editor-integration/create-renderers.tsx
+++ b/packages/editor/src/editor-integration/create-renderers.tsx
@@ -30,8 +30,6 @@ import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
 import { ComponentProps } from 'react'
 
-import { Lazy } from '@/components/content/lazy'
-
 export function createRenderers(
   customPluginRenderers: PluginStaticRenderer[]
 ): InitRenderersArgs {

--- a/packages/editor/src/editor-integration/create-renderers.tsx
+++ b/packages/editor/src/editor-integration/create-renderers.tsx
@@ -110,14 +110,7 @@ export function createRenderers(
       },
       ...customPluginRenderers,
     ],
-    mathRenderer: (element: MathElement) =>
-      element.inline ? (
-        <StaticMath {...element} />
-      ) : (
-        <Lazy slim>
-          <StaticMath {...element} />
-        </Lazy>
-      ),
+    mathRenderer: (element: MathElement) => <StaticMath {...element} />,
     linkRenderer: ({ href, children }: ComponentProps<LinkRenderer>) => {
       return (
         <a


### PR DESCRIPTION
`Lazy` had a dependency on `next/router` which resulted in this issue in `serlo-editor-for-edusharing`