### PR TITLE
refactor(plugin-gallery): simpler image grid

### DIFF
--- a/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
@@ -1,11 +1,9 @@
 import { StaticSlate } from '@editor/plugins/text/static-components/static-slate'
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
-import { Fragment } from 'react'
 import { Descendant } from 'slate'
 
 import { GridImage } from '../types'
-import { getRowPercentages } from '../utils/helpers'
 import { cn } from '@/helper/cn'
 
 const wrapperClassNames = 'group relative'
@@ -21,56 +19,52 @@ interface ImageGridProps {
   onRemoveImageButtonClick?: (index: number) => void
 }
 
+function getFlexString(img: GridImage) {
+  return `calc(${img.width} / ${img.height})`
+}
+
 export function ImageGrid({
   images,
   onImageClick,
   onRemoveImageButtonClick,
 }: ImageGridProps) {
   return (
-    <div className="flex flex-wrap gap-4">
-      {images.map((image, index) => {
+    <div>
+      {}
+      {images.map((leftImage, index) => {
         if (index % 2 !== 0) return null
 
-        // If the image is the last one in the array, render it as a single image
-        if (index + 1 === images.length) {
-          return (
-            <div key={image.src} className={cn(wrapperClassNames, 'mx-auto')}>
-              <button onClick={() => onImageClick(index)}>
-                <img
-                  src={image.src}
-                  alt={`Image ${image.src}`}
-                  className="max-h-96"
-                />
-              </button>
-              {renderHoverOverlay(image.caption, index)}
-            </div>
-          )
-        }
-
-        const [leftImage, rightImage] = [image, images[index + 1]]
-        const rowPercentages = getRowPercentages(leftImage, rightImage)
+        const isLastImage = index + 1 === images.length
+        const rightImage = isLastImage ? undefined : images[index + 1]
 
         return (
-          <Fragment key={leftImage.src}>
+          <div className="mb-4 flex gap-4" key={leftImage.src}>
             <div
-              className={wrapperClassNames}
-              style={{ width: `calc(${rowPercentages.left}% - 0.5rem)` }}
+              className={cn(wrapperClassNames, isLastImage && 'mx-auto')}
+              style={isLastImage ? {} : { flex: getFlexString(leftImage) }}
             >
               <button onClick={() => onImageClick(index)}>
-                <img src={leftImage.src} alt={`leftImage ${leftImage.src}`} />
+                <img
+                  src={leftImage.src}
+                  // TODO: get actual alt text or fallback
+                  alt={`Image ${leftImage.src}`}
+                  className={cn(isLastImage && 'max-h-96')}
+                />
               </button>
               {renderHoverOverlay(leftImage.caption, index)}
             </div>
-            <div
-              className={wrapperClassNames}
-              style={{ width: `calc(${rowPercentages.right}% - 0.5rem)` }}
-            >
-              <button onClick={() => onImageClick(index + 1)}>
-                <img src={rightImage.src} alt={`Image ${rightImage.src}`} />
-              </button>
-              {renderHoverOverlay(rightImage.caption, index + 1)}
-            </div>
-          </Fragment>
+            {rightImage ? (
+              <div
+                className={wrapperClassNames}
+                style={{ flex: getFlexString(rightImage) }}
+              >
+                <button onClick={() => onImageClick(index + 1)}>
+                  <img src={rightImage.src} alt={`Image ${rightImage.src}`} />
+                </button>
+                {renderHoverOverlay(rightImage.caption, index + 1)}
+              </div>
+            ) : null}
+          </div>
         )
       })}
     </div>

--- a/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/image-grid.tsx
@@ -30,7 +30,6 @@ export function ImageGrid({
 }: ImageGridProps) {
   return (
     <div>
-      {}
       {images.map((leftImage, index) => {
         if (index % 2 !== 0) return null
 

--- a/packages/editor/src/plugins/image-gallery/utils/helpers.tsx
+++ b/packages/editor/src/plugins/image-gallery/utils/helpers.tsx
@@ -1,36 +1,16 @@
 import { GridImage } from '../types'
 
-const aspectRatio = (height: number, width: number) => {
-  if (height > width) {
-    return { width: 1, height: height / width }
-  } else {
-    return { height: 1, width: width / height }
-  }
-}
-
 export const createGalleryImage = ({
   src,
   caption,
 }: Omit<GridImage, 'width' | 'height'>): Promise<GridImage> => {
   return new Promise((resolve) => {
-    const mockImage = document.createElement('img')
-    mockImage.src = src
-
-    mockImage.onload = function () {
-      const { width, height } = aspectRatio(mockImage.height, mockImage.width)
+    const img = new Image()
+    img.src = src
+    void img.decode().then(() => {
+      const width = img.naturalWidth
+      const height = img.naturalHeight
       resolve({ src, caption, width, height })
-    }
+    })
   })
-}
-
-export const getRowPercentages = (image1: GridImage, image2: GridImage) => {
-  const commonHeight = Math.min(image1.height, image2.height)
-
-  const leftWidth = (image1.width / image1.height) * commonHeight
-  const rightWidth = (image2.width / image2.height) * commonHeight
-
-  const leftPercentage = (leftWidth / (leftWidth + rightWidth)) * 100
-  const rightPercentage = (rightWidth / (leftWidth + rightWidth)) * 100
-
-  return { left: leftPercentage, right: rightPercentage }
 }


### PR DESCRIPTION
@hejtful this simplifies the js part of the image grid by using rows. 
also integrates the single image case into the normal logic to make it a bit more compact.