### PR TITLE
chore(editor): activate AnchorLinkCopyTool for everyone

### DIFF
--- a/apps/web/graphql.schema.json
+++ b/apps/web/graphql.schema.json
@@ -10854,6 +10854,71 @@
         "description": null,
         "fields": [
           {
+            "name": "entities",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "instance",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "Instance",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "modifiedAfter",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ResourceMetadataConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Please use the `resources` field instead. This property will be deleted."
+          },
+          {
             "name": "publisher",
             "description": null,
             "args": [],

--- a/apps/web/src/components/user/profile-experimental.tsx
+++ b/apps/web/src/components/user/profile-experimental.tsx
@@ -23,12 +23,6 @@ export const features = {
     activeInDev: true,
     hideInProduction: false,
   },
-  editorAnchorLinkCopyTool: {
-    cookieName: 'useEditorAnchorLinkCopyTool',
-    isActive: false,
-    activeInDev: true,
-    hideInProduction: false,
-  },
 }
 
 const showExperimentsStorageKey = 'showExperiments'
@@ -129,21 +123,6 @@ export function ProfileExperimental() {
             Content eingefügt werden. Zum einfügen einfach ein Text-Plugin
             auswählen und STRG/CMD+V oder rechtsklick&gt;einfügen benutzen. Wenn
             das Plugin an der Stelle erlaubt ist, erscheint es direkt.
-          </p>
-        </div>
-      ) : null}
-      <hr className="mx-side -mt-2 mb-4" />
-      {shouldBeVisible('editorAnchorLinkCopyTool') ? (
-        <div>
-          <h3 className="serlo-h3 mb-3">
-            {renderFeatureButton('editorAnchorLinkCopyTool')} Editor: Anker-Link
-            Tool
-          </h3>
-          <p className="serlo-p">
-            Ein neues Tool in der Editor-Toolbar um direkt Anker-Links auf
-            Editor-Plugins in die Zwischenablage zu kopieren. Wichtig:
-            Funktioniert nur, wenn der Inhalt ab Juli 2023 eine neue Revision
-            erhalten hat.
           </p>
         </div>
       ) : null}

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1102,8 +1102,6 @@ export const loggedInData = {
         author: 'Author',
         createdAt: 'when?',
         ready: 'Ready to save?',
-        anchorLinkWarning:
-          'This link will only work in the frontend and for content that has a somewhat new revision.',
         pluginCopyInfo: 'You can now paste this plugin into text plugins',
         pluginCopyButtonLabel: 'Copy plugin to clipboard',
       },

--- a/apps/web/src/fetcher/graphql-types/operations.ts
+++ b/apps/web/src/fetcher/graphql-types/operations.ts
@@ -1125,9 +1125,19 @@ export interface MediaUpload {
 
 export interface MetadataQuery {
   __typename?: 'MetadataQuery';
+  /** @deprecated Please use the `resources` field instead. This property will be deleted. */
+  entities: ResourceMetadataConnection;
   publisher: Scalars['JSONObject']['output'];
   resources: ResourceMetadataConnection;
   version: Scalars['String']['output'];
+}
+
+
+export interface MetadataQueryEntitiesArgs {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  instance?: InputMaybe<Instance>;
+  modifiedAfter?: InputMaybe<Scalars['String']['input']>;
 }
 
 

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -145,7 +145,7 @@ export function createPlugins({
     {
       type: EditorPluginType.Anchor,
       plugin: anchorPlugin,
-      visibleInSuggestions: true,
+      visibleInSuggestions: false,
     },
     {
       type: EditorPluginType.PasteHack,

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
@@ -1,5 +1,4 @@
 import { faHashtag } from '@fortawesome/free-solid-svg-icons'
-import { shouldUseFeature } from '@serlo/frontend/src/components/user/profile-experimental'
 import { useInstanceData } from '@serlo/frontend/src/contexts/instance-context'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { showToastNotice } from '@serlo/frontend/src/helper/show-toast-notice'
@@ -18,11 +17,7 @@ export function AnchorLinkCopyTool({
   const editorStrings = useEditorStrings()
   const { strings } = useInstanceData()
 
-  if (
-    !navigator.clipboard ||
-    !window.location.href.includes('add-revision') ||
-    !shouldUseFeature('editorAnchorLinkCopyTool')
-  ) {
+  if (!navigator.clipboard || !window.location.href.includes('add-revision')) {
     return null
   }
 
@@ -34,11 +29,6 @@ export function AnchorLinkCopyTool({
         }`
         void navigator.clipboard.writeText(url)
         showToastNotice(strings.share.copySuccess, 'success', 2000)
-        showToastNotice(
-          '👉 ' + editorStrings.edtrIo.anchorLinkWarning,
-          undefined,
-          5500
-        )
       }}
       label={editorStrings.plugins.rows.copyAnchorLink}
       icon={faHashtag}

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/anchor-link-copy-tool.tsx
@@ -17,6 +17,7 @@ export function AnchorLinkCopyTool({
   const editorStrings = useEditorStrings()
   const { strings } = useInstanceData()
 
+  // only on "/add-revision/…" is a simple way to only show the tool on serlo.org and when we have a uuid
   if (!navigator.clipboard || !window.location.href.includes('add-revision')) {
     return null
   }


### PR DESCRIPTION
Feature was an experiment before (since we could not rely on the editor-ids to be present).
Now after the migration this works a lot nicer.

<img width="841" alt="image" src="https://github.com/serlo/frontend/assets/1258870/90d47df1-1e47-44b1-b188-25bb07441c9e">

(has crowdin changes)
