### PR TITLE
SEO: add noIndex to many pages, refactor head code

### DIFF
--- a/apps/web/src/components/entity/entity-base.tsx
+++ b/apps/web/src/components/entity/entity-base.tsx
@@ -211,7 +211,7 @@ export function EntityBase({ children, page, entityId }: EntityBaseProps) {
         <HeadTags
           data={page.metaData}
           breadcrumbsData={page.breadcrumbsData}
-          noindex={'entityData' in page && page.entityData.trashed}
+          noIndex={'entityData' in page && page.entityData.trashed}
         />
       )}
       {page.kind === 'single-entity' || page.kind === 'taxonomy' ? (

--- a/apps/web/src/components/exams-info-box.tsx
+++ b/apps/web/src/components/exams-info-box.tsx
@@ -1,10 +1,10 @@
 import { BoxRenderer } from '@editor/plugins/box/renderer'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons'
 import { faGraduationCap } from '@fortawesome/free-solid-svg-icons'
-import Head from 'next/head'
 
 import { Link } from './content/link'
 import { FaIcon } from './fa-icon'
+import { HeadTags } from './head-tags'
 import {
   SupportedRegion,
   deRegions,
@@ -104,12 +104,7 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
             ) : null}
           </>
         </BoxRenderer>
-        {extraMeta ? (
-          <Head>
-            <title>{extraMeta.title}</title>
-            <meta name="description" content={extraMeta.metaDescription} />
-          </Head>
-        ) : null}
+        {extraMeta ? <HeadTags data={{ ...extraMeta }} /> : null}
 
         <style jsx global>
           {`

--- a/apps/web/src/components/frontend-client-base/frontend-client-base.tsx
+++ b/apps/web/src/components/frontend-client-base/frontend-client-base.tsx
@@ -1,4 +1,5 @@
 import type { AuthorizationPayload } from '@serlo/authorization'
+import Head from 'next/head'
 import { Router, useRouter } from 'next/router'
 import NProgress from 'nprogress'
 import { useState, useEffect } from 'react'
@@ -29,6 +30,7 @@ export interface FrontendClientBaseProps {
   children: JSX.Element | (JSX.Element | null)[]
   noHeaderFooter?: boolean
   noContainers?: boolean
+  noIndex?: boolean
   showNav?: boolean
   serloEntityData?: UuidsContextData
   authorization?: AuthorizationPayload
@@ -54,6 +56,7 @@ export function FrontendClientBase({
   children,
   noHeaderFooter,
   noContainers,
+  noIndex,
   showNav,
   serloEntityData,
   authorization,
@@ -112,6 +115,11 @@ export function FrontendClientBase({
   return (
     <InstanceDataProvider value={instanceData}>
       <PrintMode />
+      {noIndex ? (
+        <Head>
+          <meta name="robots" content="noindex" />
+        </Head>
+      ) : null}
       <AuthProvider unauthenticatedAuthorizationPayload={authorization}>
         <LoggedInDataProvider value={loggedInData}>
           <UuidsProvider value={serloEntityData ?? null}>

--- a/apps/web/src/components/head-tags.tsx
+++ b/apps/web/src/components/head-tags.tsx
@@ -9,10 +9,10 @@ import { serloDomain } from '@/helper/urls/serlo-domain'
 interface HeadTagsProps {
   data: HeadData
   breadcrumbsData?: BreadcrumbsData
-  noindex?: boolean
+  noIndex?: boolean
 }
 
-export function HeadTags({ data, breadcrumbsData, noindex }: HeadTagsProps) {
+export function HeadTags({ data, breadcrumbsData, noIndex }: HeadTagsProps) {
   const { title, contentType, metaDescription, metaImage, canonicalUrl } = data
   const { strings, lang } = useInstanceData()
   const router = useRouter()
@@ -56,7 +56,7 @@ export function HeadTags({ data, breadcrumbsData, noindex }: HeadTagsProps) {
       (entry) => entry.id === testAreaId
     )
     if (
-      noindex ||
+      noIndex ||
       (filteredBreadcrumbs && filteredBreadcrumbs.length > 0) ||
       data.title.startsWith('Testbereich')
     ) {

--- a/apps/web/src/components/pages/add-revision.tsx
+++ b/apps/web/src/components/pages/add-revision.tsx
@@ -1,9 +1,9 @@
 import { faWarning } from '@fortawesome/free-solid-svg-icons'
-import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
 import { loginUrl } from './auth/utils'
 import { Link } from '../content/link'
+import { HeadTags } from '../head-tags'
 import { InfoPanel } from '../info-panel'
 import { LoadingSpinner } from '../loading/loading-spinner'
 import { Breadcrumbs } from '../navigation/breadcrumbs'
@@ -110,14 +110,12 @@ export function AddRevision({
     return success ? Promise.resolve() : Promise.reject()
   }
 
+  const typeString = getTranslatedType(strings, type)
+  const title = `${strings.editOrAdd.button} | ${typeString}${id ? ` (${id})` : ''}`
+
   return (
     <>
-      <Head>
-        <title>{`${strings.editOrAdd.button} | ${getTranslatedType(
-          strings,
-          type
-        )}${id ? ` (${id})` : ''}`}</title>
-      </Head>
+      <HeadTags data={{ title }} />
       {renderBacklink()}
       <div className="controls-portal pointer-events-none sticky top-0 z-[90] bg-white md:bg-transparent" />
       <div className="serlo-editor-hacks mx-auto mb-24 max-w-[816px]">

--- a/apps/web/src/components/pages/editor/editor-presentation.tsx
+++ b/apps/web/src/components/pages/editor/editor-presentation.tsx
@@ -22,14 +22,10 @@ const h3Class = 'text-gray-700 text-[1.3rem] font-extrabold'
 export function EditorPresentation() {
   editorRenderers.init(createRenderers())
 
+  const title = 'Serlo Editor: Seamless Creation of Digital Learning Resources'
   return (
     <>
-      <HeadTags
-        data={{
-          title:
-            'Serlo Editor: Seamless Creation of Digital Learning Resources',
-        }}
-      />
+      <HeadTags data={{ title }} />
       <header className="px-side pb-8 pt-6 lg:px-side-lg">
         <Logo />
         {renderSupporterLogos()}

--- a/apps/web/src/components/pages/error-page.tsx
+++ b/apps/web/src/components/pages/error-page.tsx
@@ -1,7 +1,7 @@
-import Head from 'next/head'
 import { useState, useEffect } from 'react'
 
 import { PageTitle } from '../content/page-title'
+import { HeadTags } from '../head-tags'
 import { HSpace } from '@/components/content/h-space'
 import { useInstanceData } from '@/contexts/instance-context'
 import { getTranslatedType } from '@/helper/get-translated-type'
@@ -49,13 +49,12 @@ export function ErrorPage({ code, message }: ErrorPageProps) {
       ? errStrings.temporary
       : errStrings.permanent
 
+  const titleText = isDeletedComment ? 'Deleted Comment' : title
+
   return (
     <>
-      <Head>
-        {isDeletedComment && 'Deleted Comment'}
-        <meta name="robots" content="noindex" />
-      </Head>
-      <PageTitle title={title} headTitle />
+      <HeadTags data={{ title: titleText }} noIndex />
+      <PageTitle title={titleText} />
       <p className="serlo-p text-2xl" id="error-page-description">
         {text}
       </p>

--- a/apps/web/src/components/pages/search.tsx
+++ b/apps/web/src/components/pages/search.tsx
@@ -20,10 +20,7 @@ export function Search() {
 
   return (
     <>
-      <HeadTags
-        data={{ title: `Serlo.org - ${strings.header.search}` }}
-        noindex
-      />
+      <HeadTags data={{ title: `Serlo.org - ${strings.header.search}` }} />
       <PageTitle title={strings.header.search} />
       {consentGiven ? renderSearch() : renderConsentBanner()}
     </>

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -3,7 +3,7 @@ import { ErrorPage } from '@/components/pages/error-page'
 
 export default function Custom404() {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <ErrorPage code={404} />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/___bot_or_not.tsx
+++ b/apps/web/src/pages/___bot_or_not.tsx
@@ -4,7 +4,6 @@ import { StaticRenderer } from '@editor/static-renderer/static-renderer'
 import { User } from '@serlo/authorization'
 import { gql } from 'graphql-request'
 import { NextPage } from 'next'
-import Head from 'next/head'
 import { MouseEvent, useRef, useState } from 'react'
 
 import { useGraphqlSwrPaginationWithAuth } from '@/api/use-graphql-swr'
@@ -28,12 +27,10 @@ const ContentPage: NextPage = () => {
     <FrontendClientBase
       noHeaderFooter
       noContainers
+      noIndex
       showNav={false}
       authorization={{}}
     >
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       <BotHunt />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/___cf_not_found.tsx
+++ b/apps/web/src/pages/___cf_not_found.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps, NextPage } from 'next'
-import Head from 'next/head'
 
 import { FrontendClientBase } from '@/components/frontend-client-base/frontend-client-base'
 
@@ -8,12 +7,10 @@ const ContentPage: NextPage = () => {
     <FrontendClientBase
       noHeaderFooter
       noContainers
+      noIndex
       showNav={false}
       authorization={{}}
     >
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       <div className="mt-12 p-12 text-center">
         <h1 className="serlo-h1">Diese URL kennen wir leider nicht. 😶‍🌫️</h1>
         (sorry, we don&apos;t seem to know this url)

--- a/apps/web/src/pages/___content.tsx
+++ b/apps/web/src/pages/___content.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next'
-import Head from 'next/head'
 
+import { HeadTags } from '@/components/head-tags'
 import { getEditUrl } from '@/helper/urls/get-edit-url'
 
 // from https://github.com/serlo/frontend/wiki/Schema
@@ -29,9 +29,7 @@ const specialCases = [
 const ContentPage: NextPage = () => {
   return (
     <>
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
+      <HeadTags data={{ title: 'Example Content' }} noIndex />
       <nav>
         <h2>Entities</h2>
         <ul>{renderLis(entities)}</ul>

--- a/apps/web/src/pages/___content.tsx
+++ b/apps/web/src/pages/___content.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next'
+import Head from 'next/head'
 
-import { HeadTags } from '@/components/head-tags'
 import { getEditUrl } from '@/helper/urls/get-edit-url'
 
 // from https://github.com/serlo/frontend/wiki/Schema
@@ -29,7 +29,10 @@ const specialCases = [
 const ContentPage: NextPage = () => {
   return (
     <>
-      <HeadTags data={{ title: 'Example Content' }} noIndex />
+      <Head>
+        <title>Example Content</title>
+        <meta name="robots" content="noindex" />
+      </Head>
       <nav>
         <h2>Entities</h2>
         <ul>{renderLis(entities)}</ul>

--- a/apps/web/src/pages/___design.tsx
+++ b/apps/web/src/pages/___design.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from 'next'
-import Head from 'next/head'
 
 import DesignGuideSVG from '@/assets-webkit/img/design-guide/design-guide.svg'
 import { FrontendClientBase } from '@/components/frontend-client-base/frontend-client-base'
@@ -9,12 +8,10 @@ const ContentPage: NextPage = () => {
     <FrontendClientBase
       noHeaderFooter
       noContainers
+      noIndex
       showNav={false}
       authorization={{}}
     >
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       <DesignGuideSVG className="design-guide mx-auto h-auto max-w-5xl [&_text]:!whitespace-normal" />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/___editor_preview.tsx
+++ b/apps/web/src/pages/___editor_preview.tsx
@@ -29,6 +29,7 @@ export default renderedPageNoHooks<EditorPageData>((props) => {
     <FrontendClientBase
       noContainers
       noHeaderFooter
+      noIndex
       loadLoggedInData /* warn: enables preview editor without login */
       serloEntityData={{ entityId: props.id }}
     >

--- a/apps/web/src/pages/___exercise_folder_dashboard/[id].tsx
+++ b/apps/web/src/pages/___exercise_folder_dashboard/[id].tsx
@@ -4,12 +4,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
 import jsonDiff from 'json-diff'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
 import { Link } from '@/components/content/link'
 import { FaIcon } from '@/components/fa-icon'
-import { HeadTags } from '@/components/head-tags'
 import { cn } from '@/helper/cn'
 
 interface FolderData {
@@ -76,7 +76,9 @@ export default function Page() {
   if (!data) {
     return (
       <>
-        <HeadTags data={{ title: 'Loading…' }} noIndex />
+        <Head>
+          <meta name="robots" content="noindex" />
+        </Head>
         <p>Lade Daten für Ordner {router.query.id}</p>
       </>
     )
@@ -106,13 +108,10 @@ export default function Page() {
     })
     return (
       <>
-        <HeadTags
-          data={{
-            title: `Daten-Auswertung für ${decodeURIComponent(data.title)}`,
-          }}
-          noIndex
-        />
-
+        <Head>
+          <title>Daten-Auswertung für {decodeURIComponent(data.title)}</title>
+          <meta name="robots" content="noindex" />
+        </Head>
         <div className="flex items-baseline justify-between bg-gray-50 py-4 pl-8">
           <a
             href={data.title}

--- a/apps/web/src/pages/___exercise_folder_dashboard/[id].tsx
+++ b/apps/web/src/pages/___exercise_folder_dashboard/[id].tsx
@@ -4,12 +4,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
 import jsonDiff from 'json-diff'
-import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
 import { Link } from '@/components/content/link'
 import { FaIcon } from '@/components/fa-icon'
+import { HeadTags } from '@/components/head-tags'
 import { cn } from '@/helper/cn'
 
 interface FolderData {
@@ -74,7 +74,12 @@ export default function Page() {
     }
   }, [id])
   if (!data) {
-    return <p>Lade Daten für Ordner {router.query.id}</p>
+    return (
+      <>
+        <HeadTags data={{ title: 'Loading…' }} noIndex />
+        <p>Lade Daten für Ordner {router.query.id}</p>
+      </>
+    )
   } else {
     const diff = jsonDiff.diffString(
       data.versions[start].content,
@@ -101,9 +106,13 @@ export default function Page() {
     })
     return (
       <>
-        <Head>
-          <title>Daten-Auswertung für {decodeURIComponent(data.title)}</title>
-        </Head>
+        <HeadTags
+          data={{
+            title: `Daten-Auswertung für ${decodeURIComponent(data.title)}`,
+          }}
+          noIndex
+        />
+
         <div className="flex items-baseline justify-between bg-gray-50 py-4 pl-8">
           <a
             href={data.title}

--- a/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
+++ b/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
@@ -1,8 +1,6 @@
 import Head from 'next/head'
 import { useState, useEffect } from 'react'
 
-import { HeadTags } from '@/components/head-tags'
-
 type OverviewData = {
   id: number
   title: string
@@ -62,7 +60,6 @@ export default function Overview() {
         <title>Aufgabenordner Übersicht</title>
         <meta name="robots" content="noindex" />
       </Head>
-      <HeadTags data={{ title: '' }} noIndex />
       <h1 className="mb-4 text-3xl">Aufgabenordner Übersicht</h1>
       <div className="text-right">
         Sortierung:{' '}

--- a/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
+++ b/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head'
 import { useState, useEffect } from 'react'
 
 import { HeadTags } from '@/components/head-tags'
@@ -57,7 +58,11 @@ export default function Overview() {
 
   return (
     <div className="mx-auto max-w-[800px] pt-16">
-      <HeadTags data={{ title: 'Aufgabenordner Übersicht' }} noIndex />
+      <Head>
+        <title>Aufgabenordner Übersicht</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <HeadTags data={{ title: '' }} noIndex />
       <h1 className="mb-4 text-3xl">Aufgabenordner Übersicht</h1>
       <div className="text-right">
         Sortierung:{' '}

--- a/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
+++ b/apps/web/src/pages/___exercise_folder_dashboard/overview.tsx
@@ -1,5 +1,6 @@
-import Head from 'next/head'
 import { useState, useEffect } from 'react'
+
+import { HeadTags } from '@/components/head-tags'
 
 type OverviewData = {
   id: number
@@ -56,9 +57,7 @@ export default function Overview() {
 
   return (
     <div className="mx-auto max-w-[800px] pt-16">
-      <Head>
-        <title>Aufgabenordner Übersicht</title>
-      </Head>
+      <HeadTags data={{ title: 'Aufgabenordner Übersicht' }} noIndex />
       <h1 className="mb-4 text-3xl">Aufgabenordner Übersicht</h1>
       <div className="text-right">
         Sortierung:{' '}

--- a/apps/web/src/pages/___old_comments.tsx
+++ b/apps/web/src/pages/___old_comments.tsx
@@ -1,6 +1,5 @@
 import { GraphQLClient, gql } from 'graphql-request'
 import { NextPage } from 'next'
-import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
 import { endpoint } from '@/api/endpoint'
@@ -19,12 +18,10 @@ const ContentPage: NextPage = () => {
     <FrontendClientBase
       noHeaderFooter
       noContainers
+      noIndex
       showNav={false}
       authorization={{}}
     >
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       <OldComments />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/auth/___activate_vidis.tsx
+++ b/apps/web/src/pages/auth/___activate_vidis.tsx
@@ -8,7 +8,7 @@ import { features } from '@/components/user/profile-experimental'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/error.tsx
+++ b/apps/web/src/pages/auth/error.tsx
@@ -9,7 +9,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 import { triggerSentry } from '@/helper/trigger-sentry'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Error />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/login.tsx
+++ b/apps/web/src/pages/auth/login.tsx
@@ -3,7 +3,7 @@ import { Login } from '@/components/pages/auth/login'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Login />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/logout.tsx
+++ b/apps/web/src/pages/auth/logout.tsx
@@ -3,7 +3,7 @@ import { Logout } from '@/components/pages/auth/logout'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Logout />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/oauth/consent.tsx
+++ b/apps/web/src/pages/auth/oauth/consent.tsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from '@/components/loading/loading-spinner'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Consent />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/oauth/login.tsx
+++ b/apps/web/src/pages/auth/oauth/login.tsx
@@ -3,7 +3,7 @@ import { Login } from '@/components/pages/auth/login'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Login oauth />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/oauth/logout.tsx
+++ b/apps/web/src/pages/auth/oauth/logout.tsx
@@ -3,7 +3,7 @@ import { Logout } from '@/components/pages/auth/logout'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Logout oauth />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/recovery.tsx
+++ b/apps/web/src/pages/auth/recovery.tsx
@@ -3,7 +3,7 @@ import { Recovery } from '@/components/pages/auth/recovery'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Recovery />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/registration.tsx
+++ b/apps/web/src/pages/auth/registration.tsx
@@ -3,7 +3,7 @@ import { Registration } from '@/components/pages/auth/registration'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Registration />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/settings.tsx
+++ b/apps/web/src/pages/auth/settings.tsx
@@ -3,7 +3,7 @@ import { Settings } from '@/components/pages/auth/settings'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Settings />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/auth/verification.tsx
+++ b/apps/web/src/pages/auth/verification.tsx
@@ -3,7 +3,7 @@ import { Verification } from '@/components/pages/auth/verification'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Verification />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/authorization/roles.tsx
+++ b/apps/web/src/pages/authorization/roles.tsx
@@ -22,7 +22,7 @@ import { replacePlaceholders } from '@/helper/replace-placeholders'
 import { useUserAddOrRemoveRoleMutation } from '@/mutations/use-user-role-mutation'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/backend.tsx
+++ b/apps/web/src/pages/backend.tsx
@@ -5,7 +5,6 @@ import {
   faHatWizard,
   IconDefinition,
 } from '@fortawesome/free-solid-svg-icons'
-import Head from 'next/head'
 
 import { Link } from '@/components/content/link'
 import { PageTitle } from '@/components/content/page-title'
@@ -23,7 +22,7 @@ interface Entry {
 }
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))
@@ -58,9 +57,6 @@ function Content() {
 
   return (
     <>
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       <PageTitle title={`🧙‍♀️ ${strings.pageTitles.diagon} 🔮`} headTitle />
       {renderMenu()}
     </>

--- a/apps/web/src/pages/content-only/[...slug].tsx
+++ b/apps/web/src/pages/content-only/[...slug].tsx
@@ -24,7 +24,7 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
       }, 1000)
     }
     return (
-      <FrontendClientBase>
+      <FrontendClientBase noIndex>
         <LoadingSpinner noText />
       </FrontendClientBase>
     )
@@ -48,6 +48,7 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
     <FrontendClientBase
       noContainers
       noHeaderFooter
+      noIndex
       serloEntityData={{ entityId }}
       authorization={pageData.authorization}
     >
@@ -56,7 +57,6 @@ export default renderedPageNoHooks<SlugProps>(({ pageData }) => {
         <HeadTags
           data={pageData.metaData}
           breadcrumbsData={pageData.breadcrumbsData}
-          noindex
         />
       ) : null}
       <div className="relative">

--- a/apps/web/src/pages/entity/create/[type]/[taxonomyId].tsx
+++ b/apps/web/src/pages/entity/create/[type]/[taxonomyId].tsx
@@ -67,6 +67,7 @@ function Content({
   return (
     <FrontendClientBase
       noContainers
+      noIndex
       loadLoggedInData={!isProduction} // warn: enables preview editor without login
       serloEntityData={{ entityId: taxonomyParentId }}
     >

--- a/apps/web/src/pages/entity/license/update/[id].tsx
+++ b/apps/web/src/pages/entity/license/update/[id].tsx
@@ -16,7 +16,7 @@ interface UpdateLicenseProps {
 }
 
 export default renderedPageNoHooks<UpdateLicenseProps>((props) => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content {...props} />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/entity/repository/add-revision/[...id].tsx
+++ b/apps/web/src/pages/entity/repository/add-revision/[...id].tsx
@@ -12,6 +12,7 @@ export default renderedPageNoHooks<EditorPageData>((props) => {
   return (
     <FrontendClientBase
       noContainers
+      noIndex
       loadLoggedInData /* warn: enables preview editor without login */
       serloEntityData={{ entityId: props.id }}
     >

--- a/apps/web/src/pages/entity/repository/compare/[entity_id]/[revision_id].tsx
+++ b/apps/web/src/pages/entity/repository/compare/[entity_id]/[revision_id].tsx
@@ -11,9 +11,10 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 export default renderedPageNoHooks<RevisionProps>(({ pageData }) => (
   <RevisionViewProvider value>
     <FrontendClientBase
+      noContainers
+      noIndex
       serloEntityData={{ entityId: pageData.revisionData.thisRevision.id }}
       authorization={pageData.authorization}
-      noContainers
     >
       <Revision data={pageData.revisionData} />
     </FrontendClientBase>

--- a/apps/web/src/pages/entity/repository/history/[id].tsx
+++ b/apps/web/src/pages/entity/repository/history/[id].tsx
@@ -17,7 +17,7 @@ export interface HistoryRevisionProps {
 }
 
 export default renderedPageNoHooks<HistoryRevisionProps>((props) => (
-  <FrontendClientBase serloEntityData={{ entityId: props.id }}>
+  <FrontendClientBase serloEntityData={{ entityId: props.id }} noIndex>
     <Content {...props} />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/entity/taxonomy/update/[id].tsx
+++ b/apps/web/src/pages/entity/taxonomy/update/[id].tsx
@@ -36,7 +36,7 @@ interface UpdateTaxonomyLinksProps {
 
 export default renderedPageNoHooks<UpdateTaxonomyLinksProps>((props) => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content {...props} />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/entity/unrevised.tsx
+++ b/apps/web/src/pages/entity/unrevised.tsx
@@ -15,7 +15,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks<UnrevisedRevisionsProps>(({ pageData }) => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content data={pageData.revisionsData} />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/event/history/[...slug].tsx
+++ b/apps/web/src/pages/event/history/[...slug].tsx
@@ -12,7 +12,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks<EventHistoryProps>(({ pageData }) => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content {...pageData} />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/event/history/index.tsx
+++ b/apps/web/src/pages/event/history/index.tsx
@@ -6,7 +6,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/event/history/user/profile/[username].tsx
+++ b/apps/web/src/pages/event/history/user/profile/[username].tsx
@@ -12,7 +12,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/license/detail/[id].tsx
+++ b/apps/web/src/pages/license/detail/[id].tsx
@@ -9,7 +9,7 @@ import { LicenseDetailProps } from '@/data-types'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks<LicenseDetailProps>(({ pageData }) => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <LicenseDetail {...pageData.licenseData} />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/page/create.tsx
+++ b/apps/web/src/pages/page/create.tsx
@@ -21,6 +21,7 @@ export default renderedPageNoHooks(() => {
   return (
     <FrontendClientBase
       noContainers
+      noIndex
       loadLoggedInData={!isProduction} // warn: enables preview editor without login
     >
       <div className="relative">

--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -3,7 +3,7 @@ import { Search } from '@/components/pages/search'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Search />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/subscriptions/manage.tsx
+++ b/apps/web/src/pages/subscriptions/manage.tsx
@@ -20,7 +20,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 import { replacePlaceholders } from '@/helper/replace-placeholders'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/taxonomy/term/[copyOrMove]/batch/[id].tsx
+++ b/apps/web/src/pages/taxonomy/term/[copyOrMove]/batch/[id].tsx
@@ -13,6 +13,7 @@ export default renderedPageNoHooks<{ pageData: TaxonomyPage }>(
     return (
       <FrontendClientBase
         noContainers
+        noIndex
         loadLoggedInData /* warn: enables preview editor without login */
       >
         <div className="relative">

--- a/apps/web/src/pages/taxonomy/term/create/[parent_id]/[id].tsx
+++ b/apps/web/src/pages/taxonomy/term/create/[parent_id]/[id].tsx
@@ -14,6 +14,7 @@ export default renderedPageNoHooks<TaxonomyTermCreateProps>(({ parent }) => {
   return (
     <FrontendClientBase
       noContainers
+      noIndex
       loadLoggedInData /* warn: enables preview editor without login */
     >
       <div className="relative">

--- a/apps/web/src/pages/taxonomy/term/sort/entities/[id].tsx
+++ b/apps/web/src/pages/taxonomy/term/sort/entities/[id].tsx
@@ -46,7 +46,7 @@ type Category = (typeof allCategories)[number]
 
 export default renderedPageNoHooks<{ pageData: TaxonomyPage }>((props) => {
   return (
-    <FrontendClientBase>
+    <FrontendClientBase noIndex>
       <Content {...props} />
     </FrontendClientBase>
   )

--- a/apps/web/src/pages/taxonomy/term/update/[id].tsx
+++ b/apps/web/src/pages/taxonomy/term/update/[id].tsx
@@ -10,6 +10,7 @@ export default renderedPageNoHooks<EditorPageData>((props) => {
   return (
     <FrontendClientBase
       noContainers
+      noIndex
       loadLoggedInData /* warn: enables preview editor without login */
     >
       <div className="relative">

--- a/apps/web/src/pages/user/[...userslug].tsx
+++ b/apps/web/src/pages/user/[...userslug].tsx
@@ -7,7 +7,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 // frontend redirect for routes the old form of `/user/${userId}/${username}`
 // deployed this will be handled by the cf-worker
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/user/me.tsx
+++ b/apps/web/src/pages/user/me.tsx
@@ -8,7 +8,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 // redirect for route `/user/me`
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/user/notifications.tsx
+++ b/apps/web/src/pages/user/notifications.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/helper/cn'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Title />
     <Content />
   </FrontendClientBase>

--- a/apps/web/src/pages/user/profile/[username].tsx
+++ b/apps/web/src/pages/user/profile/[username].tsx
@@ -14,12 +14,10 @@ export default renderedPageNoHooks<UserProps>(({ pageData }) => {
     <FrontendClientBase
       serloEntityData={{ entityId: pageData.userData.id }}
       authorization={pageData.authorization}
+      noIndex={!isActiveDonor && !isActiveAuthor && !isActiveReviewer}
     >
       <Head>
         <title>{username}</title>
-        {!isActiveDonor && !isActiveAuthor && !isActiveReviewer && (
-          <meta name="robots" content="noindex" />
-        )}
       </Head>
       <Profile userData={pageData.userData} />
     </FrontendClientBase>

--- a/apps/web/src/pages/user/settings.tsx
+++ b/apps/web/src/pages/user/settings.tsx
@@ -12,7 +12,7 @@ import { userByUsernameQuery } from '@/fetcher/user/query-by-username'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))

--- a/apps/web/src/pages/uuid/recycle-bin.tsx
+++ b/apps/web/src/pages/uuid/recycle-bin.tsx
@@ -1,6 +1,5 @@
 import { faTrashRestore } from '@fortawesome/free-solid-svg-icons'
 import { gql } from 'graphql-request'
-import Head from 'next/head'
 
 import { useGraphqlSwrPaginationWithAuth } from '@/api/use-graphql-swr'
 import { Link } from '@/components/content/link'
@@ -19,7 +18,7 @@ import { renderedPageNoHooks } from '@/helper/rendered-page'
 import { useSetUuidStateMutation } from '@/mutations/use-set-uuid-state-mutation'
 
 export default renderedPageNoHooks(() => (
-  <FrontendClientBase>
+  <FrontendClientBase noIndex>
     <Content />
   </FrontendClientBase>
 ))
@@ -32,9 +31,6 @@ function Content() {
 
   return (
     <>
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
       {renderBackButton()}
       <PageTitle title={strings.pageTitles.recycleBin} headTitle />
       <Guard data={data} error={error} needsAuth>


### PR DESCRIPTION
We index a lot of pages, that are not really relevant for almost all users (like author tools etc) and some of them are actually hurting our SEO ratings. So I added a `noindex` to most routes.

You can now also just add the `noIndex` prop to the `FrontendClientBase` component (`<FrontendClientBase noIndex>`).
This should make it easier and more visible that those pages are not indexed.

Reviewers could double check if I noindexed some important pages :)