### PR TITLE
feat: enable exercises plugin in some content types, refactor serlo exercise Id code

### DIFF
--- a/apps/web/src/contexts/exercise-group-id-context.ts
+++ b/apps/web/src/contexts/exercise-group-id-context.ts
@@ -1,7 +1,0 @@
-import { createContext } from 'react'
-
-export const ExerciseGroupIdContext = createContext<number | undefined>(
-  undefined
-)
-
-export const ExerciseGroupIdProvider = ExerciseGroupIdContext.Provider

--- a/apps/web/src/contexts/exercise-ids-context.ts
+++ b/apps/web/src/contexts/exercise-ids-context.ts
@@ -2,10 +2,9 @@ import { createContext } from 'react'
 
 export const ExerciseIdsContext = createContext<
   | {
-      exerciseId?: number
+      exerciseEntityId?: number
       exerciseTrackingId?: number
-      exerciseGroupId?: number
-      exerciseGroupTrackingId?: number
+      exerciseGroupEntityId?: number
     }
   | undefined
 >(undefined)

--- a/apps/web/src/contexts/exercise-ids-context.ts
+++ b/apps/web/src/contexts/exercise-ids-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+export const ExerciseIdsContext = createContext<
+  | {
+      exerciseId?: number
+      exerciseTrackingId?: number
+      exerciseGroupId?: number
+      exerciseGroupTrackingId?: number
+    }
+  | undefined
+>(undefined)
+
+export const ExerciseIdsProvider = ExerciseIdsContext.Provider

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -201,7 +201,7 @@ export const instanceData = {
     },
     comments: {
       question: 'Do you have a question?',
-      questionLink: 'Write it below',
+      questionLink: 'Write it here',
       commentsOne: 'Comment',
       commentsMany: 'Comments',
       submit: 'Submit',

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -179,7 +179,7 @@ export function createPlugins({
     {
       type: EditorPluginType.Exercise,
       plugin: exercisePlugin,
-      visibleInSuggestions: !isProduction,
+      visibleInSuggestions: true,
     },
     { type: EditorPluginType.Solution, plugin: solutionPlugin },
     { type: EditorPluginType.H5p, plugin: H5pPlugin },

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-exercise-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/blanks-exercise-static-renderer.tsx
@@ -1,9 +1,11 @@
 import { BlanksExerciseStaticRenderer } from '@editor/plugins/blanks-exercise/static'
 import { EditorBlanksExerciseDocument } from '@editor/types/editor-plugins'
 import { useRouter } from 'next/router'
+import { useContext } from 'react'
 
 import { useAB } from '@/contexts/ab'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
@@ -12,7 +14,7 @@ export function BlanksExerciseSerloStaticRenderer(
 ) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseIds = useContext(ExerciseIdsContext)
   const revisionId = useRevisionId()
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
 
@@ -22,7 +24,7 @@ export function BlanksExerciseSerloStaticRenderer(
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseIds?.exerciseTrackingId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type: 'blanks',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-group-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-group-serlo-static-renderer.tsx
@@ -46,10 +46,7 @@ export function ExerciseGroupSerloStaticRenderer(
       </div>
       {/* Provide parent uuids for nested exercises plugins */}
       <ExerciseIdsContext.Provider
-        value={{
-          exerciseGroupId: context?.uuid,
-          exerciseGroupTrackingId: context?.uuid,
-        }}
+        value={{ exerciseGroupEntityId: context?.uuid }}
       >
         <div className="-mt-block">
           <ExerciseGroupStaticRenderer {...props} />

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-group-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-group-serlo-static-renderer.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import { useAuthentication } from '@/auth/use-authentication'
 import { ExerciseLicenseNotice } from '@/components/content/license/exercise-license-notice'
 import type { MoreAuthorToolsProps } from '@/components/user-tools/foldout-author-menus/more-author-tools'
-import { ExerciseGroupIdProvider } from '@/contexts/exercise-group-id-context'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
 import { ExerciseInlineType } from '@/data-types'
 
 const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
@@ -45,11 +45,16 @@ export function ExerciseGroupSerloStaticRenderer(
         ) : null}
       </div>
       {/* Provide parent uuids for nested exercises plugins */}
-      <ExerciseGroupIdProvider value={context?.uuid}>
+      <ExerciseIdsContext.Provider
+        value={{
+          exerciseGroupId: context?.uuid,
+          exerciseGroupTrackingId: context?.uuid,
+        }}
+      >
         <div className="-mt-block">
           <ExerciseGroupStaticRenderer {...props} />
         </div>
-      </ExerciseGroupIdProvider>
+      </ExerciseIdsContext.Provider>
     </div>
   )
 }

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -9,8 +9,8 @@ import { useContext, useEffect, useState } from 'react'
 import { useAuthentication } from '@/auth/use-authentication'
 import { ExerciseLicenseNotice } from '@/components/content/license/exercise-license-notice'
 import type { MoreAuthorToolsProps } from '@/components/user-tools/foldout-author-menus/more-author-tools'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { UuidsProvider } from '@/contexts/uuids-context'
 import { ExerciseInlineType } from '@/data-types'
 
 const AuthorToolsExercises = dynamic<MoreAuthorToolsProps>(() =>
@@ -33,10 +33,12 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
   const solutionLicenseId = (props.state.solution as EditorSolutionDocument)
     ?.state.licenseId
 
+  const exerciseIds = useContext(ExerciseIdsContext)
+
   // when we moved the groupedExercises into the exercises state we used the old entity uuid as editor id
   // e.g. `3743-exercise-child`. This way we can use the entity ids in injections and for exercise analytics
   const oldEntityId = context?.uuid ?? Number(props.id?.split('-')[0])
-  const entityId = isNaN(oldEntityId)
+  const exerciseTrackingId = isNaN(oldEntityId)
     ? // construct fake but persisting entityId just for evaluation
       Number(props.id?.replace(/[^0-9]/g, '').substring(0, 8))
     : oldEntityId
@@ -64,12 +66,17 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
           />
         ) : null}
       </div>
-      {/* Provide uuids for interactive exercises */}
-      <UuidsProvider value={{ entityId, revisionId: context?.revisionId }}>
+      <ExerciseIdsContext.Provider
+        value={{
+          ...exerciseIds, // spread group ids
+          exerciseId: context?.uuid,
+          exerciseTrackingId,
+        }}
+      >
         <div className="-mt-block">
           <ExerciseStaticRenderer {...props} />
         </div>
-      </UuidsProvider>
+      </ExerciseIdsContext.Provider>
     </div>
   )
 }

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -39,7 +39,7 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
   // e.g. `3743-exercise-child`. This way we can use the entity ids in injections and for exercise analytics
   const oldEntityId = context?.uuid ?? Number(props.id?.split('-')[0])
   const exerciseTrackingId = isNaN(oldEntityId)
