### PR TITLE
feat: integrate VIDIS

### DIFF
--- a/apps/web/src/components/auth/login-button-vidis.tsx
+++ b/apps/web/src/components/auth/login-button-vidis.tsx
@@ -1,0 +1,36 @@
+import type { UiNodeInputAttributes } from '@ory/client'
+import { type FormEvent } from 'react'
+
+import { cn } from '@/helper/cn'
+
+export interface NodeProps {
+  attributes: UiNodeInputAttributes
+  disabled: boolean
+  onSubmit: (e: FormEvent | MouseEvent, method?: string) => Promise<void>
+}
+
+export function LoginButtonVidis({
+  attributes,
+  onSubmit,
+  disabled,
+}: NodeProps) {
+  return (
+    <div className="-mb-8 mt-10">
+      <hr />
+      <button
+        className={cn(`
+        mt-10 block inline-block w-full border border-transparent px-[22px] py-2 py-2
+        text-lg font-bold shadow-menu transition-all hover:border-black focus-visible:border-black
+        `)}
+        name={attributes.name}
+        onClick={(e) => {
+          void onSubmit(e, (attributes as { value: string }).value)
+        }}
+        value={(attributes.value as string) || ''}
+        disabled={attributes.disabled || disabled}
+      >
+        VIDIS
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/auth/login-button-vidis.tsx
+++ b/apps/web/src/components/auth/login-button-vidis.tsx
@@ -2,6 +2,7 @@ import type { UiNodeInputAttributes } from '@ory/client'
 import { type FormEvent } from 'react'
 
 import { cn } from '@/helper/cn'
+import { frontendOrigin } from '@/helper/urls/frontent-origin'
 
 export interface NodeProps {
   attributes: UiNodeInputAttributes
@@ -9,6 +10,9 @@ export interface NodeProps {
   onSubmit: (e: FormEvent | MouseEvent, method?: string) => Promise<void>
 }
 
+const loginUrl = `${frontendOrigin}/auth/login`
+console.log('loginUrl', loginUrl)
+const vidisScript = `<vidis-login loginurl={${loginUrl}}></vidis-login>`
 export function LoginButtonVidis({
   attributes,
   onSubmit,
@@ -31,6 +35,7 @@ export function LoginButtonVidis({
       >
         VIDIS
       </button>
+      <span dangerouslySetInnerHTML={{ __html: vidisScript }}></span>
     </div>
   )
 }

--- a/apps/web/src/components/auth/node.tsx
+++ b/apps/web/src/components/auth/node.tsx
@@ -5,6 +5,7 @@ import { type FormEvent, useState } from 'react'
 
 import { FlowType } from './flow-type'
 import { LoginButtonBildungsraum } from './login-button-bildungsraum'
+import { LoginButtonVidis } from './login-button-vidis'
 import { FaIcon } from '../fa-icon'
 import { Message, getKratosMessageString } from '@/components/auth/message'
 import { useInstanceData } from '@/contexts/instance-context'
@@ -96,6 +97,15 @@ export function Node({
         if (attributes.name === 'provider' && attributes.value === 'nbp') {
           return (
             <LoginButtonBildungsraum
+              attributes={attributes}
+              onSubmit={onSubmit}
+              disabled={disabled}
+            />
+          )
+        }
+        if (attributes.name === 'provider' && attributes.value === 'vidis') {
+          return (
+            <LoginButtonVidis
               attributes={attributes}
               onSubmit={onSubmit}
               disabled={disabled}

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 
 import { Instance } from '@/fetcher/graphql-types/operations'
 import { colors } from '@/helper/colors'
@@ -120,6 +121,10 @@ export default class MyDocument extends Document {
               __html: `window.sa_event=window.sa_event||function(){a=[].slice.call(arguments);sa_event.q?sa_event.q.push(a):sa_event.q=[a]};`,
             }}
           ></script>
+          <Script
+            src="https://repo.vidis.schule/repository/vidis-
+cdn/latest/vidisLogin.umd.js"
+          />
         </Head>
         <body style={bodyStyles}>
           <Main />


### PR DESCRIPTION
There is a way of using the a web component through a CDN, could we try it out? 
I suppose it is important for brand UI button.
```
VIDIS-Login Example
<script src="https://repo.vidis.schule/repository/vidiscdn/latest/vidisLogin.umd.js"></script>
<vidis-login loginurl="https://www.domain.de/path-toauth/" size="L" cookie="true"></vidis-login>
```