### PR TITLE
refactor(editor): Publish css extra & release v0.7.0

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/editor",
-  "version": "0.6.0-beta.17",
+  "version": "0.7.0",
   "homepage": "https://de.serlo.org/editor",
   "bugs": {
     "url": "https://github.com/serlo/frontend/issues"
@@ -17,7 +17,8 @@
       "import": "./dist/editor.js",
       "require": "./dist/editor.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "main": "./dist/editor.js",
   "module": "./dist/editor.js",

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -1,7 +1,6 @@
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import dts from 'vite-plugin-dts'
 import svgr from 'vite-plugin-svgr'
 
@@ -41,6 +40,6 @@ export default defineConfig({
       rollupTypes: true,
     }),
     svgr({ include: '**/*.svg' }),
-    cssInjectedByJsPlugin(),
   ],
+  css: {},
 })


### PR DESCRIPTION
The web component will require the css to be exported and published to npm. Meanwhile, the editor package and package consumers would best like to have the css served by the JS bundle (cssInjectedByJsPlugin) which I now removed.

Unfortunately, I'm not sure if this means that we'll need to import the css from edusharing extra.

If we don't want to do that (as it would make the API more complex instead of simplifying it), we may need to have two modes in the vite.config of the editor package. One for including the css and one for injecting it within the JavaScript plugin. What do you think is the right move forward here? 