### PR TITLE
fix(editor-plugin-menu): Make mouse hover not change selected plugin

### DIFF
--- a/e2e-tests/tests/480-focus.ts
+++ b/e2e-tests/tests/480-focus.ts
@@ -102,17 +102,15 @@ Scenario('focus plugins with arrow keys', ({ I }) => {
   I.say('add first text plugin, type in it, check that it has focus')
   I.click('Füge ein Element hinzu')
   I.type('Text')
-  I.pressKey('Tab')
   I.pressKey('Enter')
   I.type('First text plugin')
   I.see('First text plugin', 'div[data-slate-editor="true"]:focus')
 
   I.say('add second text plugin, type in it, check that it has focus')
-  I.pressKey('Tab')
+  I.pressKey('Tab') // Afterwards on button 'Füge ein Element hinzu'
   I.pressKey('Enter')
 
   I.type('Text')
-  I.pressKey('Tab')
   I.pressKey('Enter')
   I.type('Second text plugin')
   I.see('First text plugin', 'div[data-slate-editor="true"]')

--- a/packages/editor/src/plugins/rows/components/plugin-menu-items.tsx
+++ b/packages/editor/src/plugins/rows/components/plugin-menu-items.tsx
@@ -72,11 +72,6 @@ export function PluginMenuItems({
             onClick={() => onInsertPlugin(pluginType)}
             onFocus={() => setFocusedItemIndex(currentIndex)}
             onBlur={() => setFocusedItemIndex(null)}
-            onMouseEnter={() => setFocusedItemIndex(currentIndex)}
-            onMouseLeave={() => {
-              setFocusedItemIndex(null)
-              itemRefs.current[currentIndex]?.blur()
-            }}
             className={cn(
               'serlo-tooltip-trigger w-full rounded-md p-2 hover:shadow-xl',
               selected && 'shadow-xl'


### PR DESCRIPTION
**Before**
Having the mouse hover unintentionally over a plugin in the menu caused the wrong plugin to be created on pressing 'enter'. 
Here the mouse hovers over 'Lückentext' and this will be created even though the user typed in 'text' and expects the first item in the list to be created. Even if the mouse is never moved / used. 
![image](https://github.com/user-attachments/assets/e63d0920-a550-4b9a-be3b-21608f220c3f)

I think this also caused e2e test "focus plugins with arrow keys" to fail sometimes. 

**After**
Mouse hover does no longer select a plugin. But clicking to create still works & tooltips show up. I think "mouse hover to select" is a feature we can remove. 