### PR TITLE
refactor: move empty plugin check to helper

### DIFF
--- a/packages/editor/src/store/documents/helpers.ts
+++ b/packages/editor/src/store/documents/helpers.ts
@@ -1,5 +1,6 @@
 import type { ToStaticHelpers } from '@editor/plugin'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
+import * as R from 'ramda'
 
 import { ChildTreeNode } from './types'
 import { ROOT } from '../root/constants'
@@ -70,4 +71,19 @@ export function getStaticDocument({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     state: plugin.state.toStaticState(document.state, toStaticHelpers),
   }
+}
+
+export function isPluginEmpty(document: DocumentState) {
+  const plugin = editorPlugins.getByType(document.plugin)
+
+  if (typeof plugin.isEmpty === 'function') {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const state = plugin.state.init(document.state, () => {})
+    return plugin.isEmpty(state)
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const initialState = plugin.state.createInitialState({
+    createDocument: () => {},
+  })
+  return R.equals(document.state, initialState)
 }


### PR DESCRIPTION
I did not find an obviously better way.
I slightly prefer this version, but I'm fine with both. You decide @hejtful 

(easier to read than the diff: https://github.com/serlo/frontend/blob/8b2b00498a9eec036dc12fa0098310e1d4cf344e/packages/editor/src/store/documents/selectors.ts)