### PR TITLE
feat(plugin-rows): larger last add plugin button

### DIFF
--- a/packages/editor/src/plugins/rows/components/add-row-button-large.tsx
+++ b/packages/editor/src/plugins/rows/components/add-row-button-large.tsx
@@ -11,11 +11,11 @@ export function AddRowButtonLarge({ onClick }: AddRowButtonLargeProps) {
 
   return (
     <button
-      className="serlo-button-editor-secondary mx-auto mt-24 block"
+      className="serlo-button-editor-secondary mx-auto mt-24 flex items-center rounded-lg px-5 py-2.5 text-xl"
       onClick={onClick}
       data-qa="add-new-plugin-row-button"
     >
-      <FaIcon icon={faCirclePlus} className="text-xl" />{' '}
+      <FaIcon icon={faCirclePlus} className="mr-3 text-3xl" />
       <span className="text-almost-black">{rowsStrings.addAnElement}</span>
     </button>
   )


### PR DESCRIPTION
Task: https://linear.app/serlo/issue/PE-31/redesign-add-plugin-button

<img width="875" alt="Screenshot 2024-08-19 at 12 00 29" src="https://github.com/user-attachments/assets/f877b525-f3d5-418f-bfcb-9a22d0ecff7d">
<img width="851" alt="Screenshot 2024-08-19 at 12 00 34" src="https://github.com/user-attachments/assets/871206ac-aa77-4d52-bb41-bd5aa42424e4">
