### PR TITLE
feat(auth): vidis as experiment with special auto-activate route

### DIFF
--- a/apps/web/src/components/auth/node.tsx
+++ b/apps/web/src/components/auth/node.tsx
@@ -94,7 +94,11 @@ export function Node({
       }
       // provider: Mein Bildungsraum
       case 'button': {
-        if (attributes.name === 'provider' && attributes.value === 'nbp') {
+        if (
+          !isProduction &&
+          attributes.name === 'provider' &&
+          attributes.value === 'nbp'
+        ) {
           return (
             <LoginButtonBildungsraum
               attributes={attributes}
@@ -103,7 +107,11 @@ export function Node({
             />
           )
         }
-        if (attributes.name === 'provider' && attributes.value === 'vidis') {
+        if (
+          !isProduction &&
+          attributes.name === 'provider' &&
+          attributes.value === 'vidis'
+        ) {
           return (
             <LoginButtonVidis
               attributes={attributes}

--- a/apps/web/src/components/auth/node.tsx
+++ b/apps/web/src/components/auth/node.tsx
@@ -7,6 +7,7 @@ import { FlowType } from './flow-type'
 import { LoginButtonBildungsraum } from './login-button-bildungsraum'
 import { LoginButtonVidis } from './login-button-vidis'
 import { FaIcon } from '../fa-icon'
+import { shouldUseFeature } from '../user/profile-experimental'
 import { Message, getKratosMessageString } from '@/components/auth/message'
 import { useInstanceData } from '@/contexts/instance-context'
 import { cn } from '@/helper/cn'
@@ -104,6 +105,9 @@ export function Node({
           )
         }
         if (attributes.name === 'provider' && attributes.value === 'vidis') {
+          if (!shouldUseFeature('authVidis')) {
+            return null // silently return if experiment is not active
+          }
           return (
             <LoginButtonVidis
               attributes={attributes}

--- a/apps/web/src/components/auth/node.tsx
+++ b/apps/web/src/components/auth/node.tsx
@@ -109,7 +109,7 @@ export function Node({
           )
         }
         if (
-          (!isProduction || !shouldUseFeature('authVidis')) &&
+          (!isProduction || shouldUseFeature('authVidis')) &&
           attributes.name === 'provider' &&
           attributes.value === 'vidis'
         ) {

--- a/apps/web/src/components/user/profile-experimental.tsx
+++ b/apps/web/src/components/user/profile-experimental.tsx
@@ -23,6 +23,12 @@ export const features = {
     activeInDev: true,
     hideInProduction: true,
   },
+  authVidis: {
+    cookieName: 'useAllowVidisLogin',
+    isActive: false,
+    activeInDev: false,
+    hideInProduction: true,
+  },
 }
 
 const showExperimentsStorageKey = 'showExperiments'
@@ -116,6 +122,16 @@ export function ProfileExperimental() {
           </h3>
           <p className="serlo-p">
             Experimentelles Feature: nur aktivieren wenn du weißt was du tust.
+          </p>
+        </div>
+      ) : null}
+      {shouldBeVisible('authVidis') ? (
+        <div>
+          <h3 className="serlo-h3 mb-3">
+            {renderFeatureButton('authVidis')} ✹
+          </h3>
+          <p className="serlo-p">
+            Experimentelles Feature: Login mit VIDIS SSO anzeigen
           </p>
         </div>
       ) : null}

--- a/apps/web/src/pages/auth/___activate_vidis.tsx
+++ b/apps/web/src/pages/auth/___activate_vidis.tsx
@@ -1,0 +1,25 @@
+import Cookies from 'js-cookie'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+import { FrontendClientBase } from '@/components/frontend-client-base/frontend-client-base'
+import { LoadingSpinner } from '@/components/loading/loading-spinner'
+import { features } from '@/components/user/profile-experimental'
+import { renderedPageNoHooks } from '@/helper/rendered-page'
+
+export default renderedPageNoHooks(() => (
+  <FrontendClientBase>
+    <Content />
+  </FrontendClientBase>
+))
+
+function Content() {
+  const router = useRouter()
+  useEffect(() => {
+    Cookies.set(features['authVidis'].cookieName, '1', { expires: 60 })
+
+    void router.push('/auth/login')
+  }, [router])
+
+  return <LoadingSpinner noText />
+}


### PR DESCRIPTION
- this will allow testing of vidis in production
- ~might conflict with https://github.com/serlo/frontend/pull/3853 (not sure if it's necessary any more)~

route to directly enable vidis experiment is `/auth/___activate_vidis` (but not testable in feature branch since vidis is always active in dev/staging)