### PR TITLE
feat: Make image plugin available to integrations without upload (HACK)

### DIFF
--- a/packages/editor-web-component/src/editor-web-component.tsx
+++ b/packages/editor-web-component/src/editor-web-component.tsx
@@ -22,7 +22,6 @@ export class EditorWebComponent extends HTMLElement {
   private container: HTMLDivElement
 
   private _mode: Mode = 'read'
-  private _imagePluginEnabled = 'false'
 
   private _initialState: InitialState = exampleInitialState
   private _currentState: unknown
@@ -94,16 +93,6 @@ export class EditorWebComponent extends HTMLElement {
     }
   }
 
-  get imagePluginEnabled() {
-    return this._imagePluginEnabled
-  }
-
-  set imagePluginEnabled(newValue: string) {
-    this._imagePluginEnabled = newValue
-    this.setAttribute('imagePluginEnabled', newValue)
-    this.mountReactComponent()
-  }
-
   get currentState() {
     return this._currentState
   }
@@ -162,9 +151,7 @@ export class EditorWebComponent extends HTMLElement {
             <Suspense fallback={<div>Loading editor...</div>}>
               <LazySerloEditor
                 initialState={this.initialState}
-                _enableImagePlugin={
-                  this._imagePluginEnabled === 'true' ? true : false
-                }
+                _enableImagePlugin // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
                 onChange={({ changed, getDocument }) => {
                   if (changed) {
                     const newState = getDocument()

--- a/packages/editor-web-component/src/editor-web-component.tsx
+++ b/packages/editor-web-component/src/editor-web-component.tsx
@@ -22,6 +22,7 @@ export class EditorWebComponent extends HTMLElement {
   private container: HTMLDivElement
 
   private _mode: Mode = 'read'
+  private _imagePluginEnabled = 'false'
 
   private _initialState: InitialState = exampleInitialState
   private _currentState: unknown
@@ -93,6 +94,16 @@ export class EditorWebComponent extends HTMLElement {
     }
   }
 
+  get imagePluginEnabled() {
+    return this._imagePluginEnabled
+  }
+
+  set imagePluginEnabled(newValue: string) {
+    this._imagePluginEnabled = newValue
+    this.setAttribute('imagePluginEnabled', newValue)
+    this.mountReactComponent()
+  }
+
   get currentState() {
     return this._currentState
   }
@@ -151,6 +162,9 @@ export class EditorWebComponent extends HTMLElement {
             <Suspense fallback={<div>Loading editor...</div>}>
               <LazySerloEditor
                 initialState={this.initialState}
+                _enableImagePlugin={
+                  this._imagePluginEnabled === 'true' ? true : false
+                }
                 onChange={({ changed, getDocument }) => {
                   if (changed) {
                     const newState = getDocument()

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -18,6 +18,7 @@ export interface PluginsConfig {
   general?: {
     enableTextAreaExercise: boolean
     exerciseVisibleInSuggestion: boolean
+    _enableImagePlugin?: boolean // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
   }
 }
 
@@ -39,6 +40,7 @@ const defaultPluginsConfig: Required<PluginsConfig> = {
   general: {
     exerciseVisibleInSuggestion: true,
     enableTextAreaExercise: false,
+    _enableImagePlugin: false,
   },
 }
 

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -18,7 +18,6 @@ export interface PluginsConfig {
   general?: {
     enableTextAreaExercise: boolean
     exerciseVisibleInSuggestion: boolean
-    _enableImagePlugin?: boolean // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
   }
 }
 
@@ -40,7 +39,6 @@ const defaultPluginsConfig: Required<PluginsConfig> = {
   general: {
     exerciseVisibleInSuggestion: true,
     enableTextAreaExercise: false,
-    _enableImagePlugin: false,
   },
 }
 

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -27,6 +27,7 @@ export interface SerloEditorProps {
   initialState?: EditorProps['initialState']
   onChange?: EditorProps['onChange']
   language?: SupportedLanguage
+  _enableImagePlugin?: boolean // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
 }
 
 /** For exporting the editor */
@@ -45,7 +46,7 @@ export function SerloEditor(props: SerloEditorProps) {
   const basicPlugins = createBasicPlugins(pluginsConfig)
   let allPlugins = [...basicPlugins, ...customPlugins]
   // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
-  if (props.pluginsConfig?.general?._enableImagePlugin) {
+  if (props._enableImagePlugin) {
     const imagePluginNoFileUpload = createImagePlugin({
       disableFileUpload: true,
       upload: (_) => {

--- a/packages/editor/src/plugins/image/index.ts
+++ b/packages/editor/src/plugins/image/index.ts
@@ -112,6 +112,7 @@ export type ImagePluginState = typeof imageState
 export type ImageProps = EditorPluginProps<ImagePluginState, ImageConfig>
 
 export interface ImagePluginConfig {
+  disableFileUpload?: boolean // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
   upload: UploadHandler<string>
   validate: UploadValidator<FileError[]>
 }

--- a/packages/editor/src/plugins/image/toolbar.tsx
+++ b/packages/editor/src/plugins/image/toolbar.tsx
@@ -18,6 +18,7 @@ export const ImageToolbar = (
   }
 ) => {
   const { id, showSettingsModal, setShowSettingsModal } = props
+  const disableFileUpload = props.config.disableFileUpload // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
   const editorStrings = useEditorStrings()
   const imageStrings = editorStrings.plugins.image
 
@@ -47,7 +48,7 @@ export const ImageToolbar = (
             </div>
           </ModalWithCloseButton>
 
-          <UploadButton {...props} />
+          {disableFileUpload ? null : <UploadButton {...props} />}
         </>
       }
       pluginControls={<PluginDefaultTools pluginId={id} />}


### PR DESCRIPTION
Integrations can now enable the image plugin like this: 
```typescript
// using editor package
<SerloEditor _enableImagePlugin={true} ...>
  ...
</SerloEditor>

// using editor-web-component package
// -> enabled per default for now
```

Not to be used in production environments!