### PR TITLE
feat(image-gallery): add images toolbar button (PE-74)

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -808,7 +808,6 @@ export const loggedInData = {
           placeholderEmpty: 'https://example.com/image.png',
           placeholderUploading: 'Uploading…',
           placeholderFailed: 'Upload failed…',
-          tooManyImagesError: 'You can only upload up to 8 images at once.',
           retry: 'Retry',
           failedUpload: 'Upload failed',
           captionPlaceholder: 'Optional caption',
@@ -837,6 +836,8 @@ export const loggedInData = {
           modalScreenReaderTitle:
             'Modal displaying single image options for caption and settings.',
           addImages: 'Add Images',
+          tooManyImagesMessage:
+            'Image Gallery can only contain up to 8 images.',
         },
         injection: {
           title: 'serlo.org Content',

--- a/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
@@ -1,6 +1,6 @@
 import { selectStaticDocuments, useAppSelector } from '@editor/store'
 import { isImageDocument } from '@editor/types/plugin-type-guards'
-import { MouseEvent, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { ImageGrid } from './image-grid'
 import { ImageGridSkeleton } from './image-grid-skeleton'
@@ -10,7 +10,7 @@ import { loadGalleryImages } from '../utils/helpers'
 
 interface EditorImageGridProps {
   state: ImageGalleryProps['state']
-  onImageClick: (event: MouseEvent<HTMLButtonElement>, index: number) => void
+  onImageClick: (index: number) => void
 }
 
 export function EditorImageGrid({ state, onImageClick }: EditorImageGridProps) {

--- a/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
@@ -15,6 +15,7 @@ interface EditorImageGridProps {
 
 export function EditorImageGrid({ state, onImageClick }: EditorImageGridProps) {
   const [images, setImages] = useState<GridImage[]>([])
+  const [isLoading, setIsLoading] = useState(false)
 
   const imageIds = state.images.map((id) => id.get())
   const imageDocuments = useAppSelector((state) =>
@@ -27,14 +28,17 @@ export function EditorImageGrid({ state, onImageClick }: EditorImageGridProps) {
 
   useEffect(() => {
     const loadImagesAsync = async () => {
-      setImages(await loadGalleryImages(imageUrls))
+      const loadedImages = await loadGalleryImages(imageUrls)
+      setImages(loadedImages)
+      setIsLoading(false)
     }
 
+    setIsLoading(true)
     void loadImagesAsync()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(imageUrls)])
 
-  if (images.length === 0) return <ImageGridSkeleton />
+  if (isLoading) return <ImageGridSkeleton />
 
   return <ImageGrid images={images} onImageClick={onImageClick} />
 }

--- a/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
@@ -1,11 +1,11 @@
-import { Fragment, MouseEvent } from 'react'
+import { Fragment } from 'react'
 
 import { GridImage } from '../types'
 import { getRowPercentages } from '../utils/helpers'
 
 interface ImageGridProps {
   images: GridImage[]
-  onImageClick: (event: MouseEvent<HTMLButtonElement>, index: number) => void
+  onImageClick: (index: number) => void
 }
 
 export function ImageGrid({ images, onImageClick }: ImageGridProps) {
@@ -20,7 +20,7 @@ export function ImageGrid({ images, onImageClick }: ImageGridProps) {
             <button
               key={image.src}
               className="mx-auto"
-              onMouseDown={(event) => onImageClick(event, index)}
+              onMouseDown={() => onImageClick(index)}
             >
               <img
                 src={image.src}
@@ -37,13 +37,13 @@ export function ImageGrid({ images, onImageClick }: ImageGridProps) {
           <Fragment key={image.src}>
             <button
               style={{ width: `calc(${rowPercentages.left}% - 0.5rem)` }}
-              onClick={(event) => onImageClick(event, index)}
+              onClick={() => onImageClick(index)}
             >
               <img src={image.src} alt={`Image ${image.src}`} />
             </button>
             <button
               style={{ width: `calc(${rowPercentages.right}% - 0.5rem)` }}
-              onClick={(event) => onImageClick(event, index + 1)}
+              onClick={() => onImageClick(index + 1)}
             >
               <img
                 src={images[index + 1].src}

--- a/packages/editor/src/plugins/image-gallery/editor.tsx
+++ b/packages/editor/src/plugins/image-gallery/editor.tsx
@@ -63,16 +63,15 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
     dispatch(focus(id))
   }
 
-  function pruneEmptyImagePlugins() {
-    state.images.forEach((image, index) => {
-      if (selectIsDocumentEmpty(store.getState(), image.id)) {
-        state.images.remove(index)
-      }
-    })
+  function removeDefaultEmptyImagePlugin() {
+    const defaultImagePluginId = state.images[currentImageIndex].id
+    if (selectIsDocumentEmpty(store.getState(), defaultImagePluginId)) {
+      state.images.remove(currentImageIndex)
+    }
   }
 
   function handleImageModalClose() {
-    pruneEmptyImagePlugins()
+    removeDefaultEmptyImagePlugin()
     setIsModalOpen(false)
   }
 

--- a/packages/editor/src/plugins/image-gallery/editor.tsx
+++ b/packages/editor/src/plugins/image-gallery/editor.tsx
@@ -6,7 +6,7 @@ import {
   useAppSelector,
 } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
-import { MouseEvent, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import type { ImageGalleryProps } from '.'
 import { AddImagesButton } from './components/add-images-button'
@@ -34,9 +34,7 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
   )
 
   function handleAddImagesButtonClick() {
-    if (state.images.length === 0) {
-      state.images.insert(0, { plugin: EditorPluginType.Image })
-    }
+    state.images.insert(state.images.length, { plugin: EditorPluginType.Image })
     setIsModalOpen(true)
   }
 
@@ -58,7 +56,7 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
     setIsModalOpen(false)
   }
 
-  function handleImageClick(event: MouseEvent, index: number) {
+  function handleImageClick(index: number) {
     // first click on plugin should focus it, not open the modal
     if (!oldFocusState) return
     setCurrentImageIndex(index)

--- a/packages/editor/src/plugins/image-gallery/editor.tsx
+++ b/packages/editor/src/plugins/image-gallery/editor.tsx
@@ -2,6 +2,8 @@ import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 import {
   focus,
   selectHasFocusedChild,
+  selectIsDocumentEmpty,
+  store,
   useAppDispatch,
   useAppSelector,
 } from '@editor/store'
@@ -35,6 +37,7 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
 
   function handleAddImagesButtonClick() {
     state.images.insert(state.images.length, { plugin: EditorPluginType.Image })
+    setCurrentImageIndex(state.images.length)
     setIsModalOpen(true)
   }
 
@@ -52,7 +55,16 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
     dispatch(focus(id))
   }
 
+  function pruneEmptyImagePlugins() {
+    state.images.forEach((image, index) => {
+      if (selectIsDocumentEmpty(store.getState(), image.id)) {
+        state.images.remove(index)
+      }
+    })
+  }
+
   function handleImageModalClose() {
+    pruneEmptyImagePlugins()
     setIsModalOpen(false)
   }
 
@@ -73,7 +85,12 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
 
   return (
     <div data-qa="plugin-image-gallery-wrapper">
-      {focused || isAnyImageFocused ? <ImageGalleryToolbar id={id} /> : null}
+      {focused || isAnyImageFocused ? (
+        <ImageGalleryToolbar
+          id={id}
+          onAddImagesButtonClick={handleAddImagesButtonClick}
+        />
+      ) : null}
 
       {hasImages ? (
         <EditorImageGrid state={state} onImageClick={handleImageClick} />

--- a/packages/editor/src/plugins/image-gallery/editor.tsx
+++ b/packages/editor/src/plugins/image-gallery/editor.tsx
@@ -16,6 +16,9 @@ import { EditorImageGrid } from './components/editor-image-grid'
 import { ImageGalleryToolbar } from './toolbar'
 import { ModalWithCloseButton } from '@/components/modal-with-close-button'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { showToastNotice } from '@/helper/show-toast-notice'
+
+const MAX_IMAGES = 8
 
 export function ImageGalleryEditor(props: ImageGalleryProps) {
   const { id, focused, state } = props
@@ -42,14 +45,19 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
   }
 
   function handleMultipleImageUpload(files: File[]) {
-    for (const file of files) {
-      const newImagePluginState = imagePlugin.onFiles?.([file])
-      const newImagePlugin = {
-        plugin: EditorPluginType.Image,
-        state: newImagePluginState?.state as unknown,
+    if (state.images.length + files.length > MAX_IMAGES) {
+      showToastNotice(imageGalleryStrings.tooManyImagesMessage, 'warning')
+    } else {
+      for (const file of files) {
+        const newImagePluginState = imagePlugin.onFiles?.([file])
+        const newImagePlugin = {
+          plugin: EditorPluginType.Image,
+          state: newImagePluginState?.state as unknown,
+        }
+        state.images.insert(currentImageIndex, newImagePlugin)
       }
-      state.images.insert(currentImageIndex, newImagePlugin)
     }
+
     setHasImages(true)
     setIsModalOpen(false)
     dispatch(focus(id))
@@ -88,6 +96,7 @@ export function ImageGalleryEditor(props: ImageGalleryProps) {
       {focused || isAnyImageFocused ? (
         <ImageGalleryToolbar
           id={id}
+          showAddImagesButton={state.images.length < MAX_IMAGES}
           onAddImagesButtonClick={handleAddImagesButtonClick}
         />
       ) : null}

--- a/packages/editor/src/plugins/image-gallery/static.tsx
+++ b/packages/editor/src/plugins/image-gallery/static.tsx
@@ -2,7 +2,7 @@ import {
   EditorImageDocument,
   EditorImageGalleryDocument,
 } from '@editor/types/editor-plugins'
-import { MouseEvent, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { ImageGrid } from './components/image-grid'
 import { GridImage } from './types'
@@ -24,7 +24,7 @@ export function ImageGalleryStaticRenderer({
     void loadImages()
   }, [imageSources])
 
-  function handleImageClick(_event: MouseEvent, index: number) {
+  function handleImageClick(index: number) {
     console.log('Clicked image at index:', index)
     // TODO: Lightbox feature will be implemented, linear issue PE-57
   }

--- a/packages/editor/src/plugins/image-gallery/toolbar.tsx
+++ b/packages/editor/src/plugins/image-gallery/toolbar.tsx
@@ -3,25 +3,30 @@ import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
+import { cn } from '@/helper/cn'
 
 interface ImageGalleryToolbarProps {
   id: string
+  showAddImagesButton: boolean
   onAddImagesButtonClick: () => void
 }
 
 export const ImageGalleryToolbar = (props: ImageGalleryToolbarProps) => {
-  const { id, onAddImagesButtonClick } = props
+  const { id, showAddImagesButton, onAddImagesButtonClick } = props
 
   const imageGalleryStrings = useEditorStrings().plugins.imageGallery
 
-  const pluginSettings = (
+  const pluginSettings = showAddImagesButton ? (
     <button
       onClick={onAddImagesButtonClick}
-      className="mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
+      className={cn(
+        'transition-al mr-2 rounded-md border border-gray-500 px-1 text-sm',
+        'hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200'
+      )}
     >
       {imageGalleryStrings.addImages} {' +'}
     </button>
-  )
+  ) : undefined
 
   return (
     <PluginToolbar

--- a/packages/editor/src/plugins/image-gallery/toolbar.tsx
+++ b/packages/editor/src/plugins/image-gallery/toolbar.tsx
@@ -2,16 +2,31 @@ import { PluginToolbar } from '@editor/editor-ui/plugin-toolbar'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
 interface ImageGalleryToolbarProps {
   id: string
+  onAddImagesButtonClick: () => void
 }
 
 export const ImageGalleryToolbar = (props: ImageGalleryToolbarProps) => {
-  const { id } = props
+  const { id, onAddImagesButtonClick } = props
+
+  const imageGalleryStrings = useEditorStrings().plugins.imageGallery
+
+  const pluginSettings = (
+    <button
+      onClick={onAddImagesButtonClick}
+      className="mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
+    >
+      {imageGalleryStrings.addImages} {' +'}
+    </button>
+  )
 
   return (
     <PluginToolbar
       pluginType={EditorPluginType.ImageGallery}
+      pluginSettings={pluginSettings}
       pluginControls={<PluginDefaultTools pluginId={id} />}
     />
   )

--- a/packages/editor/src/plugins/image/components/image-selection-screen.tsx
+++ b/packages/editor/src/plugins/image/components/image-selection-screen.tsx
@@ -9,18 +9,24 @@ import { isImageUrl } from '../utils/check-image-url'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { cn } from '@/helper/cn'
 
-export function ImageSelectionScreen(
-  props: ImageProps & {
-    urlInputRef: RefObject<HTMLInputElement>
-    setIsAButtonFocused: (isFocused: boolean) => void
-  }
-) {
+interface ImageSelectionScreenProps {
+  config: ImageProps['config']
+  state: ImageProps['state']
+  urlInputRef: RefObject<HTMLInputElement>
+  setIsAButtonFocused: (isFocused: boolean) => void
+}
+
+export function ImageSelectionScreen({
+  config,
+  state,
+  urlInputRef,
+  setIsAButtonFocused,
+}: ImageSelectionScreenProps) {
   const editorStrings = useEditorStrings()
-  const { config, state, urlInputRef, setIsAButtonFocused } = props
   const { src, licence } = state
 
   const imageStrings = editorStrings.plugins.image
-  const disableFileUpload = props.config.disableFileUpload // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
+  const disableFileUpload = config.disableFileUpload // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
 
   const placeholder = !isTempFile(src.value)
     ? imageStrings.placeholderEmpty
@@ -49,9 +55,10 @@ export function ImageSelectionScreen(
     >
       <div className="mx-auto my-8 w-[60%]">
         <UploadButton
+          config={config}
+          src={src}
           onFocus={() => setIsAButtonFocused(true)}
           onBlur={() => setIsAButtonFocused(false)}
-          {...props}
         />
         {showPixabayButton && (
           <PixabaySearchButton

--- a/packages/editor/src/plugins/image/controls/upload-button.tsx
+++ b/packages/editor/src/plugins/image/controls/upload-button.tsx
@@ -10,7 +10,6 @@ import { useState } from 'react'
 
 import type { ImageProps } from '..'
 import { cn } from '@/helper/cn'
-import { showToastNotice } from '@/helper/show-toast-notice'
 
 interface UploadButtonProps {
   config: ImageProps['config']
@@ -63,11 +62,6 @@ export function UploadButton({
           onChange={({ target }) => {
             if (target.files && target.files.length) {
               const filesArray = Array.from(target.files)
-
-              if (target.files.length > 8) {
-                showToastNotice(imageStrings.tooManyImagesError, 'warning')
-                return
-              }
 
               // Upload the first file like normal
               void src.upload(filesArray[0], config.upload)

--- a/packages/editor/src/plugins/image/controls/upload-button.tsx
+++ b/packages/editor/src/plugins/image/controls/upload-button.tsx
@@ -14,18 +14,17 @@ import { showToastNotice } from '@/helper/show-toast-notice'
 
 interface UploadButtonProps {
   config: ImageProps['config']
-  state: ImageProps['state']
+  src: ImageProps['state']['src']
   onFocus?: () => void
   onBlur?: () => void
 }
 
 export function UploadButton({
   config,
-  state,
+  src,
   onFocus,
   onBlur,
 }: UploadButtonProps) {
-  const { src } = state
   const imageStrings = useEditorStrings().plugins.image
   const isFailed = isTempFile(src.value) && src.value.failed
 

--- a/packages/editor/src/plugins/image/editor.tsx
+++ b/packages/editor/src/plugins/image/editor.tsx
@@ -13,7 +13,6 @@ import { ImageSelectionScreen } from './components/image-selection-screen'
 import { ImageRenderer } from './renderer'
 import { ImageToolbar } from './toolbar'
 import { isImageUrl } from './utils/check-image-url'
-import { TextEditorConfig } from '../text'
 
 const captionFormattingOptions = [
   TextEditorFormattingOption.richTextBold,
@@ -23,10 +22,9 @@ const captionFormattingOptions = [
 ]
 
 export function ImageEditor(props: ImageProps) {
-  const { focused, state, config } = props
+  const { id, focused, state, config } = props
   const imageStrings = useEditorStrings().plugins.image
 
-  const [showSettingsModal, setShowSettingsModal] = useState(false)
   const [showInlineImageUrl, setShowInlineImageUrl] = useState(!state.src.value)
 
   usePendingFileUploader(state.src, config.upload)
@@ -41,12 +39,11 @@ export function ImageEditor(props: ImageProps) {
       ? imageStrings.galleryTitle
       : undefined
 
-  // focus related logic
-  const isCaptionFocused = useAppSelector((storeState) => {
-    return state.caption.defined
+  const isCaptionFocused = useAppSelector((storeState) =>
+    state.caption.defined
       ? selectIsFocused(storeState, state.caption.id)
       : false
-  })
+  )
   const [isAButtonFocused, setIsAButtonFocused] = useState(false)
 
   const hasFocus =
@@ -82,21 +79,22 @@ export function ImageEditor(props: ImageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  function handleChangeImageButtonClick() {
+    state.src.set('')
+    state.alt.defined && state.alt.remove()
+    state.caption.defined && state.caption.remove()
+    state.link.defined && state.link.remove()
+  }
+
   return (
     <>
       {hasFocus ? (
         <ImageToolbar
-          {...props}
-          onClickChangeImage={() => {
-            state.src.set('')
-            state.alt.defined && state.alt.remove()
-            state.caption.defined && state.caption.remove()
-            state.link.defined && state.link.remove()
-          }}
+          id={id}
+          state={state}
           title={toolbarTitle}
           showSettingsButtons={hasValidUrl}
-          showSettingsModal={showSettingsModal}
-          setShowSettingsModal={setShowSettingsModal}
+          onChangeImageButtonClick={handleChangeImageButtonClick}
         />
       ) : null}
 
@@ -107,14 +105,7 @@ export function ImageEditor(props: ImageProps) {
         )}
         data-qa="plugin-image-editor"
       >
-        {!hasValidUrl && (
-          <ImageSelectionScreen
-            {...props}
-            setIsAButtonFocused={setIsAButtonFocused}
-            urlInputRef={urlInputRef}
-          />
-        )}
-        {hasValidUrl && (
+        {hasValidUrl ? (
           <ImageRenderer
             image={{
               src,
@@ -127,6 +118,13 @@ export function ImageEditor(props: ImageProps) {
             caption={renderCaption()}
             placeholder={renderPlaceholder()}
             forceNewTab
+          />
+        ) : (
+          <ImageSelectionScreen
+            config={config}
+            state={state}
+            setIsAButtonFocused={setIsAButtonFocused}
+            urlInputRef={urlInputRef}
           />
         )}
       </div>
@@ -156,7 +154,7 @@ export function ImageEditor(props: ImageProps) {
         placeholder: imageStrings.captionPlaceholder,
         formattingOptions: captionFormattingOptions,
         isInlineChildEditor: true,
-      } as TextEditorConfig,
+      },
     })
   }
 }

--- a/packages/editor/src/plugins/image/toolbar.tsx
+++ b/packages/editor/src/plugins/image/toolbar.tsx
@@ -5,35 +5,35 @@ import { faCog, faSyncAlt } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
 import { ModalWithCloseButton } from '@serlo/frontend/src/components/modal-with-close-button'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
-import { Dispatch, SetStateAction } from 'react'
+import { useState } from 'react'
 
 import type { ImageProps } from '.'
 import { SettingsModalControls } from './controls/settings-modal-controls'
 
-export const ImageToolbar = (
-  props: ImageProps & {
-    title?: string
-    showSettingsButtons?: boolean
-    showSettingsModal: boolean
-    setShowSettingsModal: Dispatch<SetStateAction<boolean>>
-    onClickChangeImage: () => void
-  }
-) => {
-  const {
-    id,
-    title,
-    showSettingsModal,
-    setShowSettingsModal,
-    showSettingsButtons = true,
-    onClickChangeImage,
-  } = props
+interface ImageToolbarProps {
+  id: ImageProps['id']
+  state: ImageProps['state']
+  title: string | undefined
+  showSettingsButtons: boolean
+  onChangeImageButtonClick: () => void
+}
+
+export function ImageToolbar({
+  id,
+  state,
+  title,
+  showSettingsButtons,
+  onChangeImageButtonClick,
+}: ImageToolbarProps) {
+  const [showSettingsModal, setShowSettingsModal] = useState(false)
+
   const editorStrings = useEditorStrings()
   const imageStrings = editorStrings.plugins.image
 
   const pluginSettings = showSettingsButtons ? (
     <>
       <button
-        onClick={() => onClickChangeImage()}
+        onClick={onChangeImageButtonClick}
         className="mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
       >
         {imageStrings.change} <FaIcon className="ml-1" icon={faSyncAlt} />
@@ -55,7 +55,7 @@ export const ImageToolbar = (
         </h3>
 
         <div className="mx-side mb-3">
-          <SettingsModalControls state={props.state} />
+          <SettingsModalControls state={state} />
         </div>
       </ModalWithCloseButton>
     </>
@@ -63,12 +63,11 @@ export const ImageToolbar = (
 
   return (
     <PluginToolbar
-      pluginTitle={title}
       pluginType={EditorPluginType.Image}
       pluginSettings={pluginSettings}
-      noWhiteShadow
-      // pluginTooltipText={editorStrings.plugins.image.helpTooltipText}
       pluginControls={<PluginDefaultTools pluginId={id} />}
+      pluginTitle={title}
+      noWhiteShadow
     />
   )
 }


### PR DESCRIPTION
Linear ticket: PE-74

Todo:
- [x] Image and Image Gallery plugins code cleanup
- [x] Add add images button to toolbar
- [x] Show loader when adding additional images
- [x] Append new images to existing images in masonry
- [x] Limit upload to 8 in total