### PR TITLE
feat(editor-package)!: Add storage format and client-side migrations.

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -27,7 +27,7 @@ function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
   return (
     <SerloEditor
       initialState={initialState}
-      editorVariant="https://github.com/serlo/serlo-editor-for-edusharing"
+      editorVariant="edusharing"
       onChange={({ changed, getState }) => {
         if (changed){
           console.log(`New state: `, getState())
@@ -103,7 +103,7 @@ See below for the current API specification.
 
 - **`language` (optional)**: The default language is `de`.
 
-- **`editorVariant`**: The variant (integration) of the Serlo editor. For example `serlo-editor-for-edusharing` or `serlo-org`. The editor adds this information to the `StorageFormat` that will be saved. Might become useful for example if we need to apply a migration only to one variant of the editor.
+- **`editorVariant`**: The variant (integration) of the Serlo editor. For example `edusharing` or `serlo-org`. The editor adds this information to the `StorageFormat` that will be saved. Might become useful for example if we need to apply a migration only to one variant of the editor.
 
 - **`_testingSecret` (optional)**: Required to use Image plugin in testing. A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **To be deprecated once a long term solution is agreed on.**
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -27,9 +27,10 @@ function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
   return (
     <SerloEditor
       initialState={initialState}
-      onChange={({ changed, getDocument }) => {
+      editorVariant="https://github.com/serlo/serlo-editor-for-edusharing"
+      onChange={({ changed, getState }) => {
         if (changed){
-          console.log(`New state: `, getDocument())
+          console.log(`New state: `, getState())
         }
       }}
     >
@@ -51,15 +52,15 @@ See below for the current API specification.
 
 ### 1. `SerloEditor`, `type SerloEditorProps`
 
-- **Why Exported/How Used**: `SerloEditor` is the core component of the `@serlo/editor` package, providing the main editor functionality. It's exported to allow users to embed the editor into their applications, passing in initial state, configuration, and custom render props to tailor the editor's functionality to their needs.
+- **Why Exported/How Used**: `SerloEditor` is the core component of the `@serlo/editor` package, providing the main editor functionality. It's exported to allow users to embed the editor into their applications.
 - **Long-Term Support**: Will stay
-- **Needs Change?**: Configuration props need restructuring
+- **Needs Change?**: No
 
 #### 2. `SerloRenderer`, `type SerloRendererProps`
 
 - **Why Exported/How Used**: `SerloRenderer` is a component provided by the `@serlo/editor` for rendering content in a non-editable format. This is particularly useful for displaying the content to users who are not currently editing or are not allowed to edit.
 - **Long-Term Support**: Will stay
-- **Needs Change?**: Same changes as `SerloEditor`
+- **Needs Change?**: No
 
 #### 3. `type BaseEditor`
 
@@ -67,17 +68,23 @@ See below for the current API specification.
 - **Long-Term Support**: Will stay unless a better solution is found
 - **Needs Change?**: Unclear
 
-#### 4. Exports from from `@editor/plugin`, `@/components/fa-icon`, `@editor/editor-ui`
+#### 4. `EditorPluginType`
 
-- **Why Exported/How Used**: These exports are currently necessary for defining custom Edusharing plugins. We don't plan to support custom plugins in the future.
-- **Long-Term Support**: To be deprecated
-- **Needs Change?**: No
+- **Why Exported/How Used**: Can be used in the `SerloEditor` prop `plugins` to enable / disable plugins. Currently only used in `serlo-editor-for-edusharing` because we don't use the default plugins there.
+- **Long-Term Support**: Might stay. But should be used only in exceptional cases.
+- **Needs Change?**: Unclear
 
-#### 5. Style (css) export `@serlo/editor/styles.css`
+#### 5. `type EditorVariant`
 
-- **Why Exported/How Used**: Styles the editor with our custom css. Just import `import '@serlo/editor/style.css'` wherever you render the editor. Mostly used in the web component. The css already comes bundled within the JS of the editor package. Therefore, you shouldn't need to import this, unless you plan to render the editor within the Shadow DOM.
-- **Long-Term Support**: Yes
-- **Needs Change?**: No
+- **Why Exported/How Used**: The variant of the Serlo editor. For example `serlo-editor-for-edusharing` or `serlo.org`. The editor adds this information to the `StorageFormat` that will be saved. Might become useful for example if we need to apply a migration only to one variant of the editor.
+- **Long-Term Support**: Unsure
+- **Needs Change?**: Unsure
+
+#### 6. `defaultPlugins`
+
+- **Why Exported/How Used**: List of plugins that are active per default. Can be used in the `SerloEditor` prop `plugins` to enable / disable plugins. Currently only used in `serlo-editor-for-edusharing` because we modify the default plugins there.
+- **Long-Term Support**: Unsure
+- **Needs Change?**: Unsure
 
 ### `SerloEditor` component props
 
@@ -88,18 +95,19 @@ See below for the current API specification.
   - `history` - for persisting, undo, redo
   - `selectRootDocument` - a function for selecting the current state
 
-- **`pluginsConfig` (optional)**: Serlo Editor plugins can be configured to an extent, this configuration is currently done via the `pluginsConfig` prop of the `SerloEditor` component. Each plugin can be configured separately. There is currently ony one special rule that applies to the Editor in general:
-
-  - `testingSecret`: Required to use Image plugin in testing. A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **To be deprecated once a long term solution is agreed on.**
-  - `enableTextAreaExercise`: A flag that enables the TextAreaExercise plugin. TextAreaExercise plugin is currently not yet ready for serlo.org, but it is enabled in Edusharing integration. **To be deprecated once more features are added to the TextAreaExercise plugin and it's ready for serlo.org.**
-
-- **`customPlugins` (optional)**: An array of custom plugins. **To be deprecated, only used in Edusharing integration**.
+- **`plugins` (optional)**: List of plugins that should be active. If undefined, list `defaultPlugins` will be used. Only use in exceptional cases.
 
 - **`initialState` (optional)**: Pass in an `initialState` to the `SerloEditor` component to prevent seeing an empty editor state. [Here is the documentation](https://github.com/serlo/documentation/wiki/Serlo-Editor-Initial-State-of-Plugins) for sample initial states of each plugin, in case you want to render the Editor displaying a particular plugin by default.
 
-- **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `({ changed, getDocument }) => void` of which you can call `getDocument()` to fetch the latest editor state.
+- **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `({ changed, getState }) => void` of which you can call `getState()` to fetch the latest content state.
 
 - **`language` (optional)**: The default language is `de`.
+
+- **`editorVariant`**: The variant (integration) of the Serlo editor. For example `serlo-editor-for-edusharing` or `serlo-org`. The editor adds this information to the `StorageFormat` that will be saved. Might become useful for example if we need to apply a migration only to one variant of the editor.
+
+- **`_testingSecret` (optional)**: Required to use Image plugin in testing. A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **To be deprecated once a long term solution is agreed on.**
+
+- **`_ltik` (optional)**: Required by the custom plugin `edusharingAsset` only used in `serlo-editor-for-edusharing`. **To be removed once a better solution is found or the plugin is removed.**
 
 ## Releasing a new version to npm
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -28,10 +28,8 @@ function MyCustomSerloEditor({ initialState }: { initialState: InitialState }) {
     <SerloEditor
       initialState={initialState}
       editorVariant="edusharing"
-      onChange={({ changed, getState }) => {
-        if (changed){
-          console.log(`New state: `, getState())
-        }
+      onChange={(newState) => {
+        console.log(`New state: `, newState)
       }}
     >
       {({ editor }) => (
@@ -99,7 +97,7 @@ See below for the current API specification.
 
 - **`initialState` (optional)**: Pass in an `initialState` to the `SerloEditor` component to prevent seeing an empty editor state. [Here is the documentation](https://github.com/serlo/documentation/wiki/Serlo-Editor-Initial-State-of-Plugins) for sample initial states of each plugin, in case you want to render the Editor displaying a particular plugin by default.
 
-- **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `({ changed, getState }) => void` of which you can call `getState()` to fetch the latest content state.
+- **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `(state: StorageFormat) => void`.
 
 - **`language` (optional)**: The default language is `de`.
 

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -33,6 +33,7 @@ export interface BaseEditor {
 export type GetDocument = () => DocumentState | null
 
 export type OnEditorChange = (payload: {
+  /** False if the user undos all changes and arrives back at the initial state */
   changed: boolean
   getDocument: GetDocument
 }) => void

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -30,7 +30,7 @@ export interface BaseEditor {
   selectRootDocument: () => AnyEditorDocument
 }
 
-type GetDocument = () => DocumentState | null
+export type GetDocument = () => DocumentState | null
 
 export type OnEditorChange = (payload: {
   changed: boolean

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -1,17 +1,6 @@
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import type { SupportedLanguage } from '@editor/types/language-data'
-
-import { TemplatePluginType } from '../types/template-plugin-type'
-
-export const emptyDocumentState = {
-  plugin: EditorPluginType.Rows,
-  state: [
-    {
-      plugin: EditorPluginType.Text,
-      state: [],
-    },
-  ],
-}
+import { TemplatePluginType } from '@editor/types/template-plugin-type'
 
 export const defaultPlugins = [
   EditorPluginType.Text,
@@ -37,6 +26,5 @@ export const defaultPlugins = [
 export const defaultSerloEditorProps = {
   plugins: defaultPlugins,
   onChange: undefined,
-  initialState: emptyDocumentState,
   language: 'de' as SupportedLanguage,
 }

--- a/packages/editor/src/package/editor-version.ts
+++ b/packages/editor/src/package/editor-version.ts
@@ -1,0 +1,5 @@
+export function getEditorVersion() {
+  const editorVersion = __EDITOR_VERSION__
+  if (!editorVersion) throw new Error('__EDITOR_VERSION__ was not provided!')
+  return editorVersion
+}

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -8,6 +8,7 @@ import { LtikContext } from '@editor/plugins/edusharing-asset/ltik-context'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { SupportedLanguage } from '@editor/types/language-data'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
+import { getCurrentDatetime } from '@editor/util/get-current-datetime'
 import React from 'react'
 
 import { defaultSerloEditorProps } from './config'
@@ -16,12 +17,12 @@ import { getEditorVersion } from './editor-version'
 import {
   type StorageFormat,
   createEmptyDocument,
-  getCurrentDatetime,
   migrate,
   type EditorVariant,
 } from './storage-format'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
+
 import '@/assets-webkit/styles/serlo-tailwind.css'
 
 export interface SerloEditorProps {

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -105,11 +105,9 @@ export function SerloEditor(props: SerloEditorProps) {
         const document = payload.getDocument()
         if (!document) return null
         return {
+          ...migratedState,
           dateModified,
           editorVersion: getEditorVersion(),
-          type: migratedState.type,
-          variant: migratedState.variant,
-          version: migratedState.version,
           document,
         }
       },

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -1,4 +1,5 @@
 import { Editor, type EditorProps } from '@editor/core'
+import { type GetDocument } from '@editor/core/types'
 import { createBasicPlugins } from '@editor/editor-integration/create-basic-plugins'
 import { createRenderers } from '@editor/editor-integration/create-renderers'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
@@ -9,18 +10,30 @@ import { SupportedLanguage } from '@editor/types/language-data'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
 import React from 'react'
 
-import '@/assets-webkit/styles/serlo-tailwind.css'
 import { defaultSerloEditorProps } from './config'
 import { editorData } from './editor-data'
+import { getEditorVersion } from './editor-version'
+import {
+  type StorageFormat,
+  createEmptyDocument,
+  getCurrentDatetime,
+  migrate,
+  type EditorVariant,
+} from './storage-format'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
+import '@/assets-webkit/styles/serlo-tailwind.css'
 
 export interface SerloEditorProps {
   children: EditorProps['children']
   plugins?: (EditorPluginType | TemplatePluginType)[]
-  initialState?: EditorProps['initialState']
-  onChange?: EditorProps['onChange']
+  initialState?: unknown // Either type `StorageFormat` or outdated storage format that will be migrated to `StorageFormat`
+  onChange?: (payload: {
+    changed: boolean
+    getState: () => StorageFormat | null
+  }) => void
   language?: SupportedLanguage
+  editorVariant: EditorVariant
   _testingSecret?: string
   _ltik?: string
 }
@@ -29,7 +42,7 @@ export interface SerloEditorProps {
 export function SerloEditor(props: SerloEditorProps) {
   const {
     children,
-    initialState,
+    editorVariant,
     onChange,
     language,
     plugins,
@@ -38,6 +51,21 @@ export function SerloEditor(props: SerloEditorProps) {
   } = {
     ...defaultSerloEditorProps,
     ...props,
+  }
+
+  const initialState = !props.initialState
+    ? createEmptyDocument(editorVariant)
+    : props.initialState
+
+  const { migratedState, stateChanged } = migrate(initialState)
+
+  if (onChange && stateChanged) {
+    onChange({
+      changed: true,
+      getState: () => {
+        return migratedState
+      },
+    })
   }
 
   const { instanceData, loggedInData } = editorData[language]
@@ -53,7 +81,10 @@ export function SerloEditor(props: SerloEditorProps) {
       <LoggedInDataProvider value={loggedInData}>
         <LtikContext.Provider value={_ltik}>
           <div className="serlo-editor-hacks">
-            <Editor initialState={initialState} onChange={onChange}>
+            <Editor
+              initialState={migratedState.document}
+              onChange={handleDocumentChange}
+            >
               {children}
             </Editor>
           </div>
@@ -61,4 +92,27 @@ export function SerloEditor(props: SerloEditorProps) {
       </LoggedInDataProvider>
     </InstanceDataProvider>
   )
+
+  function handleDocumentChange(payload: {
+    changed: boolean
+    getDocument: GetDocument
+  }) {
+    if (!onChange) return
+    const dateModified = getCurrentDatetime()
+    onChange({
+      changed: payload.changed,
+      getState: () => {
+        const document = payload.getDocument()
+        if (!document) return null
+        return {
+          dateModified,
+          editorVersion: getEditorVersion(),
+          type: migratedState.type,
+          variant: migratedState.variant,
+          version: migratedState.version,
+          document,
+        }
+      },
+    })
+  }
 }

--- a/packages/editor/src/package/index.ts
+++ b/packages/editor/src/package/index.ts
@@ -1,24 +1,10 @@
 export { SerloEditor, type SerloEditorProps } from './editor'
 export { SerloRenderer, type SerloRendererProps } from './serlo-renderer'
 
-// Exported only so that integrations like serlo-editor-for-edusharing can customize available plugins based on the default plugins
-export { defaultPlugins } from './config'
-
 export type { BaseEditor } from '@editor/core'
 
 export { EditorPluginType } from '@editor/types/editor-plugin-type'
-export { TemplatePluginType } from '@editor/types/template-plugin-type'
 export { type EditorVariant } from '@editor/package/storage-format'
 
-export { string, object, optional, number } from '@editor/plugin'
-export type {
-  EditorPlugin,
-  EditorPluginProps,
-  PrettyStaticState,
-} from '@editor/plugin'
-
-export { FaIcon } from '@/components/fa-icon'
-
-export { EditorInput, PreviewOverlay } from '@editor/editor-ui'
-export { PluginToolbar } from '@editor/editor-ui/plugin-toolbar'
-export { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
+// Exported only so that integrations like serlo-editor-for-edusharing can customize available plugins based on the default plugins
+export { defaultPlugins } from './config'

--- a/packages/editor/src/package/index.ts
+++ b/packages/editor/src/package/index.ts
@@ -7,6 +7,8 @@ export { defaultPlugins } from './config'
 export type { BaseEditor } from '@editor/core'
 
 export { EditorPluginType } from '@editor/types/editor-plugin-type'
+export { TemplatePluginType } from '@editor/types/template-plugin-type'
+export { type EditorVariant } from '@editor/package/storage-format'
 
 export { string, object, optional, number } from '@editor/plugin'
 export type {

--- a/packages/editor/src/package/index.ts
+++ b/packages/editor/src/package/index.ts
@@ -4,7 +4,6 @@ export { SerloRenderer, type SerloRendererProps } from './serlo-renderer'
 export type { BaseEditor } from '@editor/core'
 
 export { EditorPluginType } from '@editor/types/editor-plugin-type'
-export { type EditorVariant } from '@editor/package/storage-format'
 
 // Exported only so that integrations like serlo-editor-for-edusharing can customize available plugins based on the default plugins
 export { defaultPlugins } from './config'

--- a/packages/editor/src/package/serlo-renderer.tsx
+++ b/packages/editor/src/package/serlo-renderer.tsx
@@ -2,25 +2,28 @@ import { createRenderers } from '@editor/editor-integration/create-renderers'
 import { editorRenderers } from '@editor/plugin/helpers/editor-renderer'
 import { LtikContext } from '@editor/plugins/edusharing-asset/ltik-context'
 import { StaticRenderer } from '@editor/static-renderer/static-renderer'
-import type { AnyEditorDocument } from '@editor/types/editor-plugins'
 import type { SupportedLanguage } from '@editor/types/language-data'
 
 import { defaultSerloEditorProps } from './config'
 import { editorData } from './editor-data'
+import { StorageFormat, migrate } from './storage-format'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
 
 export interface SerloRendererProps {
   language?: SupportedLanguage
-  document?: AnyEditorDocument | AnyEditorDocument[]
+  state: StorageFormat
   _ltik?: string
 }
 
 export function SerloRenderer(props: SerloRendererProps) {
-  const { language, _ltik } = {
+  const { language, _ltik, state } = {
     ...defaultSerloEditorProps,
     ...props,
   }
+
+  // Side note: Migrated state will not be persisted since we cannot save in static renderer view
+  const { migratedState } = migrate(state)
 
   const { instanceData, loggedInData } = editorData[language]
 
@@ -32,7 +35,7 @@ export function SerloRenderer(props: SerloRendererProps) {
       <LoggedInDataProvider value={loggedInData}>
         <LtikContext.Provider value={_ltik}>
           <div className="serlo-editor-hacks">
-            <StaticRenderer {...props} />
+            <StaticRenderer document={migratedState.document} />
           </div>
         </LtikContext.Provider>
       </LoggedInDataProvider>

--- a/packages/editor/src/package/serlo-renderer.tsx
+++ b/packages/editor/src/package/serlo-renderer.tsx
@@ -6,13 +6,13 @@ import type { SupportedLanguage } from '@editor/types/language-data'
 
 import { defaultSerloEditorProps } from './config'
 import { editorData } from './editor-data'
-import { StorageFormat, migrate } from './storage-format'
+import { migrate } from './storage-format'
 import { InstanceDataProvider } from '@/contexts/instance-context'
 import { LoggedInDataProvider } from '@/contexts/logged-in-data-context'
 
 export interface SerloRendererProps {
   language?: SupportedLanguage
-  state: StorageFormat
+  state: unknown
   _ltik?: string
 }
 

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -1,3 +1,5 @@
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+import { TemplatePluginType } from '@editor/types/template-plugin-type'
 import * as t from 'io-ts'
 import { v4 as uuid_v4 } from 'uuid'
 
@@ -52,21 +54,10 @@ export function createEmptyDocument(
     editorVersion: getEditorVersion(),
     dateModified: getCurrentDatetime(),
     document: {
-      plugin: 'type-generic-content',
+      plugin: TemplatePluginType.GenericContent,
       state: {
         content: {
-          plugin: 'rows',
-          state: [
-            {
-              plugin: 'text',
-              state: [
-                {
-                  type: 'p',
-                  children: [{ text: '' }],
-                },
-              ],
-            },
-          ],
+          plugin: EditorPluginType.Rows,
         },
       },
     },

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts'
+import { v4 as uuid_v4 } from 'uuid'
 
 import { getEditorVersion } from './editor-version'
 
@@ -8,7 +9,7 @@ const documentType = 'https://serlo.org/editor'
 type Migration = (state: { version: number }) => { version: number }
 
 const migrations: Migration[] = [
-  // Migration: Add `editorVersion`
+  // Migration: Add `editorVersion` and `id`
   (state): StorageFormat => {
     const expectedType = t.type({
       type: t.literal(documentType),
@@ -26,10 +27,12 @@ const migrations: Migration[] = [
       )
 
     const editorVersion = getEditorVersion()
+    const id = uuid_v4()
 
     return {
       ...state,
       editorVersion,
+      id,
     }
   },
   // ...
@@ -42,6 +45,7 @@ export function createEmptyDocument(
   editorVariant: EditorVariant
 ): StorageFormat {
   return {
+    id: uuid_v4(),
     type: documentType,
     variant: editorVariant,
     version: currentVersion,
@@ -114,6 +118,7 @@ export type EditorVariant = t.TypeOf<typeof EditorVariantType>
 
 const StorageFormatType = t.type({
   // Constant values (set at creation)
+  id: t.string, // https://dini-ag-kim.github.io/amb/20231019/#id
   type: t.literal(documentType),
   variant: EditorVariantType,
 

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -1,0 +1,133 @@
+import * as t from 'io-ts'
+
+import { getEditorVersion } from './editor-version'
+
+/** The creator of the saved data -> Serlo editor */
+const documentType = 'https://serlo.org/editor'
+
+type Migration = (state: { version: number }) => { version: number }
+
+const migrations: Migration[] = [
+  // Migration: Add `editorVersion`
+  (state): StorageFormat => {
+    const expectedType = t.type({
+      type: t.literal(documentType),
+      variant: EditorVariantType,
+      version: t.number,
+      dateModified: t.string,
+      document: t.type({
+        plugin: t.string,
+        state: t.unknown,
+      }),
+    })
+    if (!expectedType.is(state))
+      throw new Error(
+        `Unexpected type during migration. Expected ${JSON.stringify(expectedType)} but got ${JSON.stringify(state)}`
+      )
+
+    const editorVersion = getEditorVersion()
+
+    return {
+      ...state,
+      editorVersion,
+    }
+  },
+  // ...
+  // Add new migrations here. Make sure the last one returns the new StorageFormat.
+]
+
+const currentVersion = migrations.length
+
+export function createEmptyDocument(
+  editorVariant: EditorVariant
+): StorageFormat {
+  return {
+    type: documentType,
+    variant: editorVariant,
+    version: currentVersion,
+    editorVersion: getEditorVersion(),
+    dateModified: getCurrentDatetime(),
+    document: {
+      plugin: 'type-generic-content',
+      state: {
+        content: {
+          plugin: 'rows',
+          state: [
+            {
+              plugin: 'text',
+              state: [
+                {
+                  type: 'p',
+                  children: [{ text: '' }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  }
+}
+
+export function migrate(stateBeforeMigration: unknown): {
+  migratedState: StorageFormat
+  stateChanged: boolean
+} {
+  if (!t.type({ version: t.number }).is(stateBeforeMigration))
+    throw new Error(
+      `Missing property 'version: number' in state while trying to perform migrations. Got ${JSON.stringify(stateBeforeMigration)}`
+    )
+
+  // Only apply migrations for this version number and higher
+  const nextMigrationIndex = stateBeforeMigration.version
+
+  // Create deep copy
+  let migratedState = JSON.parse(JSON.stringify(stateBeforeMigration)) as {
+    version: number
+  }
+  let stateChanged = false
+  for (let i = nextMigrationIndex; i < migrations.length; i++) {
+    migratedState = migrations[i](migratedState)
+    stateChanged = true
+    migratedState.version = i + 1
+  }
+
+  if (!StorageFormatType.is(migratedState))
+    throw new Error(
+      'Storage format after migrations does not match StorageFormatType'
+    )
+
+  if (stateChanged) {
+    migratedState.editorVersion = getEditorVersion()
+    migratedState.dateModified = getCurrentDatetime()
+  }
+
+  return { migratedState, stateChanged }
+}
+
+/** The variant of the Serlo editor that created this saved data */
+const EditorVariantType = t.union([
+  t.literal('https://github.com/serlo/serlo-editor-for-edusharing'),
+  t.literal('https://github.com/serlo/serlo-editor-as-lti-tool/'),
+])
+export type EditorVariant = t.TypeOf<typeof EditorVariantType>
+
+const StorageFormatType = t.type({
+  // Constant values (set at creation)
+  type: t.literal(documentType),
+  variant: EditorVariantType,
+
+  // Variable values (can change when state modified)
+  version: t.number, // Index of the next migration to apply (if there is one). Example: 2 -> Apply migration[2], migration[3], ... until end of array
+  editorVersion: t.string,
+  dateModified: t.string,
+  document: t.type({
+    plugin: t.string,
+    state: t.unknown,
+  }),
+})
+export type StorageFormat = t.TypeOf<typeof StorageFormatType>
+
+export function getCurrentDatetime() {
+  return new Date().toISOString()
+}

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -1,5 +1,6 @@
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { TemplatePluginType } from '@editor/types/template-plugin-type'
+import { getCurrentDatetime } from '@editor/util/get-current-datetime'
 import * as t from 'io-ts'
 import { v4 as uuid_v4 } from 'uuid'
 
@@ -123,7 +124,3 @@ const StorageFormatType = t.type({
   }),
 })
 export type StorageFormat = t.TypeOf<typeof StorageFormatType>
-
-export function getCurrentDatetime() {
-  return new Date().toISOString()
-}

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -103,8 +103,11 @@ export function migrate(stateBeforeMigration: unknown): {
 
 /** The variant of the Serlo editor that created this saved data */
 const EditorVariantType = t.union([
-  t.literal('https://github.com/serlo/serlo-editor-for-edusharing'),
-  t.literal('https://github.com/serlo/serlo-editor-as-lti-tool/'),
+  t.literal('edusharing'),
+  t.literal('lti-tool'),
+  t.literal('serlo-org'),
+  t.literal('moodle'),
+  t.literal('chancenwerk'),
 ])
 export type EditorVariant = t.TypeOf<typeof EditorVariantType>
 

--- a/packages/editor/src/util/get-current-datetime.ts
+++ b/packages/editor/src/util/get-current-datetime.ts
@@ -1,0 +1,3 @@
+export function getCurrentDatetime() {
+  return new Date().toISOString()
+}

--- a/packages/editor/src/vite-env.d.ts
+++ b/packages/editor/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare const __EDITOR_VERSION__: string

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -8,7 +8,8 @@
     },
     "outDir": "dist",
     "module": "ES2022",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["./src/vite-env.d.ts"]
   },
   "include": [
     "./custom.d.ts",

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -8,8 +8,7 @@
     },
     "outDir": "dist",
     "module": "ES2022",
-    "moduleResolution": "bundler",
-    "types": ["./src/vite-env.d.ts"]
+    "moduleResolution": "bundler"
   },
   "include": [
     "./custom.d.ts",

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -99,4 +99,8 @@ export default defineConfig({
       },
     }),
   ],
+  define: {
+    // Makes Vite pull the version from editor/package.json and make it available in editor code
+    __EDITOR_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 })


### PR DESCRIPTION
# TODO
- [x] Implement `editorVersion` according to schema.org / AMB -> Sadly, I found nothing to use. 

# Changes
- Breaking: Now, the editor package takes and outputs state of type `StorageFormat` instead of just the editor state `{plugin: ..., state: ...}` 
``` ts
type StorageFormat {
  // Constant values (set at creation)
  id: string // uuid
  type: 'https://serlo.org/editor',
  variant: 'edusharing' | 'lti-tool' | 'serlo-org' | ...,

  // Variable values (can change when state modified)
  version: number, // Index of the next migration to apply (if there is one). Example: 2 -> Apply migration[2], migration[3], ... until end of array
  editorVersion: string, // For example 0.10.1
  dateModified: string,
  document: {
    plugin: string,
    state: unknown,
  }
}
```
- Breaking: New required parameter `editorVariant` in editor API
- Breaking: Parameter `onChange`

# Notes

- `SerloRenderer` also performs migrations but content cannot be saved. 
- serlo.org is unaffected by this since it does not consume the editor npm package yet. In the future it should however. 

# Followups

- Migrate content in database on serlo.org to new storage format & consume editor package