### PR TITLE
fix(plugin-gallery): show last drop indicator on the right side

### DIFF
--- a/packages/editor/src/plugins/image-gallery/components/drag-and-drop-overlay.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/drag-and-drop-overlay.tsx
@@ -9,10 +9,12 @@ export function DragAndDropOverlay({
   index,
   onDrop,
   onClick,
+  isLast,
 }: {
   index: number
   onDrop: (dragIndex: number, hoverIndex: number) => void
   onClick?: () => void
+  isLast?: boolean
 }) {
   const ref = useRef<HTMLDivElement>(null)
 
@@ -43,8 +45,9 @@ export function DragAndDropOverlay({
     >
       <div
         className={cn(
-          'absolute -left-2.5 bottom-0 top-0 w-1.5 bg-brand-500 transition-opacity',
-          isHovering ? 'opacity-100' : 'opacity-0'
+          'absolute bottom-0 top-0 w-1.5 bg-brand-500 transition-opacity',
+          isHovering ? 'opacity-100' : 'opacity-0',
+          isLast ? '-right-2.5' : '-left-2.5'
         )}
       ></div>
     </div>

--- a/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/editor-image-grid.tsx
@@ -66,10 +66,9 @@ export function EditorImageGrid({
 
   function handleDrop(dragIndex: number, hoverIndex: number) {
     if (dragIndex === hoverIndex) return
-    state.images.move(
-      dragIndex,
+    const targetIndex =
       state.images.length === hoverIndex ? hoverIndex - 1 : hoverIndex
-    )
+    state.images.move(dragIndex, targetIndex)
   }
 
   return (
@@ -90,6 +89,7 @@ export function EditorImageGrid({
                 onDrop={handleDrop}
                 onClick={() => onImageClick(index)}
                 index={index}
+                isLast={index === images.length - 1}
               />
             )
           })}

--- a/packages/editor/src/plugins/image-gallery/editor.tsx
+++ b/packages/editor/src/plugins/image-gallery/editor.tsx
@@ -18,7 +18,7 @@ import { ModalWithCloseButton } from '@/components/modal-with-close-button'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { showToastNotice } from '@/helper/show-toast-notice'
 
-const MAX_IMAGES = 8
+const MAX_IMAGES = 6
 
 function replaceWithMaxImages(input: string) {
   return input.replace('%max_images%', MAX_IMAGES.toString())


### PR DESCRIPTION
Demo: https://frontend-git-fix-image-gallery-last-drop-indicator-right-serlo.vercel.app/entity/repository/add-revision/277232

(also reduces max. images to 6 – see linear)