### PR TITLE
feat(kratos): Change wording due to feedback and redirect prod user in auth/error

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -475,6 +475,7 @@ export const instanceData = {
         'Click here to request the verification email again.',
       badRole:
         'You are only allowed to log in through VIDIS if you are a teacher.',
+      somethingWrong: 'Sorry, something went wrong!',
     },
     keys: {
       ctrl: 'ctrl',

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -474,7 +474,7 @@ export const instanceData = {
       verificationLinkText:
         'Click here to request the verification email again.',
       badRole:
-        'You are only allowed to log in through Vidis if you are a teacher.',
+        'You are only allowed to log in through VIDIS if you are a teacher.',
     },
     keys: {
       ctrl: 'ctrl',

--- a/apps/web/src/pages/auth/error.tsx
+++ b/apps/web/src/pages/auth/error.tsx
@@ -76,5 +76,5 @@ interface FlowErrorWithErrorField extends FlowError {
 function hasFlowErrorFieldError(
   error: FlowError | undefined
 ): error is FlowErrorWithErrorField {
-  return Object.prototype.hasOwnProperty.call(error?.error, 'message')
+  return !!error?.error && Object.hasOwn(error.error, 'message')
 }


### PR DESCRIPTION
We received feedback from the PO that the name VIDIS should be in upper case and in the German string we should use Lehrkraft instead of Lehrer.

Besides that, I've added some logic to redirect a user that is in production and would go to the auth/error page, since this page isn't user friendly.
