### PR TITLE
refactor: Store pixabay API key in code instead of nextJS env variable

### DIFF
--- a/packages/editor/src/plugins/image/components/image-selection-screen.tsx
+++ b/packages/editor/src/plugins/image/components/image-selection-screen.tsx
@@ -43,8 +43,7 @@ export function ImageSelectionScreen(
     setShowPixabayModal(false)
   }
 
-  const showPixabayButton =
-    !disableFileUpload && !!process.env.NEXT_PUBLIC_PIXABAY_API_KEY
+  const showPixabayButton = !disableFileUpload
 
   return (
     <div

--- a/packages/editor/src/plugins/image/components/pixabay-image-search.tsx
+++ b/packages/editor/src/plugins/image/components/pixabay-image-search.tsx
@@ -63,7 +63,8 @@ export const PixabayImageSearch = ({
   const { lang } = useInstanceData()
   const editorStrings = useEditorStrings()
   const imageStrings = editorStrings.plugins.image
-  const apiKey = process.env.NEXT_PUBLIC_PIXABAY_API_KEY
+  // Pixabay API key connected to an unpaid account -> No need to keep it secret.
+  const apiKey = '44761287-06b5809c17d0a9132219f5173'
   const inputRef = useRef<HTMLInputElement>(null)
 
   const handleSearch = async (searchQuery: string) => {


### PR DESCRIPTION
Easy solution to make it available in all editor integrations. The API key is connected to an unpaid account and was shared with the browser. No need to keep it secret.