### PR TITLE
feat(editor-plugin-menu): make sure filter finds all relevant plugins

### DIFF
--- a/packages/editor/src/plugins/rows/utils/plugin-menu.ts
+++ b/packages/editor/src/plugins/rows/utils/plugin-menu.ts
@@ -50,16 +50,9 @@ export function filterOptions(option: PluginMenuItemType[], text: string) {
   // title or pluginType start with search string
   option.forEach((entry) => {
     if (
-      entry.title.toLowerCase().startsWith(search) ||
-      entry.pluginType.startsWith(search)
+      entry.title.toLowerCase().includes(search) ||
+      entry.pluginType.toLowerCase().includes(search)
     ) {
-      filterResults.add(entry)
-    }
-  })
-
-  // title includes search string
-  option.forEach((entry) => {
-    if (entry.title.toLowerCase().includes(search)) {
       filterResults.add(entry)
     }
   })

--- a/packages/editor/src/plugins/rows/utils/plugin-menu.ts
+++ b/packages/editor/src/plugins/rows/utils/plugin-menu.ts
@@ -42,22 +42,16 @@ export function createOption(
 }
 
 export function filterOptions(option: PluginMenuItemType[], text: string) {
+  if (!text.length) return option
+
   const search = text.toLowerCase()
-  if (!search.length) return option
 
-  const filterResults = new Set<PluginMenuItemType>()
-
-  // title or pluginType start with search string
-  option.forEach((entry) => {
-    if (
+  // title (localized) or pluginType includes search string
+  return option.filter(
+    (entry) =>
       entry.title.toLowerCase().includes(search) ||
       entry.pluginType.toLowerCase().includes(search)
-    ) {
-      filterResults.add(entry)
-    }
-  })
-
-  return [...filterResults]
+  )
 }
 
 const interactivePluginTypes = new Set([


### PR DESCRIPTION
This makes sure users find all relevant plugins (e.g. in the german instance searching for "table" also finds "serloTable"). 

This should also fix the gallery e2e test.