### PR TITLE
fix(auth): Vidis ERR_BAD_ROLE handling cleanup

### DIFF
--- a/apps/web/src/components/auth/flow.tsx
+++ b/apps/web/src/components/auth/flow.tsx
@@ -14,6 +14,7 @@ import type {
 import { getNodeId, isUiNodeInputAttributes } from '@ory/integrations/ui'
 import type { NextRouter } from 'next/router'
 import NProgress from 'nprogress'
+import { clone } from 'ramda'
 import {
   type Dispatch,
   type FormEvent,
@@ -178,6 +179,8 @@ export function handleFlowError<S>(
   return async (error: AxiosError) => {
     // eslint-disable-next-line no-console
     console.error(error)
+    // eslint-disable-next-line no-console
+    console.error(clone(error))
     triggerSentry({ message: 'Auth error', code: error.response?.status })
 
     const data = error.response?.data as {

--- a/apps/web/src/pages/auth/error.tsx
+++ b/apps/web/src/pages/auth/error.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react'
 
 import { kratos } from '@/auth/kratos'
 import type { AxiosError } from '@/auth/types'
-import { FlowType } from '@/components/auth/flow-type'
 import { FrontendClientBase } from '@/components/frontend-client-base/frontend-client-base'
+import { loginUrl } from '@/components/pages/auth/utils'
 import { useInstanceData } from '@/contexts/instance-context'
 import { renderedPageNoHooks } from '@/helper/rendered-page'
 import { showToastNotice } from '@/helper/show-toast-notice'
@@ -52,7 +52,7 @@ function Error() {
     error.error.message.includes('ERR_BAD_ROLE')
   ) {
     showToastNotice(authStrings.badRole, 'warning', 5000)
-    void router.push(`/auth/${FlowType.login}`)
+    void router.push(loginUrl)
   }
 
   return error ? <pre>{JSON.stringify(error, null, 2)}</pre> : null

--- a/apps/web/src/pages/auth/error.tsx
+++ b/apps/web/src/pages/auth/error.tsx
@@ -51,7 +51,7 @@ function Error() {
     isVidisKratosError(error) &&
     error.error.message.includes('ERR_BAD_ROLE')
   ) {
-    showToastNotice(authStrings.badRole, 'warning')
+    showToastNotice(authStrings.badRole, 'warning', 5000)
     void router.push(`/auth/${FlowType.login}`)
   }
 

--- a/apps/web/src/pages/auth/error.tsx
+++ b/apps/web/src/pages/auth/error.tsx
@@ -1,6 +1,5 @@
 import { FlowError } from '@ory/client'
 import { useRouter } from 'next/router'
-import { clone } from 'ramda'
 import { useEffect, useState } from 'react'
 
 import { kratos } from '@/auth/kratos'
@@ -48,7 +47,6 @@ function Error() {
       })
   }, [id, router, router.isReady, error])
 
-  console.log('cloned error -> ', clone(error))
   if (
     isVidisKratosError(error) &&
     error.error.message.includes('ERR_BAD_ROLE')


### PR DESCRIPTION
The current state of staging works as expected -> show a toast and redirect to login page.

This PR is to clean up the code -- you two have a better idea of how to write this logic so that it fits with the rest of the auth code. Please suggest improvements 🙏 