-    ? // construct fake but persisting entityId just for evaluation
+    ? // construct fake but persisting tracking id just for evaluation
       Number(props.id?.replace(/[^0-9]/g, '').substring(0, 8))
     : oldEntityId
 

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -69,7 +69,7 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
       <ExerciseIdsContext.Provider
         value={{
           ...exerciseIds, // spread group ids
-          exerciseId: context?.uuid,
+          exerciseEntityId: context?.uuid,
           exerciseTrackingId,
         }}
       >

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/exercise-serlo-static-renderer.tsx
@@ -66,6 +66,7 @@ export function ExerciseSerloStaticRenderer(props: EditorExerciseDocument) {
           />
         ) : null}
       </div>
+      {/* Provide exercise ids for analytics & comments */}
       <ExerciseIdsContext.Provider
         value={{
           ...exerciseIds, // spread group ids

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/h5p-serlo-static.tsx
@@ -2,10 +2,11 @@ import { parseH5pUrl } from '@editor/plugins/h5p/renderer'
 import { H5pStaticRenderer } from '@editor/plugins/h5p/static'
 import type { EditorH5PDocument } from '@editor/types/editor-plugins'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 
 import { useAB } from '@/contexts/ab'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
@@ -13,7 +14,7 @@ import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-
 export function H5pSerloStaticRenderer(props: EditorH5PDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseIds = useContext(ExerciseIdsContext)
   const revisionId = useRevisionId()
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
 
@@ -26,7 +27,7 @@ export function H5pSerloStaticRenderer(props: EditorH5PDocument) {
         exerciseSubmission(
           {
             path: asPath,
-            entityId,
+            entityId: exerciseIds?.exerciseTrackingId,
             revisionId,
             result: e.type === 'h5pExerciseCorrect' ? 'correct' : 'wrong',
             type: 'h5p',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/injection-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/injection-serlo-static-renderer.tsx
@@ -86,7 +86,12 @@ export function InjectionSerloStaticRenderer({
                 exercise.id?.startsWith(hash)
               )
               if (exercise) {
-                setContent([exercise])
+                setContent([
+                  {
+                    ...exercise,
+                    serloContext: { licenseId: uuid.licenseId, uuid: uuid.id },
+                  },
+                ])
                 return
               }
             }
@@ -94,8 +99,8 @@ export function InjectionSerloStaticRenderer({
               ...content,
               state: {
                 ...content.state,
-                serloContext: { licenseId: uuid.licenseId },
               },
+              serloContext: { licenseId: uuid.licenseId, uuid: uuid.id },
             }
             setContent([contentWithLicenseId])
             return

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/input-serlo-static-renderer.tsx
@@ -5,14 +5,15 @@ import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
 import { useAB } from '@/contexts/ab'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
 import { useInstanceData } from '@/contexts/instance-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
 export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
-  const entityId = useEntityId()
+  const exerciseIds = useContext(ExerciseIdsContext)
   const revisionId = useRevisionId()
   const exStrings = useInstanceData().strings.content.exercises
   const { asPath } = useRouter()
@@ -31,7 +32,7 @@ export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseIds?.exerciseTrackingId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type: 'input',
@@ -42,7 +43,7 @@ export function InputSerloStaticRenderer(props: EditorInputExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseIds?.exerciseTrackingId,
         revisionId,
         result: val.substring(0, 200),
         type: 'ival',

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/sc-mc-serlo-static-renderer.tsx
@@ -6,9 +6,10 @@ import { useContext } from 'react'
 
 import { isPrintMode } from '@/components/print-mode'
 import { useAB } from '@/contexts/ab'
+import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
 import { useInstanceData } from '@/contexts/instance-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
-import { useEntityId, useRevisionId } from '@/contexts/uuids-context'
+import { useRevisionId } from '@/contexts/uuids-context'
 import {
   ExerciseSubmissionData,
   exerciseSubmission,
@@ -18,7 +19,7 @@ import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-
 export function ScMcSerloStaticRenderer(props: EditorScMcExerciseDocument) {
   const { asPath } = useRouter()
   const ab = useAB()
-  const entityId = useEntityId()
+  const exerciseIds = useContext(ExerciseIdsContext)
   const revisionId = useRevisionId()
   const isRevisionView = useContext(RevisionViewContext)
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
@@ -38,7 +39,7 @@ export function ScMcSerloStaticRenderer(props: EditorScMcExerciseDocument) {
     exerciseSubmission(
       {
         path: asPath,
-        entityId,
+        entityId: exerciseIds?.exerciseTrackingId,
         revisionId,
         result: correct ? 'correct' : 'wrong',
         type,

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
@@ -21,7 +21,7 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
   const isRevisionView = useContext(RevisionViewContext)
 
   const exerciseIds = useContext(ExerciseIdsContext)
-  const exerciseGroupId = exerciseIds?.exerciseGroupId
+  const exerciseGroupId = exerciseIds?.exerciseGroupEntityId
 
   const trackExperiment = useCreateExerciseSubmissionMutation(asPath)
 
@@ -61,7 +61,7 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
 
   function renderCommentLink() {
     if (isRevisionView) return null
-    const exerciseId = exerciseIds?.exerciseId
+    const exerciseId = exerciseIds?.exerciseEntityId
     const linkPrefix =
       exerciseGroupId || exerciseId ? `${exerciseGroupId ?? exerciseId}/` : ''
 

--- a/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-plugin-wrappers/solution-serlo-static-renderer.tsx
@@ -4,12 +4,15 @@ import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
+import { CommentAreaEntity } from '@/components/comments/comment-area-entity'
+import { Lazy } from '@/components/content/lazy'
 import { FaIcon } from '@/components/fa-icon'
 import { isPrintMode, printModeSolutionVisible } from '@/components/print-mode'
 import { useAB } from '@/contexts/ab'
 import { ExerciseIdsContext } from '@/contexts/exercise-ids-context'
 import { useInstanceData } from '@/contexts/instance-context'
 import { RevisionViewContext } from '@/contexts/revision-view-context'
+import { useEntityId } from '@/contexts/uuids-context'
 import { exerciseSubmission } from '@/helper/exercise-submission'
 import { useCreateExerciseSubmissionMutation } from '@/mutations/use-experiment-create-exercise-submission-mutation'
 
@@ -20,6 +23,7 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
   const commentStrings = useInstanceData().strings.comments
   const isRevisionView = useContext(RevisionViewContext)
 
+  const entityId = useEntityId()
   const exerciseIds = useContext(ExerciseIdsContext)
   const exerciseGroupId = exerciseIds?.exerciseGroupEntityId
 
@@ -62,11 +66,23 @@ export function SolutionSerloStaticRenderer(props: EditorSolutionDocument) {
   function renderCommentLink() {
     if (isRevisionView) return null
     const exerciseId = exerciseIds?.exerciseEntityId
+    const exerciseEntityId = exerciseGroupId ?? exerciseId
+
+    const isExerciseEntityInInjectionOrTaxonomy =
+      exerciseId && exerciseId !== entityId
+
+    if (isExerciseEntityInInjectionOrTaxonomy) {
+      if (!exerciseEntityId) return null
+      return (
+        <Lazy>
+          <CommentAreaEntity entityId={exerciseEntityId} />
+        </Lazy>
+      )
+    }
+
     const linkPrefix =
-      exerciseGroupId || exerciseId ? `${exerciseGroupId ?? exerciseId}/` : ''
-
+      exerciseGroupId || exerciseId ? `${exerciseEntityId}/` : ''
     const onlyScroll = !linkPrefix
-
     return (
       <>
         <h2 className="serlo-h2 mt-10 border-b-0">

--- a/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -41,21 +41,27 @@ export function checkIsAllowedNesting(
     return false
   }
 
-  if (pluginType === EditorPluginType.Exercise) {
-    // never allow exercises in solutions
-    if (typesOfAncestors.includes(EditorPluginType.Solution)) return false
+  const rootPluginType = typesOfAncestors.at(0)
 
-    const rootPlugin = typesOfAncestors[0]
+  if (pluginType === EditorPluginType.Exercise) {
+    // Restrict Exercise->Exercise nesting
     if (
-      // serlo template plugins start with "type-…"
-      // so we use this to not hide exercises in edusharing and /___editor_preview
-      rootPlugin.startsWith('type-') &&
-      rootPlugin !== TemplatePluginType.GenericContent &&
-      rootPlugin !== TemplatePluginType.Article &&
-      rootPlugin !== TemplatePluginType.CoursePage
-    ) {
+      typesOfAncestors.includes(EditorPluginType.Exercise) ||
+      typesOfAncestors.includes(EditorPluginType.ExerciseGroup)
+    )
       return false
-    }
+
+    // Allow exercise only inside Article, CoursePage & GenericContent and on ___editor_preview (rows plugin at the root)
+    const hasValidRoot =
+      rootPluginType &&
+      [
+        TemplatePluginType.Article,
+        TemplatePluginType.CoursePage,
+        TemplatePluginType.GenericContent,
+        EditorPluginType.Rows,
+      ].includes(rootPluginType as TemplatePluginType)
+
+    return Boolean(hasValidRoot)
   }
 
   return true


### PR DESCRIPTION
inspired by https://github.com/serlo/frontend/pull/3754 with a little bit different approach

**Exercise Plugin in Editor Plugin suggestions**
- Exercises are enabled in articles, courses, preview pages, etc …

**Context**
- `ExerciseGroupIdContext` is now `ExerciseIdsContext` and additionally provides:
  - `exerciseEntityId` (if the exercise is actually a standalone serlo entity)
  - `exerciseTrackingId` (for the constructed Id that is only used for evaluation)

I hope this way we can avoid confusion here

**Comments**
The comments inside solutions is now only shown on exercises (not exerciseGroups) that are actually entites.
Otherwise we always show a link:
- for injected exerciseGroups (entites): link to the comment section of the standalone view of the exercise (new tab)
- for exercises/groups in the content of an article/coursePage: scroll to comment section of current page



Follow ups from https://github.com/serlo/frontend/pull/3754 still make sense.