### PR TITLE
fix(dropzone-image): move add drop zone button

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -695,8 +695,7 @@ export const loggedInData = {
           description:
             'Create an exercise with interactive images for matching and labeling',
           backgroundImage: 'Background image',
-          dropZone: 'Drop zone',
-          dropZoneTooltip: 'Choose the drop zone',
+          addDropZone: 'Add drop zone',
           removeDropZone: 'Remove drop zone',
           dropzoneVisibility: 'Dropzone Visibility',
           answers: {

--- a/packages/editor/src/plugins/dropzone-image/components/editor/possible-answers.tsx
+++ b/packages/editor/src/plugins/dropzone-image/components/editor/possible-answers.tsx
@@ -3,27 +3,41 @@ import { DraggableArea } from '@editor/editor-ui/exercises/draggable-area'
 import type { DropzoneImageProps } from '../..'
 import { convertAnswer } from '../../utils/answer-zone'
 import { DraggableAnswer } from '../shared/draggable-answer'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
 
 interface PossibleAnswersProps {
   answerZones: DropzoneImageProps['state']['answerZones']
+  onClickAddAnswerZone: () => void
 }
 
 export function PossibleAnswers(props: PossibleAnswersProps) {
-  const { answerZones } = props
+  const { answerZones, onClickAddAnswerZone } = props
+
+  const dropzoneImageStrings = useEditorStrings().plugins.dropzoneImage
 
   const correctAnswers = answerZones
     .map(({ answers }) => answers.map(convertAnswer))
     .flat()
 
   return (
-    <DraggableArea accept="none" className="mt-4">
-      {correctAnswers.map((possibleAnswer, index) => (
-        <DraggableAnswer
-          key={index}
-          answer={possibleAnswer}
-          data-qa="plugin-dropzone-image-correct-possible-answer"
-        />
-      ))}
-    </DraggableArea>
+    <div className="mt-4">
+      <button
+        className="serlo-button-editor-primary"
+        onClick={onClickAddAnswerZone}
+        data-qa="plugin-dropzone-image-add-wrong-answer-button"
+      >
+        {dropzoneImageStrings.addDropZone}
+      </button>
+
+      <DraggableArea accept="none" className="mt-4">
+        {correctAnswers.map((possibleAnswer, index) => (
+          <DraggableAnswer
+            key={index}
+            answer={possibleAnswer}
+            data-qa="plugin-dropzone-image-correct-possible-answer"
+          />
+        ))}
+      </DraggableArea>
+    </div>
   )
 }

--- a/packages/editor/src/plugins/dropzone-image/editor.tsx
+++ b/packages/editor/src/plugins/dropzone-image/editor.tsx
@@ -110,7 +110,6 @@ export function DropzoneImageEditor(props: DropzoneImageProps) {
       }}
     >
       <DropzoneImageToolbar
-        onClickAddAnswerZone={insertAnswerZone}
         id={id}
         showSettingsButton={isBackgroundTypeImage}
         backgroundImageState={{
@@ -145,7 +144,10 @@ export function DropzoneImageEditor(props: DropzoneImageProps) {
             setModalType={setModalType}
           />
           <EditorCanvas state={state} setModalType={setModalType} />
-          <PossibleAnswers answerZones={answerZones} />
+          <PossibleAnswers
+            answerZones={answerZones}
+            onClickAddAnswerZone={insertAnswerZone}
+          />
           <ExtraIncorrectAnswers
             extraDraggableAnswers={extraDraggableAnswers}
             setModalType={setModalType}

--- a/packages/editor/src/plugins/dropzone-image/toolbar.tsx
+++ b/packages/editor/src/plugins/dropzone-image/toolbar.tsx
@@ -1,4 +1,3 @@
-import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
 import { PluginToolbar } from '@editor/editor-ui/plugin-toolbar'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
 import type { ImageProps } from '@editor/plugins/image'
@@ -19,7 +18,6 @@ interface DropzoneImageToolbarProps {
     state?: ImageProps['state']
   }
   children?: ReactNode
-  onClickAddAnswerZone?: () => void
   showSettingsButton?: boolean
 }
 
@@ -27,7 +25,6 @@ export const DropzoneImageToolbar = (props: DropzoneImageToolbarProps) => {
   const {
     id,
     backgroundImageState,
-    onClickAddAnswerZone,
     showSettingsButton = false,
     children,
   } = props
@@ -40,7 +37,6 @@ export const DropzoneImageToolbar = (props: DropzoneImageToolbarProps) => {
   return (
     <PluginToolbar
       pluginType={EditorPluginType.DropzoneImage}
-      contentControls={renderAddButton()}
       pluginSettings={
         <>
           {renderSettingsModal()}
@@ -50,27 +46,6 @@ export const DropzoneImageToolbar = (props: DropzoneImageToolbarProps) => {
       pluginControls={pluginControls}
     />
   )
-
-  function renderAddButton() {
-    return onClickAddAnswerZone ? (
-      <button
-        data-qa="plugin-dropzone-image-add-answer-zone-button"
-        onClick={onClickAddAnswerZone}
-        className={cn(`
-          serlo-tooltip-trigger mr-2 rounded-md border border-gray-500 px-1 text-sm
-          transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200
-        `)}
-      >
-        <EditorTooltip
-          text={editorStrings.plugins.dropzoneImage.dropZoneTooltip}
-          className="-ml-5 !pb-1"
-        />
-        {editorStrings.plugins.dropzoneImage.dropZone}
-      </button>
-    ) : (
-      <></>
-    )
-  }
 
   function renderSettingsModal() {
     if (!showSettingsButton || !backgroundImageState) return null


### PR DESCRIPTION
- Remove add drop zone button from toolbar
- Add primary add drop zone button to underneath the canvas

## [Demo link](https://frontend-git-fix-dropzone-image-add-dropzone-button-ux-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22dropzoneImage%22%2C%22state%22%3A%7B%22answerZones%22%3A%5B%7B%22id%22%3A%22answerZone-0%22%2C%22name%22%3A%22%22%2C%22position%22%3A%7B%22top%22%3A0.5074%2C%22left%22%3A0.1933%7D%2C%22layout%22%3A%7B%22width%22%3A0.2%2C%22height%22%3A0.15247109826589597%7D%2C%22answers%22%3A%5B%7B%22id%22%3A%22a5633d5f-eadd-4749-943d-37787a8a7a76%22%2C%22image%22%3A%7B%22plugin%22%3A%22image%22%2C%22state%22%3A%7B%22src%22%3A%22%22%7D%2C%22id%22%3A%224d612307-008f-41df-9ba9-1c5773502924%22%7D%2C%22text%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22asfasf%22%7D%5D%7D%5D%2C%22id%22%3A%22fc9d95c8-5037-44eb-9476-1e746996b557%22%7D%7D%5D%7D%2C%7B%22id%22%3A%22answerZone-1%22%2C%22name%22%3A%22%22%2C%22position%22%3A%7B%22top%22%3A0.4328%2C%22left%22%3A0.4816%7D%2C%22layout%22%3A%7B%22width%22%3A0.4217%2C%22height%22%3A0.4032%7D%2C%22answers%22%3A%5B%7B%22id%22%3A%22dae8e88d-db3e-4a48-b57c-55631c467dad%22%2C%22image%22%3A%7B%22plugin%22%3A%22image%22%2C%22state%22%3A%7B%22src%22%3A%22https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fen%2Fa%2Faa%2FBart_Simpson_200px.png%22%2C%22caption%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22e751c067-bf81-4006-bdde-839e9532d4ad%22%7D%7D%2C%22id%22%3A%2276753974-066a-4162-a338-86ed2f659c5e%22%7D%2C%22text%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22dd64c3d2-43b7-4e3a-8b71-448204de968d%22%7D%7D%5D%7D%2C%7B%22id%22%3A%22answerZone-2%22%2C%22name%22%3A%22%22%2C%22position%22%3A%7B%22top%22%3A0.05%2C%22left%22%3A0.05%7D%2C%22layout%22%3A%7B%22width%22%3A0.2%2C%22height%22%3A0.15247109826589597%7D%2C%22answers%22%3A%5B%7B%22id%22%3A%22c5926543-7c67-444d-8769-b27871b6ea84%22%2C%22image%22%3A%7B%22plugin%22%3A%22image%22%2C%22state%22%3A%7B%22src%22%3A%22%22%7D%2C%22id%22%3A%22a7647d77-317b-433e-a20c-623772088dc3%22%7D%2C%22text%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%2C%7B%22type%22%3A%22math%22%2C%22src%22%3A%22math%22%2C%22inline%22%3Atrue%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%2C%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22990dd288-1950-41b8-86a8-c0ab9b5f8f78%22%7D%7D%5D%7D%5D%2C%22canvasShape%22%3A%22%22%2C%22canvasDimensions%22%3A%7B%22height%22%3A295.13790162069944%2C%22width%22%3A600%7D%2C%22backgroundType%22%3A%22image%22%2C%22backgroundImage%22%3A%7B%22plugin%22%3A%22image%22%2C%22state%22%3A%7B%22src%22%3A%22https%3A%2F%2Fassets.serlo.org%2F2eb3b040-3eb7-11ef-894e-93d020c289ff%2Fimage.png%22%2C%22caption%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22f9b2b3f2-ae72-4cba-bbd8-08441ce6d5e1%22%7D%7D%2C%22id%22%3A%22c8685cfd-6a00-446e-ac48-eda694103a8e%22%7D%2C%22dropzoneVisibility%22%3A%22full%22%2C%22extraDraggableAnswers%22%3A%5B%5D%7D%2C%22id%22%3A%22b9f61a3b-61cc-45b1-9536-91b4d4d9fba3%22%7D%5D%7D)