### PR TITLE
wip: migrate() should accept newer versions of a document

### DIFF
--- a/packages/editor/__tests__/migration-state.ts
+++ b/packages/editor/__tests__/migration-state.ts
@@ -1,4 +1,4 @@
-import { migrate } from '@editor/package/storage-format'
+import { migrate, createEmptyDocument } from '@editor/package/storage-format'
 
 test('A document not being in the storage format can be migrated', () => {
   const { stateChanged, migratedState } = migrate({ plugin: 'rows' }, 'unknown')
@@ -7,5 +7,17 @@ test('A document not being in the storage format can be migrated', () => {
   expect(migratedState).toMatchObject({
     type: 'https://serlo.org/editor',
     document: { plugin: 'rows' },
+  })
+})
+
+test('A document in a more recent storage format is not changed', () => {
+  const moreRecentDocument = {
+    ...createEmptyDocument('unknown'),
+    version: 10000,
+  }
+
+  expect(migrate(moreRecentDocument, 'unknown')).toEqual({
+    stateChanged: false,
+    migratedState: moreRecentDocument,
   })
 })


### PR DESCRIPTION
See https://linear.app/serlo/issue/PE-151/bug-migration-algorithm-does-not-accept-newer-versions