### PR TITLE
e2e: patch tests in multimedia plugin and editor

### DIFF
--- a/e2e-tests/tests/400-serlo-editor.ts
+++ b/e2e-tests/tests/400-serlo-editor.ts
@@ -116,6 +116,9 @@ Scenario(
 
     I.say('Remove the Image plugin and merge the split Text plugin')
     I.click(locate('$plugin-image-editor').inside('.plugin-rows'))
+
+    I.click('$modal-close-button') // patch to close the pixabay
+
     I.moveCursorTo(
       locate('[data-radix-collection-item]').inside('.plugin-toolbar')
     )
@@ -182,6 +185,8 @@ Scenario(
     // beginning of each page already contains one. But, we do need to focus it,
     // in order to make the src input visible
     I.click('$plugin-image-editor')
+    I.click('$modal-close-button') // patch to close the pixabay modal
+
     const imagePluginUrlInput =
       'input[placeholder="https://example.com/image.png"]'
 

--- a/e2e-tests/tests/431-multimedia-plugin-image.ts
+++ b/e2e-tests/tests/431-multimedia-plugin-image.ts
@@ -102,7 +102,11 @@ Scenario('Multimedia plugin valid image URL', ({ I }) => {
 
   I.say('Switch to video and back to image - image and settings should stay')
   I.click(locate('$plugin-image-editor').inside('.plugin-rows'))
+
+  I.click('$modal-close-button') // patch to close the pixabay modal
+
   I.click('$plugin-multimedia-parent-button')
+
   I.click('$plugin-multimedia-settings-button')
   I.selectOption('$plugin-multimedia-type-select', 'Video')
   I.click('$modal-close-button')
@@ -135,7 +139,11 @@ Scenario('Multimedia plugin fill in image caption', ({ I }) => {
 
   I.say('Switch to video and back to image - caption should stay')
   I.click(locate('$plugin-image-editor').inside('.plugin-rows'))
+
+  I.click('$modal-close-button') // patch to close the pixabay modal
+
   I.click('$plugin-multimedia-parent-button')
+
   I.click('$plugin-multimedia-settings-button')
   I.selectOption('$plugin-multimedia-type-select', 'Video')
   I.click('$modal-close-button')

--- a/packages/editor/src/plugins/image/components/image-selection-screen.tsx
+++ b/packages/editor/src/plugins/image/components/image-selection-screen.tsx
@@ -57,6 +57,7 @@ export function ImageSelectionScreen(
         <UploadButton {...props} />
         {!disableFileUpload && !isProduction && (
           <button
+            data-qa="plugin-image-pixabay-search-button"
             onClick={() => setShowPixabayModal(true)}
             className="almost-black mb-4 flex min-w-full flex-shrink-0 items-center justify-center rounded-lg bg-editor-primary-200 p-1 py-2 font-semibold text-gray-800 hover:bg-editor-primary-300"
           >


### PR DESCRIPTION
A bug appears in the tests which leads to the pixabay modal being opened, seemingly every time the tests use this line

`  I.click(locate('$plugin-image-editor').inside('.plugin-rows'))`

This PR is a patch so that the affected tests pass