### PR TITLE
feat(plugin-image): expose `upload` prop in Editor config

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -56,25 +56,25 @@ See below for the current API specification.
 - **Long-Term Support**: Will stay
 - **Needs Change?**: Configuration props need restructuring
 
-#### 2. `SerloRenderer`, `type SerloRendererProps`
+### 2. `SerloRenderer`, `type SerloRendererProps`
 
 - **Why Exported/How Used**: `SerloRenderer` is a component provided by the `@serlo/editor` for rendering content in a non-editable format. This is particularly useful for displaying the content to users who are not currently editing or are not allowed to edit.
 - **Long-Term Support**: Will stay
 - **Needs Change?**: Same changes as `SerloEditor`
 
-#### 3. `type BaseEditor`
+### 3. `type BaseEditor`
 
 - **Why Exported/How Used**: This type describes the `editor` render prop provided by the `SerloEditor` component.
 - **Long-Term Support**: Will stay unless a better solution is found
 - **Needs Change?**: Unclear
 
-#### 4. Exports from from `@editor/plugin`, `@/components/fa-icon`, `@editor/editor-ui`
+### 4. Exports from from `@editor/plugin`, `@/components/fa-icon`, `@editor/editor-ui`
 
 - **Why Exported/How Used**: These exports are currently necessary for defining custom Edusharing plugins. We don't plan to support custom plugins in the future.
 - **Long-Term Support**: To be deprecated
 - **Needs Change?**: No
 
