### PR TITLE
docs(packages): Update readmes of packages on current usage

### DIFF
--- a/packages/editor-web-component/README.md
+++ b/packages/editor-web-component/README.md
@@ -8,15 +8,63 @@ This is an early version of the web component wrapping the [Serlo Editor](https:
 2. Register the web component `customElements.define('serlo-editor', EditorWebComponent)`.
 3. Render the web component
 
-```JSX
+Below is an example of how to use the web component in a Vue.js application.
+
+```vue
+<template>
+  <div>
+    <button @click="toggleMode">{{ isEditing ? 'READ' : 'EDIT' }}</button>
+    <serlo-editor
+      :mode="isEditing ? 'write' : 'read'"
+      :initial-state="initialExampleState"
+      @state-changed="handleStateChange"
+    ></serlo-editor>
+  </div>
+</template>
+
+<script>
+import { defineComponent, ref } from 'vue'
 import { EditorWebComponent } from '@serlo/editor-web-component'
 
 customElements.define('serlo-editor', EditorWebComponent)
 
-// in your render function
-return (
-  <serlo-editor></serlo-editor>
-)
+export default defineComponent({
+  name: 'SerloEditorComponent',
+  setup() {
+    const isEditing = ref(false)
+    const initialExampleState = ref({
+      plugin: 'rows',
+      state: [
+        {
+          plugin: 'text',
+          state: [
+            {
+              type: 'h',
+              level: 1,
+              children: [{ text: 'Example Heading' }],
+            },
+          ],
+        },
+      ],
+    })
+
+    const toggleMode = () => {
+      isEditing.value = !isEditing.value
+    }
+
+    const handleStateChange = (event) => {
+      console.log('New state:', event.detail.newState)
+    }
+
+    return {
+      isEditing,
+      initialExampleState,
+      toggleMode,
+      handleStateChange,
+    }
+  },
+})
+</script>
 ```
 
 ## Releasing a new version to npm

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -2,9 +2,52 @@
 
 This is an early beta version of the [Serlo Editor](https://de.serlo.org/editor). Be aware that we are currently working on this package and thus there will be breaking changes. The repository [serlo/serlo-editor-for-edusharing](https://github.com/serlo/serlo-editor-for-edusharing) shows how this package can be used.
 
+## Using the Serlo Editor
+
+### Installation
+
+In your React project
+
+```bash
+yarn add @serlo/editor
+```
+
+### Usage
+
+You can see a complete working example of the usage [here](https://github.com/serlo/serlo-editor-for-edusharing/blob/main/src/frontend/editor.tsx#L32).
+
+```tsx
+import { SerloEditor, SerloEditorProps } from '@serlo/editor'
+
+type InitialState = SerloEditorProps['initialState']
+
+function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
+  return (
+    <SerloEditor
+      initialState={initialState}
+      onChange={({ changed, getDocument }) => {
+        if (changed){
+          console.log(`New state: `, getDocument())
+        }
+      }}
+    >
+      {({ editor }) => (
+        {/* Optionally configure plugins or i18n strings via the editor object */}
+        <div>
+          {/* Renders the actual editor content */}
+          {editor.element}
+        </div>
+      )}
+    </SerloEditor>
+  )
+}
+```
+
+See below for the current API specification.
+
 ## Current Editor package API
 
-#### 1. `SerloEditor`, `type SerloEditorProps`
+### 1. `SerloEditor`, `type SerloEditorProps`
 
 - **Why Exported/How Used**: `SerloEditor` is the core component of the `@serlo/editor` package, providing the main editor functionality. It's exported to allow users to embed the editor into their applications, passing in initial state, configuration, and custom render props to tailor the editor's functionality to their needs.
 - **Long-Term Support**: Will stay

--- a/packages/katex-styles/README.md
+++ b/packages/katex-styles/README.md
@@ -1,6 +1,6 @@
-# serlo-katex-styles
+# Serlo KaTeX styles
 
-Our custom CSS styles for KaTeX
+Custom CSS styles for KaTeX.
 
 ## Installation
 


### PR DESCRIPTION
Add Vue.js example on how to render Web Component.

Add example how to render React package.


Closes https://github.com/serlo/frontend/issues/3796