### PR TITLE
chore: remove `PIXABAY_API_KEY` from vite config as it is no longer needed

### DIFF
--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -12,11 +12,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs'
 
 const js = (value: string) => JSON.stringify(value)
 
-const productionKeys = [
-  'process.env.NODE_ENV',
-  'process.env.NEXT_PUBLIC_ENV',
-  'process.env.PIXABAY_API_KEY',
-]
+const productionKeys = ['process.env.NODE_ENV', 'process.env.NEXT_PUBLIC_ENV']
 
 const notProvidedKeys = [
   '__NEXT_I18N_SUPPORT',


### PR DESCRIPTION
Not needed any more after https://github.com/serlo/frontend/pull/4014