### PR TITLE
fix(plugin-exercise): don't allow exercise plugins in task

### DIFF
--- a/apps/web/src/serlo-editor-integration/create-plugins.tsx
+++ b/apps/web/src/serlo-editor-integration/create-plugins.tsx
@@ -164,12 +164,6 @@ export function createPlugins({
       icon: <IconMultimedia />,
     },
     {
-      type: EditorPluginType.DropzoneImage,
-      plugin: createDropzoneImagePlugin(),
-      visibleInSuggestions: false,
-      icon: <IconDropzones />,
-    },
-    {
       type: EditorPluginType.Spoiler,
       plugin: createSpoilerPlugin(plugins),
       visibleInSuggestions: true,
@@ -271,17 +265,16 @@ export function createPlugins({
       plugin: solutionPlugin,
       icon: <IconPencil />,
     },
-    { type: EditorPluginType.H5p, plugin: H5pPlugin, icon: <IconH5p /> },
-    {
-      type: EditorPluginType.InputExercise,
-      plugin: createInputExercisePlugin(),
-      icon: <IconTextArea />,
-    },
     {
       type: EditorPluginType.ScMcExercise,
       plugin: createScMcExercisePlugin(),
       icon: <IconScMcExercise />,
       visibleInSuggestions: true,
+    },
+    {
+      type: EditorPluginType.InputExercise,
+      plugin: createInputExercisePlugin(),
+      icon: <IconTextArea />,
     },
     {
       type: EditorPluginType.BlanksExercise,
@@ -293,6 +286,13 @@ export function createPlugins({
       plugin: createBlanksExercisePlugin({ defaultMode: 'drag-and-drop' }),
       icon: <IconBlanksDragAndDrop />,
     },
+    {
+      type: EditorPluginType.DropzoneImage,
+      plugin: createDropzoneImagePlugin(),
+      visibleInSuggestions: false,
+      icon: <IconDropzones />,
+    },
+    { type: EditorPluginType.H5p, plugin: H5pPlugin, icon: <IconH5p /> },
 
     // Special plugins, never visible in suggestions
     // ===================================================

--- a/packages/editor/src/editor-integration/create-basic-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-basic-plugins.tsx
@@ -134,11 +134,6 @@ export function createBasicPlugins(
       visibleInSuggestions: true,
     },
     {
-      type: EditorPluginType.TextAreaExercise,
-      plugin: textAreaExercisePlugin,
-      icon: <IconFallback />,
-    },
-    {
       type: EditorPluginType.Solution,
       plugin: solutionPlugin,
       icon: <IconPencil />,
@@ -168,6 +163,11 @@ export function createBasicPlugins(
       plugin: createDropzoneImagePlugin(),
       visibleInSuggestions: false,
       icon: <IconDropzones />,
+    },
+    {
+      type: EditorPluginType.TextAreaExercise,
+      plugin: textAreaExercisePlugin,
+      icon: <IconFallback />,
     },
 
     // Special plugins, never visible in suggestions

--- a/packages/editor/src/plugins/exercise/index.tsx
+++ b/packages/editor/src/plugins/exercise/index.tsx
@@ -12,8 +12,25 @@ import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { ExerciseEditor } from './editor'
 import { InteractivePluginType } from './interactive-plugin-types'
 
+const allowedPlugins = [
+  EditorPluginType.Text,
+  EditorPluginType.Image,
+  EditorPluginType.ImageGallery,
+  EditorPluginType.Multimedia,
+  EditorPluginType.Spoiler,
+  EditorPluginType.Box,
+  EditorPluginType.SerloTable,
+  EditorPluginType.Injection,
+  EditorPluginType.Equations,
+  EditorPluginType.Geogebra,
+  EditorPluginType.Highlight,
+  EditorPluginType.Video,
+  EditorPluginType.Audio,
+  EditorPluginType.EdusharingAsset,
+]
+
 const exerciseState = object({
-  content: child({ plugin: EditorPluginType.Rows }),
+  content: child({ plugin: EditorPluginType.Rows, config: { allowedPlugins } }),
   interactive: optional(
     child<InteractivePluginType>({
       plugin: EditorPluginType.ScMcExercise,

--- a/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
+++ b/packages/editor/src/plugins/exercise/interactive-plugin-types.ts
@@ -1,13 +1,13 @@
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 export const interactivePluginTypes = [
-  EditorPluginType.TextAreaExercise,
   EditorPluginType.ScMcExercise,
-  EditorPluginType.H5p,
+  EditorPluginType.InputExercise,
   EditorPluginType.BlanksExercise,
   EditorPluginType.BlanksExerciseDragAndDrop,
-  EditorPluginType.InputExercise,
   EditorPluginType.DropzoneImage,
+  EditorPluginType.TextAreaExercise,
+  EditorPluginType.H5p,
 ] as const
 
 export type InteractivePluginType = (typeof interactivePluginTypes)[number]

--- a/packages/editor/src/plugins/spoiler/index.ts
+++ b/packages/editor/src/plugins/spoiler/index.ts
@@ -47,7 +47,6 @@ const possiblePlugins: EditorPluginType[] = [
   EditorPluginType.EdusharingAsset,
 
   EditorPluginType.DropzoneImage,
-  EditorPluginType.Solution,
   EditorPluginType.H5p,
   EditorPluginType.InputExercise,
   EditorPluginType.ScMcExercise,


### PR DESCRIPTION
(implemented with whilelist for simplicity)

PE-132

[Demo](https://frontend-git-pe-132-restrictions-for-plugin-select-3b0e3a-serlo.vercel.app/___editor_preview?state=%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"exercise"%2C"state"%3A%7B"content"%3A%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"8706596c-53ac-4b9c-ae4c-7fad7418a62a"%7D%5D%2C"id"%3A"aaf993ac-dc1b-4f5c-b086-b1fd28bae31a"%7D%7D%2C"id"%3A"cc505c10-5ba8-4953-94cc-912ad961e636"%7D%5D%7D)
