### PR TITLE
refactor(ci): Change editor publish yml to new output syntax to remove warning

### DIFF
--- a/.github/workflows/editor.yaml
+++ b/.github/workflows/editor.yaml
@@ -25,9 +25,9 @@ jobs:
         run: |
           CURRENT_VERSION=$(node -p "require('./packages/editor/package.json').version")
           if npm view @serlo/editor@$CURRENT_VERSION > /dev/null 2>&1; then
-            echo "::set-output name=already_published::true"
+            echo "already_published=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=already_published::false"
+            echo "already_published=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish to npm


### PR DESCRIPTION
`set-output` was deprecated a while ago. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR changes it to the new syntax. I [tested it out for the web component and it worked great](https://github.com/serlo/frontend/actions/runs/10808989680/job/29983145085). 


More docs
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#environment-files