### PR TITLE
try to improve INP

### DIFF
--- a/packages/editor/src/plugins/solution/renderer.tsx
+++ b/packages/editor/src/plugins/solution/renderer.tsx
@@ -40,12 +40,14 @@ export function SolutionRenderer({
         )}
         {elementAfterToggle}
       </nav>
-      {visible ? (
-        <div className="serlo-solution-box">
-          {visible === 'solution' ? renderSolutionContent() : null}
-          {visible === 'strategy' ? strategy : null}
+      <div className={cn('serlo-solution-box', visible ? '' : 'hidden')}>
+        <div className={cn(visible === 'solution' ? '' : 'hidden')}>
+          {renderSolutionContent()}
         </div>
-      ) : null}
+        <div className={cn(visible === 'strategy' ? '' : 'hidden')}>
+          {strategy}
+        </div>
+      </div>
     </>
   )
 


### PR DESCRIPTION
**Problem:** [Interaction to Next Paint](https://web.dev/articles/inp) (INP) is quite slow when the solution of an exercise is long.

**Approach:**
Toggling the solutions with css display instead of rendering solution on click improves this
(but might cause long exercise collection to load slower overall?)


@hejtful, @Entkenntnis Review not really needed, but maybe you have other suggestions :)


pages to check after some time:
- https://de.serlo.org/mathe/78918/aufgaben-zum-l%C3%B6sen-linearer-gleichungssysteme
- https://de.serlo.org/mathe/25616/aufgaben-zum-baumdiagramm
- https://de.serlo.org/mathe/50462/aufgaben-zu-oberfläche-und-volumen-von-würfel-und-quader
- https://de.serlo.org/mathe/31912/aufgaben-zu-linearen-funktionen-und-geradengleichungen
- https://de.serlo.org/mathe/30678/aufgaben-zur-satzgruppe-des-pythagoras
- https://de.serlo.org/mathe/63588/aufgaben-zum-zylinder
- https://de.serlo.org/mathe/31911/aufgaben-zu-linearen-funktionen-als-geraden-im-koordinatensystem
- https://de.serlo.org/mathe/16351/aufgaben-zur-kurvendiskussion – 429 ms
- https://de.serlo.org/mathe/40819/aufgaben-zum-vereinfachen-von-termen → 943 ms

https://pagespeed.web.dev/analysis/https-de-serlo-org-mathe-78918-aufgaben-zum-l%C3%B6sen-linearer-gleichungssysteme/od8fl8oird?utm_source=search_console&form_factor=mobile&hl=de