### PR TITLE
feat(plugin-exercise): rework interactive plugin add menu

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1093,13 +1093,6 @@ export const loggedInData = {
           confirmDelete: 'Are you sure you want to delete this course page?',
         },
         exercise: {
-          scMcExercise: 'Choice Exercise',
-          inputExercise: 'Input Exercise',
-          textAreaExercise: 'Text Box Exercise',
-          dropzoneImage: 'Image Dropzones Exercise',
-          blanksExercise: 'Fill In The Blanks Exercise',
-          blanksExerciseDragAndDrop: 'Fill In The Blanks Exercise (Drag&Drop)',
-          h5p: 'H5p Exercise',
           addOptionalInteractiveEx: 'Add an optional interactive exercise:',
           changeInteractive: 'Change interactive element',
           removeInteractive: 'Remove interactive element',

--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -164,12 +164,6 @@ export function createPlugins({
       icon: <IconMultimedia />,
     },
     {
-      type: EditorPluginType.DropzoneImage,
-      plugin: createDropzoneImagePlugin(),
-      visibleInSuggestions: false,
-      icon: <IconDropzones />,
-    },
-    {
       type: EditorPluginType.Spoiler,
       plugin: createSpoilerPlugin(plugins),
       visibleInSuggestions: true,
@@ -271,17 +265,16 @@ export function createPlugins({
       plugin: solutionPlugin,
       icon: <IconPencil />,
     },
-    { type: EditorPluginType.H5p, plugin: H5pPlugin, icon: <IconH5p /> },
-    {
-      type: EditorPluginType.InputExercise,
-      plugin: createInputExercisePlugin(),
-      icon: <IconTextArea />,
-    },
     {
       type: EditorPluginType.ScMcExercise,
       plugin: createScMcExercisePlugin(),
       icon: <IconScMcExercise />,
       visibleInSuggestions: true,
+    },
+    {
+      type: EditorPluginType.InputExercise,
+      plugin: createInputExercisePlugin(),
+      icon: <IconTextArea />,
     },
     {
       type: EditorPluginType.BlanksExercise,
@@ -293,6 +286,13 @@ export function createPlugins({
       plugin: createBlanksExercisePlugin({ defaultMode: 'drag-and-drop' }),
       icon: <IconBlanksDragAndDrop />,
     },
+    {
+      type: EditorPluginType.DropzoneImage,
+      plugin: createDropzoneImagePlugin(),
+      visibleInSuggestions: false,
+      icon: <IconDropzones />,
+    },
+    { type: EditorPluginType.H5p, plugin: H5pPlugin, icon: <IconH5p /> },
 
     // Special plugins, never visible in suggestions
     // ===================================================

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -134,11 +134,6 @@ export function createBasicPlugins(
       visibleInSuggestions: true,
     },
     {
-      type: EditorPluginType.TextAreaExercise,
-      plugin: textAreaExercisePlugin,
-      icon: <IconFallback />,
-    },
-    {
       type: EditorPluginType.Solution,
       plugin: solutionPlugin,
       icon: <IconPencil />,
@@ -168,6 +163,11 @@ export function createBasicPlugins(
       plugin: createDropzoneImagePlugin(),
       visibleInSuggestions: false,
       icon: <IconDropzones />,
+    },
+    {
+      type: EditorPluginType.TextAreaExercise,
+      plugin: textAreaExercisePlugin,
+      icon: <IconFallback />,
     },
 
     // Special plugins, never visible in suggestions

--- a/packages/editor/src/plugin/helpers/editor-plugins.tsx
+++ b/packages/editor/src/plugin/helpers/editor-plugins.tsx
@@ -37,5 +37,11 @@ export const editorPlugins = (function () {
     return (contextPlugin?.plugin as EditorPlugin) ?? null
   }
 
-  return { init, getAllWithData, getByType }
+  function isSupported(pluginType: string) {
+    const plugins = getAllWithData()
+
+    return !!plugins.find((plugin) => plugin.type === pluginType)
+  }
+
+  return { init, getAllWithData, getByType, isSupported }
 })()

--- a/packages/editor/src/plugins/blanks-exercise/editor.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/editor.tsx
@@ -40,7 +40,9 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
   const { text: childPlugin, mode, extraDraggableAnswers } = state
   const [previewActive, setPreviewActive] = useState(false)
 
-  const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
+  const pluginStrings = useEditorStrings().plugins
+  const blanksExerciseStrings = pluginStrings.blanksExercise
+  const dragAndDropTitle = pluginStrings.blanksExerciseDragAndDrop.title
 
   const isChildPluginFocused = useAppSelector((storeState) =>
     selectIsFocused(storeState, childPlugin.id)
@@ -90,7 +92,9 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
           `)}
           data-qa="plugin-blanks-exercise-parent-button"
         >
-          {blanksExerciseStrings.title}
+          {mode.value === 'typing'
+            ? blanksExerciseStrings.title
+            : dragAndDropTitle}
         </button>
       )}
 

--- a/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
@@ -23,10 +23,14 @@ export const BlanksExerciseToolbar = ({
 }) => {
   const pluginsStrings = useEditorStrings().plugins
   const blanksExerciseStrings = pluginsStrings.blanksExercise
+  const pluginType =
+    state.mode.value === 'typing'
+      ? EditorPluginType.BlanksExercise
+      : EditorPluginType.BlanksExerciseDragAndDrop
 
   return (
     <PluginToolbar
-      pluginType={EditorPluginType.BlanksExercise}
+      pluginType={pluginType}
       className="top-[-33px]"
       pluginSettings={
         <>

--- a/packages/editor/src/plugins/exercise/components/interactive-exercises-selection.tsx
+++ b/packages/editor/src/plugins/exercise/components/interactive-exercises-selection.tsx
@@ -1,0 +1,57 @@
+import IconFallback from '@editor/editor-ui/assets/plugin-icons/icon-fallback.svg'
+import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
+import type { PluginMenuItemType } from '@editor/plugins/rows/contexts/plugin-menu/types'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+
+import { type ExerciseProps } from '..'
+import { type InteractivePluginType } from '../interactive-plugin-types'
+import { useEditorStrings } from '@/contexts/logged-in-data-context'
+
+export function InteractiveExercisesSelection({
+  interactivePluginOptions,
+  interactive,
+}: {
+  interactivePluginOptions: PluginMenuItemType[]
+  interactive: ExerciseProps['state']['interactive']
+}) {
+  const templateStrings = useEditorStrings().templatePlugins
+  const exTemplateStrings = templateStrings.exercise
+
+  function getTooltipClass(index: number) {
+    const isLast = index === interactivePluginOptions.length - 1
+    return index === 0 ? 'left-0' : isLast ? '-left-24' : 'right-0'
+  }
+
+  function handleOnClick(pluginType: EditorPluginType) {
+    if (interactive.defined) return
+    const plugin = pluginType as InteractivePluginType
+    interactive.create({ plugin })
+  }
+
+  return (
+    <>
+      <p className="mb-2 text-gray-400">
+        {exTemplateStrings.addOptionalInteractiveEx}
+      </p>
+      <div className="flex items-start">
+        {interactivePluginOptions.map(
+          ({ pluginType, title, icon, description }, index) => (
+            <button
+              key={title}
+              data-qa={`add-exercise-${pluginType}`}
+              onClick={() => handleOnClick(pluginType)}
+              className="serlo-tooltip-trigger w-full rounded-md p-1 hover:shadow-xl focus:shadow-xl"
+            >
+              <EditorTooltip
+                className={getTooltipClass(index)}
+                text={description}
+              />
+              {icon || <IconFallback />}
+              <b className="mt-2 block text-sm">{title}</b>
+            </button>
+          )
+        )}
+      </div>
+    </>
+  )
+}

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -1,30 +1,22 @@
 import { AddButton } from '@editor/editor-ui'
+import IconFallback from '@editor/editor-ui/assets/plugin-icons/icon-fallback.svg'
 import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
-import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
 import { useContext } from 'react'
 
-import type { ExerciseProps } from '.'
+import { type ExerciseProps } from '.'
+import {
+  type InteractivePluginType,
+  interactivePluginTypes,
+} from './interactive-plugin-types'
 import { ExerciseToolbar } from './toolbar/toolbar'
+import { createOption } from '../rows/utils/plugin-menu'
 import { SerloLicenseChooser } from '../solution/serlo-license-chooser'
 import { IsSerloContext } from '@/serlo-editor-integration/context/is-serlo-context'
-
-const allInteractiveExerciseTypes = [
-  EditorPluginType.ScMcExercise,
-  EditorPluginType.InputExercise,
-  EditorPluginType.H5p,
-  EditorPluginType.TextAreaExercise,
-  EditorPluginType.BlanksExercise,
-  EditorPluginType.BlanksExerciseDragAndDrop,
-  EditorPluginType.DropzoneImage,
-] as const
-
-export type InteractiveExerciseType =
-  (typeof allInteractiveExerciseTypes)[number]
 
 export function ExerciseEditor(props: ExerciseProps) {
   const { state, focused } = props
@@ -36,9 +28,13 @@ export function ExerciseEditor(props: ExerciseProps) {
     hideInteractiveInitially,
   } = state
   const isSerlo = useContext(IsSerloContext) // only on serlo
+  const editorStrings = useEditorStrings()
 
-  const interactiveExerciseTypes = allInteractiveExerciseTypes.filter((type) =>
+  const interactiveExerciseTypes = interactivePluginTypes.filter((type) =>
     editorPlugins.getAllWithData().some((plugin) => plugin.type === type)
+  )
+  const interactiveExerciseMenuItems = interactiveExerciseTypes.map((type) =>
+    createOption(type, editorStrings.plugins)
   )
 
   const templateStrings = useEditorStrings().templatePlugins
@@ -97,19 +93,36 @@ export function ExerciseEditor(props: ExerciseProps) {
             <p className="mb-2 text-gray-400">
               {exTemplateStrings.addOptionalInteractiveEx}
             </p>
-            <div className="-ml-1.5 flex">
-              {interactiveExerciseTypes.map((type) => {
-                return (
-                  <AddButton
-                    key={type}
-                    onClick={() => interactive.create({ plugin: type })}
-                    secondary
-                    dataQa={`add-exercise-${type}`}
-                  >
-                    {exTemplateStrings[type]}
-                  </AddButton>
-                )
-              })}
+            <div className="flex items-start">
+              {interactiveExerciseMenuItems.map(
+                ({ pluginType, title, icon, description }, index) => {
+                  const tooltipClassName =
+                    index === 0
+                      ? 'left-0'
+                      : index + 1 < interactiveExerciseMenuItems.length
+                        ? '-left-24'
+                        : 'right-0'
+                  return (
+                    <button
+                      key={title}
+                      data-qa={`add-exercise-${pluginType}`}
+                      onClick={() =>
+                        interactive.create({
+                          plugin: pluginType as InteractivePluginType,
+                        })
+                      }
+                      className="serlo-tooltip-trigger w-full rounded-md p-1 hover:shadow-xl focus:shadow-xl"
+                    >
+                      <EditorTooltip
+                        className={tooltipClassName}
+                        text={description}
+                      />
+                      {icon || <IconFallback />}
+                      <b className="mt-2 block text-sm">{title}</b>
+                    </button>
+                  )
+                }
+              )}
             </div>
           </>
         )}

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -1,5 +1,4 @@
 import { AddButton } from '@editor/editor-ui'
-import IconFallback from '@editor/editor-ui/assets/plugin-icons/icon-fallback.svg'
 import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
@@ -9,10 +8,8 @@ import { cn } from '@serlo/frontend/src/helper/cn'
 import { useContext } from 'react'
 
 import { type ExerciseProps } from '.'
-import {
-  type InteractivePluginType,
-  interactivePluginTypes,
-} from './interactive-plugin-types'
+import { InteractiveExercisesSelection } from './components/interactive-exercises-selection'
+import { interactivePluginTypes } from './interactive-plugin-types'
 import { ExerciseToolbar } from './toolbar/toolbar'
 import { createOption } from '../rows/utils/plugin-menu'
 import { SerloLicenseChooser } from '../solution/serlo-license-chooser'
@@ -29,14 +26,12 @@ export function ExerciseEditor(props: ExerciseProps) {
   } = state
   const isSerlo = useContext(IsSerloContext) // only on serlo
   const editorStrings = useEditorStrings()
+  const exTemplateStrings = editorStrings.templatePlugins.exercise
+  const exPluginStrings = editorStrings.plugins.exercise
 
   const interactivePluginOptions = interactivePluginTypes
     .filter((type) => editorPlugins.isSupported(type))
     .map((type) => createOption(type, editorStrings.plugins))
-
-  const templateStrings = useEditorStrings().templatePlugins
-  const exTemplateStrings = templateStrings.exercise
-  const exPluginStrings = useEditorStrings().plugins.exercise
 
   return (
     <div
@@ -86,42 +81,10 @@ export function ExerciseEditor(props: ExerciseProps) {
             ) : null}
           </>
         ) : (
-          <>
-            <p className="mb-2 text-gray-400">
-              {exTemplateStrings.addOptionalInteractiveEx}
-            </p>
-            <div className="flex items-start">
-              {interactivePluginOptions.map(
-                ({ pluginType, title, icon, description }, index, arr) => {
-                  const tooltipClassName =
-                    index === 0
-                      ? 'left-0'
-                      : index + 1 < arr.length
-                        ? '-left-24'
-                        : 'right-0'
-                  return (
-                    <button
-                      key={title}
-                      data-qa={`add-exercise-${pluginType}`}
-                      onClick={() =>
-                        interactive.create({
-                          plugin: pluginType as InteractivePluginType,
-                        })
-                      }
-                      className="serlo-tooltip-trigger w-full rounded-md p-1 hover:shadow-xl focus:shadow-xl"
-                    >
-                      <EditorTooltip
-                        className={tooltipClassName}
-                        text={description}
-                      />
-                      {icon || <IconFallback />}
-                      <b className="mt-2 block text-sm">{title}</b>
-                    </button>
-                  )
-                }
-              )}
-            </div>
-          </>
+          <InteractiveExercisesSelection
+            interactivePluginOptions={interactivePluginOptions}
+            interactive={interactive}
+          />
         )}
         {solution.defined ? (
           <div className="-ml-side mt-block">

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -30,12 +30,9 @@ export function ExerciseEditor(props: ExerciseProps) {
   const isSerlo = useContext(IsSerloContext) // only on serlo
   const editorStrings = useEditorStrings()
 
-  const interactiveExerciseTypes = interactivePluginTypes.filter((type) =>
-    editorPlugins.getAllWithData().some((plugin) => plugin.type === type)
-  )
-  const interactiveExerciseMenuItems = interactiveExerciseTypes.map((type) =>
-    createOption(type, editorStrings.plugins)
-  )
+  const interactivePluginOptions = interactivePluginTypes
+    .filter((type) => editorPlugins.isSupported(type))
+    .map((type) => createOption(type, editorStrings.plugins))
 
   const templateStrings = useEditorStrings().templatePlugins
   const exTemplateStrings = templateStrings.exercise
@@ -58,7 +55,7 @@ export function ExerciseEditor(props: ExerciseProps) {
       {focused ? (
         <ExerciseToolbar
           {...props}
-          interactiveExerciseTypes={interactiveExerciseTypes}
+          interactivePluginOptions={interactivePluginOptions}
         />
       ) : (
         <button
@@ -94,12 +91,12 @@ export function ExerciseEditor(props: ExerciseProps) {
               {exTemplateStrings.addOptionalInteractiveEx}
             </p>
             <div className="flex items-start">
-              {interactiveExerciseMenuItems.map(
-                ({ pluginType, title, icon, description }, index) => {
+              {interactivePluginOptions.map(
+                ({ pluginType, title, icon, description }, index, arr) => {
                   const tooltipClassName =
                     index === 0
                       ? 'left-0'
-                      : index + 1 < interactiveExerciseMenuItems.length
+                      : index + 1 < arr.length
                         ? '-left-24'
                         : 'right-0'
                   return (

--- a/packages/editor/src/plugins/exercise/index.tsx
+++ b/packages/editor/src/plugins/exercise/index.tsx
@@ -10,19 +10,12 @@ import {
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 import { ExerciseEditor } from './editor'
+import { InteractivePluginType } from './interactive-plugin-types'
 
 const exerciseState = object({
   content: child({ plugin: EditorPluginType.Rows }),
   interactive: optional(
-    child<
-      | EditorPluginType.ScMcExercise
-      | EditorPluginType.InputExercise
-      | EditorPluginType.TextAreaExercise
-      | EditorPluginType.H5p
-      | EditorPluginType.BlanksExercise
-      | EditorPluginType.BlanksExerciseDragAndDrop
-      | EditorPluginType.DropzoneImage
-    >({
+    child<InteractivePluginType>({
       plugin: EditorPluginType.ScMcExercise,
     })
   ),

--- a/packages/editor/src/plugins/exercise/index.tsx
+++ b/packages/editor/src/plugins/exercise/index.tsx
@@ -12,8 +12,25 @@ import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { ExerciseEditor } from './editor'
 import { InteractivePluginType } from './interactive-plugin-types'
 
+const allowedPlugins = [
+  EditorPluginType.Text,
+  EditorPluginType.Image,
+  EditorPluginType.ImageGallery,
+  EditorPluginType.Multimedia,
+  EditorPluginType.Spoiler,
+  EditorPluginType.Box,
+  EditorPluginType.SerloTable,
+  EditorPluginType.Injection,
+  EditorPluginType.Equations,
+  EditorPluginType.Geogebra,
+  EditorPluginType.Highlight,
+  EditorPluginType.Video,
+  EditorPluginType.Audio,
+  EditorPluginType.EdusharingAsset,
+]
+
 const exerciseState = object({
-  content: child({ plugin: EditorPluginType.Rows }),
+  content: child({ plugin: EditorPluginType.Rows, config: { allowedPlugins } }),
   interactive: optional(
     child<InteractivePluginType>({
       plugin: EditorPluginType.ScMcExercise,

--- a/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
+++ b/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
@@ -1,13 +1,13 @@
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 export const interactivePluginTypes = [
-  EditorPluginType.TextAreaExercise,
   EditorPluginType.ScMcExercise,
-  EditorPluginType.H5p,
+  EditorPluginType.InputExercise,
   EditorPluginType.BlanksExercise,
   EditorPluginType.BlanksExerciseDragAndDrop,
-  EditorPluginType.InputExercise,
   EditorPluginType.DropzoneImage,
+  EditorPluginType.TextAreaExercise,
+  EditorPluginType.H5p,
 ] as const
 
 export type InteractivePluginType = (typeof interactivePluginTypes)[number]

--- a/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
+++ b/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
@@ -1,0 +1,13 @@
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
+
+export const interactivePluginTypes = [
+  EditorPluginType.TextAreaExercise,
+  EditorPluginType.ScMcExercise,
+  EditorPluginType.H5p,
+  EditorPluginType.BlanksExercise,
+  EditorPluginType.BlanksExerciseDragAndDrop,
+  EditorPluginType.InputExercise,
+  EditorPluginType.DropzoneImage,
+] as const
+
+export type InteractivePluginType = (typeof interactivePluginTypes)[number]

--- a/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
+++ b/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
@@ -1,6 +1,7 @@
 import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { DropdownButton } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/dropdown-button'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
+import { PluginMenuItemType } from '@editor/plugins/rows/contexts/plugin-menu/types'
 import { selectDocument, store } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -12,9 +13,9 @@ import { InteractivePluginType } from '../interactive-plugin-types'
 export const ExerciseToolbar = ({
   id,
   state,
-  interactiveExerciseTypes,
+  interactivePluginOptions,
 }: ExerciseProps & {
-  interactiveExerciseTypes: InteractivePluginType[]
+  interactivePluginOptions: PluginMenuItemType[]
 }) => {
   const { interactive } = state
   const exTemplateStrings = useEditorStrings().templatePlugins.exercise
@@ -32,9 +33,9 @@ export const ExerciseToolbar = ({
         if (interactive.defined)
           interactive.replace(value as InteractivePluginType)
       }}
-      options={interactiveExerciseTypes.map((type) => ({
-        value: type,
-        text: exTemplateStrings[type],
+      options={interactivePluginOptions.map(({ pluginType, title }) => ({
+        value: pluginType,
+        text: title,
       }))}
     />
   ) : undefined

--- a/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
+++ b/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
@@ -7,14 +7,14 @@ import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 
 import type { ExerciseProps } from '..'
-import type { InteractiveExerciseType } from '../editor'
+import { InteractivePluginType } from '../interactive-plugin-types'
 
 export const ExerciseToolbar = ({
   id,
   state,
   interactiveExerciseTypes,
 }: ExerciseProps & {
-  interactiveExerciseTypes: InteractiveExerciseType[]
+  interactiveExerciseTypes: InteractivePluginType[]
 }) => {
   const { interactive } = state
   const exTemplateStrings = useEditorStrings().templatePlugins.exercise
@@ -30,7 +30,7 @@ export const ExerciseToolbar = ({
       value={currentlySelected ?? ''}
       changeValue={(value) => {
         if (interactive.defined)
-          interactive.replace(value as InteractiveExerciseType)
+          interactive.replace(value as InteractivePluginType)
       }}
       options={interactiveExerciseTypes.map((type) => ({
         value: type,

--- a/packages/editor/src/plugins/rows/components/plugin-menu-items.tsx
+++ b/packages/editor/src/plugins/rows/components/plugin-menu-items.tsx
@@ -60,7 +60,7 @@ export function PluginMenuItems({
       const tooltipPosition = getTooltipPosition(index)
       const tooltipClassName = tooltipPosition
         ? tooltipPosition === 'left'
-          ? '-right-0 [&>span]:!min-w-80'
+          ? 'right-0 [&>span]:!min-w-80'
           : ''
         : '-left-24'
 

--- a/packages/editor/src/plugins/rows/utils/plugin-menu.ts
+++ b/packages/editor/src/plugins/rows/utils/plugin-menu.ts
@@ -1,4 +1,8 @@
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
+import {
+  type InteractivePluginType,
+  interactivePluginTypes,
+} from '@editor/plugins/exercise/interactive-plugin-types'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 import type { PluginMenuItemType } from '../contexts/plugin-menu/types'
@@ -54,16 +58,6 @@ export function filterOptions(option: PluginMenuItemType[], text: string) {
   )
 }
 
-const interactivePluginTypes = new Set([
-  EditorPluginType.TextAreaExercise,
-  EditorPluginType.ScMcExercise,
-  EditorPluginType.H5p,
-  EditorPluginType.BlanksExercise,
-  EditorPluginType.BlanksExerciseDragAndDrop,
-  EditorPluginType.InputExercise,
-  EditorPluginType.DropzoneImage,
-])
-
 export function isInteractivePluginType(pluginType: EditorPluginType) {
-  return interactivePluginTypes.has(pluginType)
+  return interactivePluginTypes.includes(pluginType as InteractivePluginType)
 }

--- a/packages/editor/src/plugins/rows/utils/plugin-menu.ts
+++ b/packages/editor/src/plugins/rows/utils/plugin-menu.ts
@@ -61,7 +61,6 @@ const interactivePluginTypes = new Set([
   EditorPluginType.BlanksExercise,
   EditorPluginType.BlanksExerciseDragAndDrop,
   EditorPluginType.InputExercise,
-  EditorPluginType.Solution,
   EditorPluginType.DropzoneImage,
 ])
 

--- a/packages/editor/src/plugins/spoiler/index.ts
+++ b/packages/editor/src/plugins/spoiler/index.ts
@@ -47,7 +47,6 @@ const possiblePlugins: EditorPluginType[] = [
   EditorPluginType.EdusharingAsset,
 
   EditorPluginType.DropzoneImage,
-  EditorPluginType.Solution,
   EditorPluginType.H5p,
   EditorPluginType.InputExercise,
   EditorPluginType.ScMcExercise,


### PR DESCRIPTION
… also small refactoring. Now there is only one list of interactive plugins.

PE-133

[Demo](https://frontend-git-pe-133-redesign-selection-of-interact-177c4f-serlo.vercel.app/___editor_preview?state=%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"exercise"%2C"state"%3A%7B"content"%3A%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"8706596c-53ac-4b9c-ae4c-7fad7418a62a"%7D%5D%2C"id"%3A"aaf993ac-dc1b-4f5c-b086-b1fd28bae31a"%7D%7D%2C"id"%3A"cc505c10-5ba8-4953-94cc-912ad961e636"%7D%5D%7D)