### PR TITLE
feat(editor-package): Add migration and some code changes in `storage-format.ts`

### DIFF
--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -15,7 +15,7 @@ import { defaultSerloEditorProps } from './config'
 import { editorData } from './editor-data'
 import { getEditorVersion } from './editor-version'
 import {
-  type StorageFormat,
+  type StorageFormatType,
   createEmptyDocument,
   migrate,
   type EditorVariant,

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -15,7 +15,7 @@ import { defaultSerloEditorProps } from './config'
 import { editorData } from './editor-data'
 import { getEditorVersion } from './editor-version'
 import {
-  type StorageFormatType,
+  type StorageFormat,
   createEmptyDocument,
   migrate,
   type EditorVariant,

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -23,33 +23,48 @@ const EditorVariantType = t.union([
 
 export type EditorVariant = t.TypeOf<typeof EditorVariantType>
 
-// A migration takes an unknown state with `version: number` and returns an unknown state with `version: number`.
-type Migration = (
-  state: unknown & { version: number }
-) => unknown & { version: number }
+const EditorStateType = t.type({
+  plugin: t.string,
+  state: t.unknown,
+})
 
-const StateBeforeMigrationZeroType = t.type({
+type EditorState = t.TypeOf<typeof EditorStateType>
+
+type Migration = (
+  state: OldStorageFormat | StorageFormat
+) => OldStorageFormat | StorageFormat
+
+const OldStorageFormatType_0 = t.type({
   type: t.literal(documentType),
   variant: EditorVariantType,
   version: t.literal(0),
   dateModified: t.string,
-  document: t.type({
-    plugin: t.string,
-    state: t.unknown,
-  }),
+  document: EditorStateType,
 })
 
-type StateBeforeMigrationZeroType = t.TypeOf<
-  typeof StateBeforeMigrationZeroType
->
+type OldStorageFormat_0 = t.TypeOf<typeof OldStorageFormatType_0>
+
+const OldStorageFormatType_1 = t.type({
+  id: t.string,
+  type: t.literal(documentType),
+  variant: EditorVariantType,
+  version: t.literal(1),
+  editorVersion: t.string,
+  dateModified: t.string,
+  document: EditorStateType,
+})
+
+type OldStorageFormat_1 = t.TypeOf<typeof OldStorageFormatType_1>
+
+// Add new outdated storage formats here ...
 
 // Usage: Do not change existing migrations. Only if you are sure that they never ran in any system where content needs to be supported long term. Instead, create a new migration. It needs to be at the end of the array. The last migration should return `StorageFormat`
 const migrations: Migration[] = [
   // Migration 0: Add editorVersion & id
   (state) => {
-    if (!StateBeforeMigrationZeroType.is(state))
+    if (!OldStorageFormatType_0.is(state))
       throw new Error(
-        `Unexpected type during migration. Expected ${JSON.stringify(StateBeforeMigrationZeroType)} but got ${JSON.stringify(state)}`
+        `Unexpected type during migration. Expected ${JSON.stringify(OldStorageFormatType_0)} but got ${JSON.stringify(state)}`
       )
 
     return {
@@ -61,18 +76,9 @@ const migrations: Migration[] = [
 
   // Migration 1: Add domainOrigin
   (state): StorageFormat => {
-    const expectedType = t.type({
-      id: t.string,
-      type: t.literal(documentType),
-      variant: EditorVariantType,
-      version: t.number,
-      editorVersion: t.string,
-      dateModified: t.string,
-      document: DocumentType,
-    })
-    if (!expectedType.is(state))
+    if (!OldStorageFormatType_1.is(state))
       throw new Error(
-        `Unexpected type during migration. Expected ${JSON.stringify(expectedType)} but got ${JSON.stringify(state)}`
+        `Unexpected type during migration. Expected ${JSON.stringify(OldStorageFormatType_1)} but got ${JSON.stringify(state)}`
       )
 
     return {
@@ -113,6 +119,8 @@ function deepCopy(obj: unknown) {
   return JSON.parse(JSON.stringify(obj)) as unknown
 }
 
+type OldStorageFormat = OldStorageFormat_0 | OldStorageFormat_1
+
 /** Migrates outdated states to the most recent `StorageFormat`. */
 export function migrate(
   stateBeforeMigration: unknown,
@@ -121,25 +129,34 @@ export function migrate(
   migratedState: StorageFormat
   stateChanged: boolean
 } {
+  if (
+    !OldStorageFormatType_0.is(stateBeforeMigration) &&
+    !OldStorageFormatType_1.is(stateBeforeMigration) &&
+    !StorageFormatType.is(stateBeforeMigration) &&
+    !EditorStateType.is(stateBeforeMigration)
+  ) {
+    throw new Error(
+      `Unknown state type when trying to run migrations. Got ${JSON.stringify(stateBeforeMigration)}`
+    )
+  }
+
   let stateChanged = false
 
   // If the state is in the old format ({ plugin: string, state: unknown }) & missing `version` property -> Add metadata (including `version`) so that type matches what should be present before running migrations[0]
   let migratingState = prepareStateForMigrations()
   function prepareStateForMigrations() {
-    if (!t.type({ version: t.number }).is(stateBeforeMigration)) {
+    if (EditorStateType.is(stateBeforeMigration)) {
       stateChanged = true
-      const statePlusMetadata: StateBeforeMigrationZeroType = {
+      const statePlusMetadata: OldStorageFormat_0 = {
         type: documentType,
         variant,
         version: 0,
         dateModified: getCurrentDatetime(),
-        document: deepCopy(stateBeforeMigration) as t.TypeOf<
-          typeof DocumentType
-        >,
+        document: deepCopy(stateBeforeMigration) as EditorState,
       }
       return statePlusMetadata
     } else {
-      return deepCopy(stateBeforeMigration) as { version: number }
+      return deepCopy(stateBeforeMigration) as StorageFormat | OldStorageFormat
     }
   }
 
@@ -164,11 +181,6 @@ export function migrate(
   return { migratedState: migratingState, stateChanged }
 }
 
-const DocumentType = t.type({
-  plugin: t.string,
-  state: t.unknown,
-})
-
 const StorageFormatType = t.type({
   // Constant values (set at creation)
   id: t.string, // https://dini-ag-kim.github.io/amb/20231019/#id
@@ -180,7 +192,7 @@ const StorageFormatType = t.type({
   version: t.literal(currentVersion), // Index of the next migration to apply
   editorVersion: t.string,
   dateModified: t.string,
-  document: DocumentType,
+  document: EditorStateType,
 })
 
 export type StorageFormat = t.TypeOf<typeof StorageFormatType>

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -12,13 +12,8 @@ const documentType = 'https://serlo.org/editor'
 type Migration = (state: unknown, variant: EditorVariant) => StorageFormat
 
 const migrations: Migration[] = [
-  // Migration 1: Add editorVersion, domainOrigin and id
+  // Migration 0: Add editorVersion, domainOrigin and id
   (state): StorageFormat => {
-    // We already have the right format, we can skip this migration.
-    if (StorageFormat.is(state)) {
-      return state
-    }
-
     const expectedType = t.type({
       type: t.literal(documentType),
       variant: EditorVariantType,


### PR DESCRIPTION
# Changes
- Separate migration for `domainOrigin` & made it mandatory. Reason: Before, we changed an existing migration and added it optionally. But this might cause this property to exist in some migrated content but not in others. I feel like it is easier for the devs if we can look at the migration code and know relatively quickly what variants of types can be out there. So, I prefer mandatory properties and making sure that after all migrations ran, they are there for sure. 
- Added code comments and did some renaming to hopefully improve clarity

# TODO 
- [x] Test 