### PR TITLE
feat(plugin-image): use editor testing secret to upload to testing bucket

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -90,6 +90,7 @@ See below for the current API specification.
 
 - **`pluginsConfig` (optional)**: Serlo Editor plugins can be configured to an extent, this configuration is currently done via the `pluginsConfig` prop of the `SerloEditor` component. Each plugin can be configured separately. There is currently ony one special rule that applies to the Editor in general:
 
+  - `testingSecret`: Required to use Image plugin in testing. A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **To be deprecated once a long term solution is agreed on.**
   - `enableTextAreaExercise`: A flag that enables the TextAreaExercise plugin. TextAreaExercise plugin is currently not yet ready for serlo.org, but it is enabled in Edusharing integration. **To be deprecated once more features are added to the TextAreaExercise plugin and it's ready for serlo.org.**
 
 - **`customPlugins` (optional)**: An array of custom plugins. **To be deprecated, only used in Edusharing integration**.

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -2,6 +2,7 @@ import IconBox from '@editor/editor-ui/assets/plugin-icons/icon-box.svg'
 import IconEquation from '@editor/editor-ui/assets/plugin-icons/icon-equation.svg'
 import IconGeogebra from '@editor/editor-ui/assets/plugin-icons/icon-geogebra.svg'
 import IconHighlight from '@editor/editor-ui/assets/plugin-icons/icon-highlight.svg'
+import IconImage from '@editor/editor-ui/assets/plugin-icons/icon-image.svg'
 import IconMultimedia from '@editor/editor-ui/assets/plugin-icons/icon-multimedia.svg'
 import IconSpoiler from '@editor/editor-ui/assets/plugin-icons/icon-spoiler.svg'
 import IconTable from '@editor/editor-ui/assets/plugin-icons/icon-table.svg'
@@ -27,7 +28,9 @@ import { unsupportedPlugin } from '@editor/plugins/unsupported'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
 