-#### 5. Style (css) export `@serlo/editor/styles.css`
+### 5. Style (css) export `@serlo/editor/styles.css`
 
 - **Why Exported/How Used**: Styles the editor with our custom css. Just import `import '@serlo/editor/style.css'` wherever you render the editor. Mostly used in the web component. The css already comes bundled within the JS of the editor package. Therefore, you shouldn't need to import this, unless you plan to render the editor within the Shadow DOM.
 - **Long-Term Support**: Yes

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -26,7 +26,7 @@ type InitialState = SerloEditorProps['initialState']
 function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
   return (
     <SerloEditor
-      pluginsProps={pluginsProps}
+      pluginsConfig={pluginsConfig}
       initialState={initialState}
       onChange={({ changed, getDocument }) => {
         if (changed){

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -4,9 +4,9 @@ This is an early version of the [Serlo Editor](https://de.serlo.org/editor). Be 
 
 If you are not using React, consider using the Serlo Editor as a [web component](https://www.npmjs.com/package/@serlo/editor-web-component).
 
-## Using the Serlo Editor
+# Using the Serlo Editor
 
-### Installation
+## Installation
 
 In your React project
 
@@ -14,7 +14,7 @@ In your React project
 yarn add @serlo/editor
 ```
 
-### Usage
+## Usage
 
 You can see a complete working example of the usage [here](https://github.com/serlo/serlo-editor-for-edusharing/blob/main/src/frontend/editor.tsx#L32).
 
@@ -26,6 +26,7 @@ type InitialState = SerloEditorProps['initialState']
 function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
   return (
     <SerloEditor
+      pluginsProps={pluginsProps}
       initialState={initialState}
       onChange={({ changed, getDocument }) => {
         if (changed){
@@ -79,34 +80,53 @@ See below for the current API specification.
 - **Long-Term Support**: Yes
 - **Needs Change?**: No
 
-### `SerloEditor` component props
+## `SerloEditor` component props
 
-- **`children`**: When passed in a function as the `children` prop, the `SerloEditor` component provides an `editor` render prop as the argument to the `children` function. This `editor` object provides:
+### **`children`**
 
-  - `element` - a React node for rendering the editor
-  - `i18n` - for customizing translation strings
-  - `history` - for persisting, undo, redo
-  - `selectRootDocument` - a function for selecting the current state
+When passed in a function as the `children` prop, the `SerloEditor` component provides an `editor` render prop as the argument to the `children` function. This `editor` object provides:
 
-- **`pluginsConfig` (optional)**: Serlo Editor plugins can be configured to an extent, this configuration is currently done via the `pluginsConfig` prop of the `SerloEditor` component. Each plugin can be configured separately. There are currently two special rules that apply to the Editor in general:
+- `element` - a React node for rendering the editor
+- `i18n` - for customizing translation strings
+- `history` - for persisting, undo, redo
+- `selectRootDocument` - a function for selecting the current state
 
-  - `enableTextAreaExercise`: A flag that enables the TextAreaExercise plugin. TextAreaExercise plugin is currently not yet ready for serlo.org, but it is enabled in Edusharing integration. **To be deprecated once more features are added to the TextAreaExercise plugin and it's ready for serlo.org.**
-  - `exerciseVisibleInSuggestion`: A flag that defines if Exercise plugin is visible in Text plugin suggestions. **Not necessary for Serlo Editor package, instead used by serlo.org, could be removed.**
+### **`pluginsConfig` (optional)**
 
-- **`customPlugins` (optional)**: An array of custom plugins. **To be deprecated, only used in Edusharing integration**.
+Serlo Editor plugins can be configured to an extent, this configuration is currently done via the `pluginsConfig` prop of the `SerloEditor` component. Each plugin can be configured separately.
+
+#### **Image** plugin
+
+The Image plugin currently accepts two props. **The API of the Image plugin is subject to changes in the future**.
+
+- `upload`: `(file: File) => Promise<string>` - used for uploading an image to the desired storage.
+- `validate` (optional): `(file: File) => { valid: true } | { valid: false; errors: FileError[] }` - used for validating the uploaded file. A default validator function is used if no validator function is provided by the user.
+
+#### General Editor config
+
+- `enableTextAreaExercise`: A flag that enables the TextAreaExercise plugin. TextAreaExercise plugin is currently not yet ready for serlo.org, but it is enabled in Edusharing integration. **To be deprecated once more features are added to the TextAreaExercise plugin and it's ready for serlo.org.**
+- `exerciseVisibleInSuggestion`: A flag that defines if Exercise plugin is visible in Text plugin suggestions. **Not necessary for Serlo Editor package, instead used by serlo.org, could be removed.**
+
+### **`customPlugins` (optional)**
+
+An array of custom plugins. **To be deprecated, only used in Edusharing integration**.
 
 - **`initialState` (optional)**: Pass in an `initialState` to the `SerloEditor` component to prevent seeing an empty editor state.
 
-- **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `({ changed, getDocument }) => void` of which you can call `getDocument()` to fetch the latest editor state.
+### **`onChange` (optional)**
 
-- **`language` (optional)**: The default language is `de`.
+To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `({ changed, getDocument }) => void` of which you can call `getDocument()` to fetch the latest editor state.
 
-## Releasing a new version to npm
+### **`language` (optional)**
+
+The default language is `de`.
+
+# Releasing a new version to npm
 
 Bump the version number in the package.json and
 the github workflow seen inside `editor.yaml` will take care of the publishing.
 
-## Linking for local development with integrations
+# Linking for local development with integrations
 
 In order to avoid publishing the editor to NPM or dealing with tarballs every time you need to test your changes in an integration locally, you can use `yalc` to link the editor package to your integration locally.
 

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -43,7 +43,7 @@ export function createBasicPlugins(config: CreateBasicPluginsConfig) {
     },
     {
       type: EditorPluginType.Multimedia,
-      plugin: createMultimediaPlugin(config.multimedia),
+      plugin: createMultimediaPlugin(createMultimediaPluginConfig(config)),
       visibleInSuggestions: true,
       icon: <IconMultimedia />,
     },
@@ -147,4 +147,23 @@ function hasImagePluginConfigUploadPropertyDefined(
   imagePluginConfig: CreateImagePluginConfig
 ): imagePluginConfig is ImageConfig {
   return imagePluginConfig.upload !== undefined
+}
+
+function createMultimediaPluginConfig(config: CreateBasicPluginsConfig) {
+  const { image, multimedia } = config
+
+  return {
+    ...multimedia,
+    allowedPlugins: multimedia.allowedPlugins.filter((allowedPlugin) => {
+      if (
+        // If the user didn't provide the `upload` prop for the Image plugin,
+        // remove the Image plugin from Multimedia config allowed plugins
+        allowedPlugin === EditorPluginType.Image &&
+        !hasImagePluginConfigUploadPropertyDefined(image)
+      ) {
+        return false
+      }
+      return true
+    }),
+  }
 }

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -2,6 +2,7 @@ import IconBox from '@editor/editor-ui/assets/plugin-icons/icon-box.svg'
 import IconEquation from '@editor/editor-ui/assets/plugin-icons/icon-equation.svg'
 import IconGeogebra from '@editor/editor-ui/assets/plugin-icons/icon-geogebra.svg'
 import IconHighlight from '@editor/editor-ui/assets/plugin-icons/icon-highlight.svg'
+import IconImage from '@editor/editor-ui/assets/plugin-icons/icon-image.svg'
 import IconMultimedia from '@editor/editor-ui/assets/plugin-icons/icon-multimedia.svg'
 import IconSpoiler from '@editor/editor-ui/assets/plugin-icons/icon-spoiler.svg'
 import IconTable from '@editor/editor-ui/assets/plugin-icons/icon-table.svg'
@@ -13,6 +14,7 @@ import { equationsPlugin } from '@editor/plugins/equations'
 import { exercisePlugin } from '@editor/plugins/exercise'
 import { geoGebraPlugin } from '@editor/plugins/geogebra'
 import { createHighlightPlugin } from '@editor/plugins/highlight'
+import { ImageConfig, createImagePlugin } from '@editor/plugins/image'
 import { createInputExercisePlugin } from '@editor/plugins/input-exercise'
 import { createMultimediaPlugin } from '@editor/plugins/multimedia'
 import { createRowsPlugin } from '@editor/plugins/rows'
@@ -27,7 +29,11 @@ import { unsupportedPlugin } from '@editor/plugins/unsupported'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
 
-export function createBasicPlugins(props: Required<PluginsConfig>) {
+type CreateBasicPluginsConfig = Required<Omit<PluginsConfig, 'image'>> & {
+  image: CreateImagePluginConfig
+}
+
+export function createBasicPlugins(config: CreateBasicPluginsConfig) {
   return [
     {
       type: EditorPluginType.Text,
@@ -37,13 +43,13 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
     },
     {
       type: EditorPluginType.Multimedia,
-      plugin: createMultimediaPlugin(props.multimedia),
+      plugin: createMultimediaPlugin(config.multimedia),
       visibleInSuggestions: true,
       icon: <IconMultimedia />,
     },
     {
       type: EditorPluginType.Spoiler,
-      plugin: createSpoilerPlugin(props.spoiler),
+      plugin: createSpoilerPlugin(config.spoiler),
       visibleInSuggestions: true,
       icon: <IconSpoiler />,
     },
@@ -55,13 +61,13 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
     },
     {
       type: EditorPluginType.Box,
-      plugin: createBoxPlugin(props.box),
+      plugin: createBoxPlugin(config.box),
       visibleInSuggestions: true,
       icon: <IconBox />,
     },
     {
       type: EditorPluginType.SerloTable,
-      plugin: createSerloTablePlugin(props.table),
+      plugin: createSerloTablePlugin(config.table),
       visibleInSuggestions: true,
       icon: <IconTable />,
     },
@@ -77,15 +83,27 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
       visibleInSuggestions: true,
       icon: <IconHighlight />,
     },
+    // Image plugin will have the `validate` prop by default, but if the user
+    // didn't provide the `upload` prop, Image plugin will not be created
+    ...(hasImagePluginConfigUploadPropertyDefined(config.image)
+      ? [
+          {
+            type: EditorPluginType.Image,
+            plugin: createImagePlugin(config.image),
+            visibleInSuggestions: true,
+            icon: <IconImage />,
+          },
+        ]
+      : []),
 
     // Exercises etc.
     // ===================================================
     {
       type: EditorPluginType.Exercise,
       plugin: exercisePlugin,
-      visibleInSuggestions: props.general.exerciseVisibleInSuggestion,
+      visibleInSuggestions: config.general.exerciseVisibleInSuggestion,
     },
-    ...(props.general.enableTextAreaExercise
+    ...(config.general.enableTextAreaExercise
       ? [
           {
             type: EditorPluginType.TextAreaExercise,
@@ -117,4 +135,16 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
       plugin: genericContentTypePlugin,
     },
   ]
+}
+
+interface CreateImagePluginConfig {
+  disableFileUpload?: ImageConfig['disableFileUpload']
+  upload?: ImageConfig['upload']
+  validate: ImageConfig['validate']
+}
+
+function hasImagePluginConfigUploadPropertyDefined(
+  imagePluginConfig: CreateImagePluginConfig
+): imagePluginConfig is ImageConfig {
+  return imagePluginConfig.upload !== undefined
 }

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -1,6 +1,8 @@
 import type { PluginWithData } from '@editor/plugin/helpers/editor-plugins'
 import type { PluginStaticRenderer } from '@editor/plugin/helpers/editor-renderer'
 import type { BoxConfig } from '@editor/plugins/box'
+import { ImageConfig } from '@editor/plugins/image'
+import { validateFile } from '@editor/plugins/image/utils/validate-file'
 import {
   defaultConfig as defaultMultimediaConfig,
   type MultimediaConfig,
@@ -12,6 +14,10 @@ import type { SupportedLanguage } from '@editor/types/language-data'
 
 export interface PluginsConfig {
   box?: BoxConfig
+  image?: {
+    validate?: ImageConfig['validate']
+    upload: ImageConfig['upload']
+  }
   multimedia?: MultimediaConfig
   spoiler?: SpoilerConfig
   table?: SerloTableConfig
@@ -25,9 +31,16 @@ export interface PluginsConfig {
 // and will not be supported in the future
 export type CustomPlugin = PluginWithData & PluginStaticRenderer
 
-const defaultPluginsConfig: Required<PluginsConfig> = {
+type DefaultPluginsConfig = Required<Omit<PluginsConfig, 'image'>> & {
+  // Image plugin should only have `validate` as a default prop, `upload` needs to be set by the user
+  image: Pick<ImageConfig, 'validate'>
+}
+const defaultPluginsConfig: DefaultPluginsConfig = {
   box: {
     allowedPlugins: [],
+  },
+  image: {
+    validate: validateFile,
   },
   multimedia: defaultMultimediaConfig,
   spoiler: {

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -39,6 +39,11 @@ export function SerloEditor(props: SerloEditorProps) {
   const pluginsConfig = {
     ...defaultSerloEditorProps.pluginsConfig,
     ...props.pluginsConfig,
+    // Merge image user-provided `upload` and the default `validate` props
+    image: {
+      ...defaultSerloEditorProps.pluginsConfig.image,
+      ...props.pluginsConfig?.image,
+    },
   }
 
   const { instanceData, loggedInData } = editorData[language]

--- a/packages/editor/src/plugins/image/index.ts
+++ b/packages/editor/src/plugins/image/index.ts
@@ -1,9 +1,9 @@
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { showToastNotice } from '@serlo/frontend/src/helper/show-toast-notice'
-import type { FileError } from '@serlo/frontend/src/serlo-editor-integration/image-with-serlo-config'
 
 import { ImageEditor } from './editor'
+import type { FileError } from './utils/validate-file'
 import {
   type EditorPlugin,
   type EditorPluginProps,

--- a/packages/editor/src/plugins/image/utils/validate-file.ts
+++ b/packages/editor/src/plugins/image/utils/validate-file.ts
@@ -1,0 +1,60 @@
+import { UploadValidator } from '@editor/plugin/upload'
+
+const maxFileSize = 2 * 1024 * 1024
+const allowedExtensions = ['gif', 'jpg', 'jpeg', 'png', 'svg', 'webp']
+
+enum FileErrorCode {
+  TOO_MANY_FILES,
+  NO_FILE_SELECTED,
+  BAD_EXTENSION,
+  FILE_TOO_BIG,
+  UPLOAD_FAILED,
+}
+
+export interface FileError {
+  errorCode: FileErrorCode
+  message: string
+}
+
+export const validateFile: UploadValidator<FileError[]> = (file) => {
+  let uploadErrors: FileErrorCode[] = []
+
+  if (!file) {
+    uploadErrors = [...uploadErrors, FileErrorCode.NO_FILE_SELECTED]
+  } else if (!matchesAllowedExtensions(file.name)) {
+    uploadErrors = [...uploadErrors, FileErrorCode.BAD_EXTENSION]
+  } else if (file.size > maxFileSize) {
+    uploadErrors = [...uploadErrors, FileErrorCode.FILE_TOO_BIG]
+  } else {
+    return { valid: true }
+  }
+
+  return { valid: false, errors: handleErrors(uploadErrors) }
+}
+
+function matchesAllowedExtensions(fileName: string) {
+  const extension = fileName.toLowerCase().slice(fileName.lastIndexOf('.') + 1)
+  return allowedExtensions.includes(extension)
+}
+
+function handleErrors(errors: FileErrorCode[]): FileError[] {
+  return errors.map((error) => ({
+    errorCode: error,
+    message: errorCodeToMessage(error),
+  }))
+}
+
+function errorCodeToMessage(error: FileErrorCode) {
+  switch (error) {
+    case FileErrorCode.TOO_MANY_FILES:
+      return 'You can only upload one file'
+    case FileErrorCode.NO_FILE_SELECTED:
+      return 'No file selected'
+    case FileErrorCode.BAD_EXTENSION:
+      return 'Not an accepted file type'
+    case FileErrorCode.FILE_TOO_BIG:
+      return 'Filesize is too big'
+    case FileErrorCode.UPLOAD_FAILED:
+      return 'Error while uploading'
+  }
+}


### PR DESCRIPTION
Resolves #3866 

Usage:
```
<SerloEditor
  pluginsConfig={{
    image: {
      upload: uploadFile
    }
  }}
  initialState={this.initialState}
>
```
where `uploadFile` is of type `UploadHandler`:
```
type UploadHandler = (file: File) => Promise<string>
```