### PR TITLE
feat: Enable exercises in articles/courses/... & make UuidContext provide entity type

### DIFF
--- a/apps/web/src/components/comments/comment-area-all-threads-thread.tsx
+++ b/apps/web/src/components/comments/comment-area-all-threads-thread.tsx
@@ -46,7 +46,10 @@ export function CommentAreaAllThreadsThread({
       thread.comments.nodes.some((obj) => obj.author.id === auth.id))
 
   return (
-    <UuidsProvider key={thread.id} value={{ entityId: thread.object.id }}>
+    <UuidsProvider
+      key={thread.id}
+      value={{ entity: { entityId: thread.object.id } }}
+    >
       <div className="mb-16">
         <div className="mx-side mb-5 mt-16 flex items-baseline justify-between border-b-2">
           <div>

--- a/apps/web/src/components/frontend-client-base.tsx
+++ b/apps/web/src/components/frontend-client-base.tsx
@@ -14,7 +14,7 @@ import { PrintMode } from '@/components/print-mode'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
 import { UuidsProvider } from '@/contexts/uuids-context'
-import { InstanceData, LoggedInData } from '@/data-types'
+import { InstanceData, LoggedInData, UuidType } from '@/data-types'
 import {
   FixedInstanceData,
   featureI18nForServerOnly,
@@ -28,6 +28,7 @@ export interface FrontendClientBaseProps {
   noContainers?: boolean
   showNav?: boolean
   entityId?: number
+  entityType?: UuidType
   revisionId?: number
   authorization?: AuthorizationPayload
   loadLoggedInData?: boolean
@@ -54,6 +55,7 @@ export function FrontendClientBase({
   noContainers,
   showNav,
   entityId,
+  entityType,
   revisionId,
   authorization,
   loadLoggedInData,
@@ -115,7 +117,9 @@ export function FrontendClientBase({
       <PrintMode />
       <AuthProvider unauthenticatedAuthorizationPayload={authorization}>
         <LoggedInDataProvider value={loggedInData}>
-          <UuidsProvider value={{ entityId, revisionId }}>
+          <UuidsProvider
+            value={{ entity: { entityId, entityType }, revisionId }}
+          >
             <Toaster />
             <ConditionalWrap
               condition={!noHeaderFooter}

--- a/apps/web/src/components/pages/editor/education-plugins.tsx
+++ b/apps/web/src/components/pages/editor/education-plugins.tsx
@@ -201,7 +201,8 @@ export function EducationPlugins() {
     return (
       <div className="m-3 mb-[3.2rem] mt-1 flex-1 text-left">
         <div className="w-full overflow-y-scroll p-8 shadow-menu md:h-[37rem]">
-          <UuidsProvider value={{ entityId: 1555 }}>
+          {/* TODO: Is providing a fake uuid avoidable here?  */}
+          <UuidsProvider value={{ entity: { entityId: 1555 } }}>
             <p className="mb-6 text-xl">{description}</p>
             {example ? (
               <>

--- a/apps/web/src/components/taxonomy/topic.tsx
+++ b/apps/web/src/components/taxonomy/topic.tsx
@@ -1,5 +1,6 @@
 import { editorRenderers } from '@editor/plugin/helpers/editor-renderer'
 import { StaticRenderer } from '@editor/static-renderer/static-renderer'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { EditorRowsDocument } from '@editor/types/editor-plugins'
 import { faFile, faTrash } from '@fortawesome/free-solid-svg-icons'
 import dynamic from 'next/dynamic'
@@ -18,6 +19,7 @@ import { LicenseNotice } from '@/components/content/license/license-notice'
 import { UserTools } from '@/components/user-tools/user-tools'
 import { useAB } from '@/contexts/ab'
 import { useInstanceData } from '@/contexts/instance-context'
+import { UuidsProvider } from '@/contexts/uuids-context'
 import { allMathExamTaxIds } from '@/data/de/math-exams-data'
 import {
   BreadcrumbsData,
@@ -168,12 +170,28 @@ export function Topic({ data, breadcrumbs }: TopicProps) {
       <ol className="mt-12">
         {data.exercisesContent.map((exerciseOrGroup, i) => {
           const exerciseUuid = exerciseOrGroup.serloContext?.uuid
+          const entityType =
+            exerciseOrGroup.plugin === EditorPluginType.Exercise
+              ? UuidType.Exercise
+              : exerciseOrGroup.plugin === EditorPluginType.ExerciseGroup
+                ? UuidType.ExerciseGroup
+                : undefined
 
           return (
             <li key={exerciseOrGroup.id ?? exerciseUuid} className="pb-10">
-              <ExerciseNumbering href={`/${exerciseUuid}`} index={i} />
-              <StaticRenderer document={exerciseOrGroup} />
-              {i === 1 && renderSurvey()}
+              <UuidsProvider
+                value={{
+                  entity: {
+                    entityId: exerciseUuid,
+                    entityType,
+                  },
+                  revisionId: exerciseOrGroup.serloContext?.revisionId,
+                }}
+              >
+                <ExerciseNumbering href={`/${exerciseUuid}`} index={i} />
+                <StaticRenderer document={exerciseOrGroup} />
+                {i === 1 && renderSurvey()}
+              </UuidsProvider>
             </li>
           )
         })}

--- a/apps/web/src/contexts/exercise-id-context.ts
+++ b/apps/web/src/contexts/exercise-id-context.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react'
+
+/** Id for exercises in analytics */
+export const ExerciseIdContext = createContext<number | undefined>(undefined)
+
+export const ExerciseIdProvider = ExerciseIdContext.Provider

--- a/apps/web/src/contexts/uuids-context.ts
+++ b/apps/web/src/contexts/uuids-context.ts
@@ -1,7 +1,14 @@
 import { createContext, useContext } from 'react'
 
+import { UuidType } from '@/data-types'
+
+// Provides ID & type & revision ID of the Serlo entity in our database. Examples:
+// - On an article page like '.../mathe/75512/rechentricks-für-die-addition' this will return ID:'75512' & type:'Article' & revision:'undefined'.
+// - On a page rendering multiple exercises (each having a Serlo entity ID) this will return the corresponding information depending on where you are
+// - On a page not linked to any Serlo entity like '.../math' this will return undefined
+
 export const UuidsContext = createContext<{
-  entityId?: number
+  entity: { entityId?: number; entityType?: UuidType }
   revisionId?: number
 } | null>(null)
 
@@ -14,7 +21,15 @@ export function useEntityId() {
   if (data === null) {
     throw new Error(errorMessage)
   }
-  return data.entityId
+  return data.entity.entityId
+}
+
+export function useEntityType() {
+  const data = useContext(UuidsContext)
+  if (data === null) {
+    throw new Error(errorMessage)
+  }
+  return data.entity.entityType
 }
 
 export function useRevisionId() {

--- a/apps/web/src/pages/[...slug].tsx
+++ b/apps/web/src/pages/[...slug].tsx
@@ -5,7 +5,7 @@ import { EntityBase } from '@/components/entity-base'
 import { FrontendClientBase } from '@/components/frontend-client-base'
 import { LoadingSpinner } from '@/components/loading/loading-spinner'
 import { Topic } from '@/components/taxonomy/topic'
-import { SlugProps } from '@/data-types'
+import { SlugProps, UuidType } from '@/data-types'
 import { Instance } from '@/fetcher/graphql-types/operations'
 import { requestPage } from '@/fetcher/request-page'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
@@ -39,6 +39,11 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
       ? pageData.entityData.id
       : pageData.taxonomyData.id
 
+  const entityType =
+    pageData.kind === 'single-entity'
+      ? pageData.entityData.typename
+      : UuidType.TaxonomyTerm
+
   const revisionId =
     pageData.kind === 'single-entity'
       ? pageData.entityData.revisionId
@@ -48,6 +53,7 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
     <FrontendClientBase
       noContainers
       entityId={entityId}
+      entityType={entityType}
       revisionId={revisionId}
       authorization={pageData.authorization}
     >

--- a/apps/web/src/pages/content-only/[...slug].tsx
+++ b/apps/web/src/pages/content-only/[...slug].tsx
@@ -7,13 +7,13 @@ import { HeadTags } from '@/components/head-tags'
 import { LoadingSpinner } from '@/components/loading/loading-spinner'
 import { MaxWidthDiv } from '@/components/navigation/max-width-div'
 import { Topic } from '@/components/taxonomy/topic'
-import { SlugProps } from '@/data-types'
+import { SlugProps, UuidType } from '@/data-types'
 import { Instance } from '@/fetcher/graphql-types/operations'
 import { requestPage } from '@/fetcher/request-page'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 // Frontend to support Content-API
-// https://github.com/serlo/serlo.org/wiki/Content-API
+// https://github.com/serlo/documentation/wiki/iframe-API
 
 export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
   //fallback, should be handled by CFWorker, (useful for localhost only)
@@ -44,11 +44,17 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
       ? pageData.entityData.id
       : pageData.taxonomyData.id
 
+  const entityType =
+    pageData.kind === 'single-entity'
+      ? pageData.entityData.typename
+      : UuidType.TaxonomyTerm
+
   return (
     <FrontendClientBase
       noContainers
       noHeaderFooter
       entityId={entityId}
+      entityType={entityType}
       authorization={pageData.authorization}
     >
       <LazyIframeResizer />

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -179,7 +179,7 @@ export function createPlugins({
     {
       type: EditorPluginType.Exercise,
       plugin: exercisePlugin,
-      visibleInSuggestions: !isProduction,
+      visibleInSuggestions: true,
     },
     { type: EditorPluginType.Solution, plugin: solutionPlugin },
     { type: EditorPluginType.H5p, plugin: H5pPlugin },

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-exercise-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-exercise-static-renderer.tsx
@@ -1,9 +1,11 @@
 import { BlanksExerciseStaticRenderer } from '@editor/plugins/blanks-exercise/static'
 import { EditorBlanksExerciseDocument } from '@editor/types/editor-plugins'
 import { useRouter } from 'next/router'
+import { useContext } from 'react'
 
 import { useAB } from '@/contexts/ab'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { ExerciseIdContext } from '@/contexts/exercise-id-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
@@ -12,7 +14,7 @@ export function BlanksExerciseSerloStaticRenderer(
 ) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseId = useContext(ExerciseIdContext)
   const revisionId = useRevisionId()
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
 
@@ -22,7 +24,7 @@ export function BlanksExerciseSerloStaticRenderer(
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type: 'blanks',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -9,8 +9,8 @@ import { useContext, useEffect, useState } from 'react'
 import { useAuthentication } from '@/auth/use-authentication'
 import { ExerciseLicenseNotice } from '@/components/content/license/exercise-license-notice'
 import type { MoreAuthorToolsProps } from '@/components/user-tools/foldout-author-menus/more-author-tools'
+import { ExerciseIdProvider } from '@/contexts/exercise-id-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { UuidsProvider } from '@/contexts/uuids-context'
 import { ExerciseInlineType } from '@/data-types'
 
 const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
@@ -36,8 +36,8 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
   // when we moved the groupedExercises into the exercises state we used the old entity uuid as editor id
   // e.g. `3743-exercise-child`. This way we can use the entity ids in injections and for exercise analytics
   const oldEntityId = context?.uuid ?? Number(props.id?.split('-')[0])
-  const entityId = isNaN(oldEntityId)
-    ? // construct fake but persisting entityId just for evaluation
+  const exerciseId = isNaN(oldEntityId)
+    ? // construct fake but persisting exerciseId just for evaluation
       Number(props.id?.replace(/[^0-9]/g, '').substring(0, 8))
     : oldEntityId
 
@@ -64,12 +64,12 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
           />
         ) : null}
       </div>
-      {/* Provide uuids for interactive exercises */}
-      <UuidsProvider value={{ entityId, revisionId: context?.revisionId }}>
+      {/* Provide exercise ids for analytics & injections */}
+      <ExerciseIdProvider value={exerciseId}>
         <div className="-mt-block">
           <ExerciseStaticRenderer {...props} />
         </div>
-      </UuidsProvider>
+      </ExerciseIdProvider>
     </div>
   )
 }

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
@@ -2,10 +2,11 @@ import { parseH5pUrl } from '@editor/plugins/h5p/renderer'
 import { H5pStaticRenderer } from '@editor/plugins/h5p/static'
 import type { EditorH5PDocument } from '@editor/types/editor-plugins'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 
 import { useAB } from '@/contexts/ab'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { ExerciseIdContext } from '@/contexts/exercise-id-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
@@ -13,7 +14,7 @@ import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-
 export function H5pSerloStaticRenderer(props: EditorH5PDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseId = useContext(ExerciseIdContext)
   const revisionId = useRevisionId()
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
 
@@ -26,7 +27,7 @@ export function H5pSerloStaticRenderer(props: EditorH5PDocument) {
         exerciseSubmission(
           {
             path: asPath,
-            entityId,
+            entityId: exerciseId,
             revisionId,
             result: e.type === 'h5pExerciseCorrect' ? 'correct' : 'wrong',
             type: 'h5p',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
@@ -5,14 +5,15 @@ import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
 import { useAB } from '@/contexts/ab'
+import { ExerciseIdContext } from '@/contexts/exercise-id-context'
 import { useInstanceData } from '@/contexts/instance-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
 export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
-  const entityId = useEntityId()
+  const exerciseId = useContext(ExerciseIdContext)
   const revisionId = useRevisionId()
   const exStrings = useInstanceData().strings.content.exercises
   const { asPath } = useRouter()
@@ -31,7 +32,7 @@ export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type: 'input',
@@ -42,7 +43,7 @@ export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseId,
         revisionId,
         result: val.substring(0, 200),
         type: 'ival',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
@@ -6,9 +6,10 @@ import { useContext } from 'react'
 
 import { isPrintMode } from '@/components/print-mode'
 import { useAB } from '@/contexts/ab'
+import { ExerciseIdContext } from '@/contexts/exercise-id-context'
 import { useInstanceData } from '@/contexts/instance-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import {
   ExerciseSubmissionData,
   exerciseSubmission,
@@ -18,7 +19,7 @@ import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-
 export function ScMcSerloStaticRenderer(props: EditorScMcExerciseDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseId = useContext(ExerciseIdContext)
   const revisionId = useRevisionId()
   const isRevisionView = useContext(RevisionViewContext)
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
@@ -44,7 +45,7 @@ export function ScMcSerloStaticRenderer(props: EditorScMcExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type,

--- a/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools.tsx
@@ -27,7 +27,7 @@ export function PluginDefaultTools({ pluginId }: PluginDefaultToolsProps) {
   const pluginStrings = useEditorStrings().plugins
 
   // using useContext directly so result can also be null for edusharing
-  const serloEntityId = useContext(UuidsContext)?.entityId
+  const serloEntityId = useContext(UuidsContext)?.entity.entityId
 
   const hasRowsParent = useMemo(
     () =>

--- a/packages/editor/src/plugins/box/index.tsx
+++ b/packages/editor/src/plugins/box/index.tsx
@@ -40,6 +40,7 @@ const defaultAllowedPlugins: (EditorPluginType | string)[] = [
   EditorPluginType.Multimedia,
   EditorPluginType.SerloTable,
   EditorPluginType.Highlight,
+  EditorPluginType.Exercise,
 ]
 
 export function createBoxPlugin({

--- a/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -41,21 +41,25 @@ export function checkIsAllowedNesting(
     return false
   }
 
-  if (pluginType === EditorPluginType.Exercise) {
-    // never allow exercises in solutions
-    if (typesOfAncestors.includes(EditorPluginType.Solution)) return false
+  const rootPluginType = typesOfAncestors.at(0)
 
-    const rootPlugin = typesOfAncestors[0]
+  if (pluginType === EditorPluginType.Exercise) {
+    // Restrict Exercise->Exercise nesting
+    if (typesOfAncestors.includes(EditorPluginType.Exercise)) return false
+
+    // Allow exercise only inside Article, CoursePage & GenericContent and on ___editor_preview (rows plugin at the root)
     if (
-      // serlo template plugins start with "type-…"
-      // so we use this to not hide exercises in edusharing and /___editor_preview
-      rootPlugin.startsWith('type-') &&
-      rootPlugin !== TemplatePluginType.GenericContent &&
-      rootPlugin !== TemplatePluginType.Article &&
-      rootPlugin !== TemplatePluginType.CoursePage
-    ) {
-      return false
-    }
+      typesOfAncestors.some(
+        (type) =>
+          type === TemplatePluginType.Article ||
+          type === TemplatePluginType.CoursePage ||
+          type === TemplatePluginType.GenericContent
+      ) ||
+      rootPluginType === EditorPluginType.Rows
+    )
+      return true
+
+    return false
   }
 
   return true


### PR DESCRIPTION
Changes: 
  - Exercises are enabled in articles, courses, ...
  - UuidContext provides entity type ('Article', 'TaxonomyTerm', ...) alongside entity id and revision id. If you are on a page rendering multiple entities (with unique uuids) the context provides different values depending on from where you access it. 
  - SolutionSerloStaticRenderer shows comment section only if the exercise has a Serlo uuid. Examples: Show on entity type 'Exercise', not show on entity type 'Article'. Uses entity type to figure that out. 
  - Before: UuidContext was used to provide IDs of groupedExercise (no longer an entity) or fake IDs for exercise analytics. Both are no valid uuids that you can query. After: UuidContext is now only providing valid uuids you can query. ExerciseIdContext provides the exercise ID used for exercise analytics. 

Followups:
  - Remove `exerciseVisibleInSuggestion` from editor API (no need to customize that any more)

Potential followups: 
  - `exerciseSubmission` is also used for tracking "spoiler opened" events which has nothing to do with exercises. Could be renamed. 
  - Move AnchorLinkCopyTool out of @serlo/editor and inject it into toolbar only on serlo.org. Come up with editor api changes. 
  - Rename `entityId` to `serloEntityId` and document in code that this is the id in the `uuid` query. 
  - Rename UuidContext to SerloContext
  - Provide the entity type also in the editor (and other pages)
  - Remove `serloContext` from exercise props and use context instead?