### PR TITLE
refactor(plugin-exercise): use plugin titles, remove extra strings

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1093,13 +1093,6 @@ export const loggedInData = {
           confirmDelete: 'Are you sure you want to delete this course page?',
         },
         exercise: {
-          scMcExercise: 'Choice Exercise',
-          inputExercise: 'Input Exercise',
-          textAreaExercise: 'Text Box Exercise',
-          dropzoneImage: 'Image Dropzones Exercise',
-          blanksExercise: 'Fill In The Blanks Exercise',
-          blanksExerciseDragAndDrop: 'Fill In The Blanks Exercise (Drag&Drop)',
-          h5p: 'H5p Exercise',
           addOptionalInteractiveEx: 'Add an optional interactive exercise:',
           changeInteractive: 'Change interactive element',
           removeInteractive: 'Remove interactive element',

--- a/packages/editor/src/plugin/helpers/editor-plugins.tsx
+++ b/packages/editor/src/plugin/helpers/editor-plugins.tsx
@@ -37,5 +37,11 @@ export const editorPlugins = (function () {
     return (contextPlugin?.plugin as EditorPlugin) ?? null
   }
 
-  return { init, getAllWithData, getByType }
+  function isSupported(pluginType: string) {
+    const plugins = getAllWithData()
+
+    return !!plugins.find((plugin) => plugin.type === pluginType)
+  }
+
+  return { init, getAllWithData, getByType, isSupported }
 })()

--- a/packages/editor/src/plugins/blanks-exercise/editor.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/editor.tsx
@@ -40,7 +40,9 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
   const { text: childPlugin, mode, extraDraggableAnswers } = state
   const [previewActive, setPreviewActive] = useState(false)
 
-  const blanksExerciseStrings = useEditorStrings().plugins.blanksExercise
+  const pluginStrings = useEditorStrings().plugins
+  const blanksExerciseStrings = pluginStrings.blanksExercise
+  const dragAndDropTitle = pluginStrings.blanksExerciseDragAndDrop.title
 
   const isChildPluginFocused = useAppSelector((storeState) =>
     selectIsFocused(storeState, childPlugin.id)
@@ -90,7 +92,9 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
           `)}
           data-qa="plugin-blanks-exercise-parent-button"
         >
-          {blanksExerciseStrings.title}
+          {mode.value === 'typing'
+            ? blanksExerciseStrings.title
+            : dragAndDropTitle}
         </button>
       )}
 

--- a/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
@@ -23,10 +23,14 @@ export const BlanksExerciseToolbar = ({
 }) => {
   const pluginsStrings = useEditorStrings().plugins
   const blanksExerciseStrings = pluginsStrings.blanksExercise
+  const pluginType =
+    state.mode.value === 'typing'
+      ? EditorPluginType.BlanksExercise
+      : EditorPluginType.BlanksExerciseDragAndDrop
 
   return (
     <PluginToolbar
-      pluginType={EditorPluginType.BlanksExercise}
+      pluginType={pluginType}
       className="top-[-33px]"
       pluginSettings={
         <>

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -30,12 +30,9 @@ export function ExerciseEditor(props: ExerciseProps) {
   const isSerlo = useContext(IsSerloContext) // only on serlo
   const editorStrings = useEditorStrings()
 
-  const interactiveExerciseTypes = interactivePluginTypes.filter((type) =>
-    editorPlugins.getAllWithData().some((plugin) => plugin.type === type)
-  )
-  const interactiveExerciseMenuItems = interactiveExerciseTypes.map((type) =>
-    createOption(type, editorStrings.plugins)
-  )
+  const interactivePluginOptions = interactivePluginTypes
+    .filter((type) => editorPlugins.isSupported(type))
+    .map((type) => createOption(type, editorStrings.plugins))
 
   const templateStrings = useEditorStrings().templatePlugins
   const exTemplateStrings = templateStrings.exercise
@@ -58,7 +55,7 @@ export function ExerciseEditor(props: ExerciseProps) {
       {focused ? (
         <ExerciseToolbar
           {...props}
-          interactiveExerciseTypes={interactiveExerciseTypes}
+          interactivePluginOptions={interactivePluginOptions}
         />
       ) : (
         <button
@@ -94,12 +91,12 @@ export function ExerciseEditor(props: ExerciseProps) {
               {exTemplateStrings.addOptionalInteractiveEx}
             </p>
             <div className="flex items-start">
-              {interactiveExerciseMenuItems.map(
-                ({ pluginType, title, icon, description }, index) => {
+              {interactivePluginOptions.map(
+                ({ pluginType, title, icon, description }, index, arr) => {
                   const tooltipClassName =
                     index === 0
                       ? 'left-0'
-                      : index + 1 < interactiveExerciseMenuItems.length
+                      : index + 1 < arr.length
                         ? '-left-24'
                         : 'right-0'
                   return (

--- a/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
+++ b/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
@@ -1,6 +1,7 @@
 import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { DropdownButton } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/dropdown-button'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
+import { PluginMenuItemType } from '@editor/plugins/rows/contexts/plugin-menu/types'
 import { selectDocument, store } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -12,9 +13,9 @@ import { InteractivePluginType } from '../interactive-plugin-types'
 export const ExerciseToolbar = ({
   id,
   state,
-  interactiveExerciseTypes,
+  interactivePluginOptions,
 }: ExerciseProps & {
-  interactiveExerciseTypes: InteractivePluginType[]
+  interactivePluginOptions: PluginMenuItemType[]
 }) => {
   const { interactive } = state
   const exTemplateStrings = useEditorStrings().templatePlugins.exercise
@@ -32,9 +33,9 @@ export const ExerciseToolbar = ({
         if (interactive.defined)
           interactive.replace(value as InteractivePluginType)
       }}
-      options={interactiveExerciseTypes.map((type) => ({
-        value: type,
-        text: exTemplateStrings[type],
+      options={interactivePluginOptions.map(({ pluginType, title }) => ({
+        value: pluginType,
+        text: title,
       }))}
     />
   ) : undefined


### PR DESCRIPTION
also shows correct blanks title depending on mode in toolbar and parent indicator