-export function createBasicPlugins(props: Required<PluginsConfig>) {
+import { createTestingImagePlugin } from './image-with-testing-config'
+
+export function createBasicPlugins(config: Required<PluginsConfig>) {
   return [
     {
       type: EditorPluginType.Text,
@@ -35,15 +38,25 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
       visibleInSuggestions: true,
       icon: <IconText />,
     },
+    ...(config.general.testingSecret
+      ? [
+          {
+            type: EditorPluginType.Image,
+            plugin: createTestingImagePlugin(config.general.testingSecret),
+            visibleInSuggestions: true,
+            icon: <IconImage />,
+          },
+        ]
+      : []),
     {
       type: EditorPluginType.Multimedia,
-      plugin: createMultimediaPlugin(props.multimedia),
+      plugin: createMultimediaPlugin(createMultimediaPluginConfig(config)),
       visibleInSuggestions: true,
       icon: <IconMultimedia />,
     },
     {
       type: EditorPluginType.Spoiler,
-      plugin: createSpoilerPlugin(props.spoiler),
+      plugin: createSpoilerPlugin(config.spoiler),
       visibleInSuggestions: true,
       icon: <IconSpoiler />,
     },
@@ -55,13 +68,13 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
     },
     {
       type: EditorPluginType.Box,
-      plugin: createBoxPlugin(props.box),
+      plugin: createBoxPlugin(config.box),
       visibleInSuggestions: true,
       icon: <IconBox />,
     },
     {
       type: EditorPluginType.SerloTable,
-      plugin: createSerloTablePlugin(props.table),
+      plugin: createSerloTablePlugin(config.table),
       visibleInSuggestions: true,
       icon: <IconTable />,
     },
@@ -85,7 +98,7 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
       plugin: exercisePlugin,
       visibleInSuggestions: true,
     },
-    ...(props.general.enableTextAreaExercise
+    ...(config.general.enableTextAreaExercise
       ? [
           {
             type: EditorPluginType.TextAreaExercise,
@@ -117,4 +130,23 @@ export function createBasicPlugins(props: Required<PluginsConfig>) {
       plugin: genericContentTypePlugin,
     },
   ]
+}
+
+function createMultimediaPluginConfig(config: Required<PluginsConfig>) {
+  const { general, multimedia } = config
+
+  return {
+    ...multimedia,
+    allowedPlugins: multimedia.allowedPlugins.filter((allowedPlugin) => {
+      if (
+        // If the user didn't provide the Serlo Editor testing secret,
+        // remove the Image plugin from Multimedia config allowed plugins
+        allowedPlugin === EditorPluginType.Image &&
+        !general?.testingSecret
+      ) {
+        return false
+      }
+      return true
+    }),
+  }
 }

--- a/packages/editor/src/editor-integration/image-with-testing-config.ts
+++ b/packages/editor/src/editor-integration/image-with-testing-config.ts
@@ -1,0 +1,166 @@
+import { LoadedFile, UploadValidator } from '@editor/plugin'
+import { createImagePlugin } from '@editor/plugins/image'
+import { gql } from 'graphql-request'
+
+import { createGraphqlFetch } from '@/api/graphql-fetch'
+import { MediaType, MediaUploadQuery } from '@/fetcher/graphql-types/operations'
+import { showToastNotice } from '@/helper/show-toast-notice'
+
+const maxFileSize = 2 * 1024 * 1024
+const allowedExtensions = ['gif', 'jpg', 'jpeg', 'png', 'svg', 'webp']
+const supportedMimeTypes = [
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/svg+xml',
+  'image/webp',
+] as const
+
+type SupportedMimeType = (typeof supportedMimeTypes)[number]
+
+const mimeTypesToMediaType: Record<SupportedMimeType, MediaType> = {
+  'image/gif': MediaType.ImageGif,
+  'image/jpeg': MediaType.ImageJpeg,
+  'image/png': MediaType.ImagePng,
+  'image/svg+xml': MediaType.ImageSvgXml,
+  'image/webp': MediaType.ImageWebp,
+}
+
+enum FileErrorCode {
+  TOO_MANY_FILES,
+  NO_FILE_SELECTED,
+  BAD_EXTENSION,
+  FILE_TOO_BIG,
+  UPLOAD_FAILED,
+}
+
+export interface FileError {
+  errorCode: FileErrorCode
+  message: string
+}
+
+const validateFile: UploadValidator<FileError[]> = (file) => {
+  let uploadErrors: FileErrorCode[] = []
+
+  if (!file) {
+    uploadErrors = [...uploadErrors, FileErrorCode.NO_FILE_SELECTED]
+  } else if (!matchesAllowedExtensions(file.name)) {
+    uploadErrors = [...uploadErrors, FileErrorCode.BAD_EXTENSION]
+  } else if (file.size > maxFileSize) {
+    uploadErrors = [...uploadErrors, FileErrorCode.FILE_TOO_BIG]
+  } else {
+    return { valid: true }
+  }
+
+  return { valid: false, errors: handleErrors(uploadErrors) }
+}
+
+export const createTestingImagePlugin = (secret: string) => {
+  return createImagePlugin({
+    upload: createUploadImageHandler(secret),
+    validate: validateFile,
+  })
+}
+
+function createUploadImageHandler(secret: string) {
+  const readFile = createReadFile(secret)
+  return async function uploadImageHandler(file: File): Promise<string> {
+    const validation = validateFile(file)
+    if (!validation.valid) {
+      onError(validation.errors)
+      return Promise.reject(validation.errors)
+    }
+
+    return (await readFile(file)).dataUrl
+  }
+}
+
+export function createReadFile(secret: string) {
+  return async function readFile(file: File): Promise<LoadedFile> {
+    return new Promise((resolve, reject) => {
+      const gqlFetch = createGraphqlFetch()
+      const args = JSON.stringify({
+        query: uploadUrlQuery,
+        context: {
+          headers: {
+            'X-SERLO-EDITOR-TESTING': secret,
+          },
+        },
+        variables: {
+          mediaType: mimeTypesToMediaType[file.type as SupportedMimeType],
+        },
+      })
+
+      async function runFetch() {
+        const data = (await gqlFetch(args)) as MediaUploadQuery
+        const reader = new FileReader()
+
+        reader.onload = async function (e: ProgressEvent) {
+          if (!e.target) return
+
+          try {
+            const response = await fetch(data.media.newUpload.uploadUrl, {
+              method: 'PUT',
+              headers: { 'Content-Type': file.type },
+              body: file,
+            })
+
+            if (response.status !== 200) reject()
+            resolve({
+              file,
+              dataUrl: data.media.newUpload.urlAfterUpload,
+            })
+          } catch {
+            reject()
+          }
+        }
+
+        reader.readAsDataURL(file)
+      }
+
+      void runFetch()
+    })
+  }
+}
+
+function matchesAllowedExtensions(fileName: string) {
+  const extension = fileName.toLowerCase().slice(fileName.lastIndexOf('.') + 1)
+  return allowedExtensions.includes(extension)
+}
+
+function handleErrors(errors: FileErrorCode[]): FileError[] {
+  return errors.map((error) => ({
+    errorCode: error,
+    message: errorCodeToMessage(error),
+  }))
+}
+
+function onError(errors: FileError[]): void {
+  showToastNotice(errors.map((error) => error.message).join('\n'), 'warning')
+}
+
+function errorCodeToMessage(error: FileErrorCode) {
+  switch (error) {
+    case FileErrorCode.TOO_MANY_FILES:
+      return 'You can only upload one file'
+    case FileErrorCode.NO_FILE_SELECTED:
+      return 'No file selected'
+    case FileErrorCode.BAD_EXTENSION:
+      return 'Not an accepted file type'
+    case FileErrorCode.FILE_TOO_BIG:
+      return 'Filesize is too big'
+    case FileErrorCode.UPLOAD_FAILED:
+      return 'Error while uploading'
+  }
+}
+
+const uploadUrlQuery = gql`
+  query mediaUpload($mediaType: MediaType!) {
+    media {
+      newUpload(mediaType: $mediaType) {
+        uploadUrl
+        urlAfterUpload
+      }
+    }
+  }
+`

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -16,6 +16,7 @@ export interface PluginsConfig {
   spoiler?: SpoilerConfig
   table?: SerloTableConfig
   general?: {
+    testingSecret?: string
     enableTextAreaExercise: boolean
   }
 }


### PR DESCRIPTION
API PR: https://github.com/serlo/api.serlo.org/pull/1624
CFW PR: https://github.com/serlo/cloudflare-worker/pull/810
Infra PR: https://github.com/serlo/infra/pull/90

A new "serlo-editor-testing" bucket is open for media uploaded while testing integrations of the Editor.

To be able to upload to the new bucket, the Editor needs to receive the secret (as `testingSecret` general config prop).

The frontend (serlo.org) still uses its old configuration, no changes there.