### PR TITLE
chore(editor-web-component): Mark all dev dependencies

### DIFF
--- a/packages/editor-web-component/package.json
+++ b/packages/editor-web-component/package.json
@@ -40,13 +40,10 @@
   "resolutions": {
     "@serlo/editor": "0.7.0"
   },
-  "dependencies": {
-    "@serlo/editor": "0.7.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
+    "@serlo/editor": "0.7.0",
     "@serlo/typescript-config": "workspace:*",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
@@ -66,6 +63,8 @@
     "prettier": "^3.2.5",
     "prettier-plugin-packagejson": "^2.5.0",
     "prettier-plugin-tailwindcss": "^0.5.14",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "uuid": "^9.0.1",
     "vite": "^5.2.10",
     "vite-plugin-css-injected-by-js": "^3.5.1",


### PR DESCRIPTION
In my understaning everything is bundled together, right? Then those dependencies should be dev dependencies.