### PR TITLE
fix warning: Allow higher node version for editor packages

### DIFF
--- a/packages/editor-web-component/package.json
+++ b/packages/editor-web-component/package.json
@@ -72,7 +72,7 @@
   },
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": "^18.0.0"
+    "node": ">=20.0.0"
   },
   "postcss": {
     "plugins": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -181,7 +181,7 @@
   },
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": "^20.0.0"
+    "node": ">=20.0.0"
   },
   "postcss": {
     "plugins": {


### PR DESCRIPTION
I think we don't really care about the node version as long as it's not too old. I received following warning, which is why I relaxed the rule:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@serlo/editor-web-component@0.0.4',
npm WARN EBADENGINE   required: { node: '^18.0.0' },
npm WARN EBADENGINE   current: { node: 'v20.12.1', npm: '10.5.0' }
npm WARN EBADENGINE }
```