### PR TITLE
Fix/plugin suggestion menu in shadow dom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ tsconfig.tsbuildinfo
 !.yarn/versions
 yarn-debug.log*
 yarn-error.log*
+.yalc
 
 # asdf-vm
 .tool-versions

--- a/packages/editor-web-component/package.json
+++ b/packages/editor-web-component/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@serlo/editor": "0.7.0",
+    "@serlo/editor": "file:.yalc/@serlo/editor",
     "@serlo/typescript-config": "workspace:*",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",

--- a/packages/editor-web-component/package.json
+++ b/packages/editor-web-component/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@serlo/editor": "file:.yalc/@serlo/editor",
+    "@serlo/editor": "0.7.0",
     "@serlo/typescript-config": "workspace:*",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/editor",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "homepage": "https://de.serlo.org/editor",
   "bugs": {
     "url": "https://github.com/serlo/frontend/issues"


### PR DESCRIPTION
It used to get rendered at the top of the webpage. Problem: Within the shadow DOM, we don't have access to the current selection (`window.getSelection()` defaults to document.body). My changes try to find the active element within the Shadow DOM and based on that, calculates the height offsets from there.  