### PR TITLE
(chore): move image-dropzones plugin to exercises, remove from suggestions

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1045,6 +1045,7 @@ export const loggedInData = {
           scMcExercise: 'Choice Exercise',
           inputExercise: 'Input Exercise',
           textAreaExercise: 'Text Box Exercise',
+          dropzoneImage: 'Image Dropzones Exercise',
           blanksExercise: 'Fill In The Blanks Exercise',
           h5p: 'H5p Exercise',
           addOptionalInteractiveEx: 'Add an optional interactive exercise:',

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -92,7 +92,7 @@ export function createPlugins({
           {
             type: EditorPluginType.DropzoneImage,
             plugin: createDropzoneImagePlugin(),
-            visibleInSuggestions: true,
+            visibleInSuggestions: false,
             icon: <IconDropzones />,
           },
         ]),

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -19,6 +19,7 @@ const allInteractiveExerciseTypes = [
   EditorPluginType.H5p,
   EditorPluginType.TextAreaExercise,
   EditorPluginType.BlanksExercise,
+  EditorPluginType.DropzoneImage,
 ] as const
 
 export type InteractiveExerciseType =

--- a/packages/editor/src/plugins/exercise/index.tsx
+++ b/packages/editor/src/plugins/exercise/index.tsx
@@ -20,6 +20,7 @@ const exerciseState = object({
       | EditorPluginType.TextAreaExercise
       | EditorPluginType.H5p
       | EditorPluginType.BlanksExercise
+      | EditorPluginType.DropzoneImage
     >({
       plugin: EditorPluginType.ScMcExercise,
     })


### PR DESCRIPTION
[Demo link](https://frontend-git-chore-move-dropzone-image-plugin-to-e-2911b5-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%226ca3e134-4f57-4e37-9963-bc93516a46d0%22%7D%2C%7B%22plugin%22%3A%22exercise%22%2C%22state%22%3A%7B%22content%22%3A%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%2208b7e6c7-8d6a-44a8-bab5-1f5fae7b8e3b%22%7D%5D%2C%22id%22%3A%229e37042c-5f5d-491b-ae6a-86f8ebffa0e1%22%7D%2C%22interactive%22%3A%7B%22plugin%22%3A%22dropzoneImage%22%2C%22state%22%3A%7B%22answerZones%22%3A%5B%5D%2C%22canvasShape%22%3A%22%22%2C%22canvasDimensions%22%3A%7B%22height%22%3A600%2C%22width%22%3A600%7D%2C%22backgroundType%22%3A%22%22%2C%22dropzoneVisibility%22%3A%22full%22%2C%22extraDraggableAnswers%22%3A%5B%5D%7D%2C%22id%22%3A%227c4fd54d-2c6e-4f25-8dc2-c8e002f522e3%22%7D%7D%2C%22id%22%3A%220ca41b4c-a209-475d-9bab-f38c10616b8e%22%7D%5D%7D)


![Screenshot from 2024-07-15 03-30-42](https://github.com/user-attachments/assets/41116dd6-28a7-425c-a713-1b5f3ae98e7b)

![Screenshot from 2024-07-15 03-31-52](https://github.com/user-attachments/assets/7efbd5e9-ada0-4da1-900f-1f9efc8f6544)

