### PR TITLE
Refactor(editor) replace NEXT env variables with custom rollup plugin

### DIFF
--- a/packages/editor-web-component/vite.config.ts
+++ b/packages/editor-web-component/vite.config.ts
@@ -6,45 +6,21 @@ import { Plugin, defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import dts from 'vite-plugin-dts'
 import svgr from 'vite-plugin-svgr'
-import replace from '@rollup/plugin-replace'
 import * as acorn from 'acorn'
 import * as estraverse from 'estraverse'
 import * as escodegen from 'escodegen'
 import { type Program, type Node } from 'estree'
+import replace from '@rollup/plugin-replace'
 
 // https://vitejs.dev/guide/build.html#library-mode
 
-const js = (value: string) => JSON.stringify(value)
-
-const productionKeys = ['process.env.NODE_ENV', 'process.env.NEXT_PUBLIC_ENV']
-
-const notProvidedKeys = [
-  '__NEXT_I18N_SUPPORT',
-  '__NEXT_ROUTER_BASEPATH',
-  '__NEXT_CLIENT_ROUTER_D_FILTER',
-  '__NEXT_CLIENT_ROUTER_S_FILTER',
-  '__NEXT_LINK_NO_TOUCH_START',
-  '__NEXT_OPTIMISTIC_CLIENT_CACHE',
-  '__NEXT_SCROLL_RESTORATION',
-  '__NEXT_HAS_REWRITES',
-  '__NEXT_CROSS_ORIGIN',
-  '__NEXT_MANUAL_CLIENT_BASE_PATH',
-  '__NEXT_STRICT_NEXT_HEAD',
-  '__NEXT_TRAILING_SLASH',
-  '__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE',
-  '__NEXT_CLIENT_ROUTER_FILTER_ENABLED',
-  '__NEXT_MIDDLEWARE_PREFETCH',
-  'NEXT_RUNTIME',
-  'NEXT_DEPLOYMENT_ID',
-]
+// We already strip most of the env variables in the built of the editor,
+// however React seems to reintroduce this one!
+const productionKeys = ['process.env.NODE_ENV']
 
 const envReplacements = {
-  ...Object.fromEntries(productionKeys.map((key) => [key, js('production')])),
   ...Object.fromEntries(
-    notProvidedKeys.map((key) => [
-      `process.env.${key}`,
-      js(`NOT_PROVIDED_${key}`),
-    ])
+    productionKeys.map((key) => [key, JSON.stringify('production')])
   ),
 }
 

--- a/packages/editor-web-component/vite.config.ts
+++ b/packages/editor-web-component/vite.config.ts
@@ -16,12 +16,8 @@ import replace from '@rollup/plugin-replace'
 
 // We already strip most of the env variables in the built of the editor,
 // however React seems to reintroduce this one!
-const productionKeys = ['process.env.NODE_ENV']
-
 const envReplacements = {
-  ...Object.fromEntries(
-    productionKeys.map((key) => [key, JSON.stringify('production')])
-  ),
+  'process.env.NODE_ENV': JSON.stringify('production'),
 }
 
 function parseCodeToAST(code: string): Program {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -68,6 +68,7 @@
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-select": "^1.2.2",
     "@reduxjs/toolkit": "^1.9.7",
+    "@rollup/plugin-replace": "^5.0.5",
     "@serlo/authorization": "^0.60.0",
     "@serlo/frontend": "workspace:*",
     "@serlo/typescript-config": "workspace:*",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/editor",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "homepage": "https://de.serlo.org/editor",
   "bugs": {
     "url": "https://github.com/serlo/frontend/issues"

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -3,11 +3,46 @@ import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 import svgr from 'vite-plugin-svgr'
+import replace from '@rollup/plugin-replace'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { existsSync, mkdirSync, writeFileSync } from 'fs'
 
 // https://vitejs.dev/guide/build.html#library-mode
 /* we use vite only for building the serlo editor package */
+
+const js = (value: string) => JSON.stringify(value)
+
+const productionKeys = ['process.env.NODE_ENV', 'process.env.NEXT_PUBLIC_ENV']
+
+const notProvidedKeys = [
+  '__NEXT_I18N_SUPPORT',
+  '__NEXT_ROUTER_BASEPATH',
+  '__NEXT_CLIENT_ROUTER_D_FILTER',
+  '__NEXT_CLIENT_ROUTER_S_FILTER',
+  '__NEXT_LINK_NO_TOUCH_START',
+  '__NEXT_OPTIMISTIC_CLIENT_CACHE',
+  '__NEXT_SCROLL_RESTORATION',
+  '__NEXT_HAS_REWRITES',
+  '__NEXT_CROSS_ORIGIN',
+  '__NEXT_MANUAL_CLIENT_BASE_PATH',
+  '__NEXT_STRICT_NEXT_HEAD',
+  '__NEXT_TRAILING_SLASH',
+  '__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE',
+  '__NEXT_CLIENT_ROUTER_FILTER_ENABLED',
+  '__NEXT_MIDDLEWARE_PREFETCH',
+  'NEXT_RUNTIME',
+  'NEXT_DEPLOYMENT_ID',
+]
+
+const envReplacements = {
+  ...Object.fromEntries(productionKeys.map((key) => [key, js('production')])),
+  ...Object.fromEntries(
+    notProvidedKeys.map((key) => [
+      `process.env.${key}`,
+      js(`NOT_PROVIDED_${key}`),
+    ])
+  ),
+}
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -35,6 +70,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    replace({ ...envReplacements, preventAssignment: false }),
     react(),
     dts({
       outDir: 'dist',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,6 +4937,7 @@ __metadata:
     "@radix-ui/react-navigation-menu": ^1.1.4
     "@radix-ui/react-select": ^1.2.2
     "@reduxjs/toolkit": ^1.9.7
+    "@rollup/plugin-replace": ^5.0.5
     "@serlo/authorization": ^0.60.0
     "@serlo/frontend": "workspace:*"
     "@serlo/katex-styles": 1.0.1


### PR DESCRIPTION
Consumers of the React package (@serlo/editor) had to define the process.env.NEXT_PUBLIC_ENV. Now we already remove it in the built of the editor, instead of the built of the editor-web-component which makes the life of consumers of the package slightly easier.

Works great for me. @LarsTheGlidingSquirrel I did check edusharing with yalc, but better double check that we are not breaking anything there as it uses Next.js under the hood. To be clear, this strips away the NEXT env variables at build time, so doesn't influence or overwrite the ones we are defining as part of edusharing.