### PR TITLE
fix(plugin-blanks): Remove autofocus blank

### DIFF
--- a/packages/editor/src/plugins/blanks-exercise/blank-renderer.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/blank-renderer.tsx
@@ -36,12 +36,7 @@ export function BlankRenderer(props: BlankRendererProps) {
     return element.acceptMathEquivalents
   }, [element.acceptMathEquivalents])
 
-  // Autofocus when adding and removing a blank
   const inputRef = useRef<HTMLInputElement | null>(null)
-  useEffect(() => {
-    // Focus input when the blank is added
-    setTimeout(() => inputRef.current?.focus())
-  }, [inputRef])
 
   // Focus input when the blank is selected using arrow keys
   // + set cursor at the start if entering using right arrow key


### PR DESCRIPTION
**Before**
When opening https://de.serlo-staging.dev/entity/repository/add-revision/277232 the focus/view jumps to the last blank. Disorienting for the user.  

**After**
The content title is focused.
But, creating a blank while editing does not focus it automatically any more. I guess a better approach would be to hook this up to the button (& keyboard shortcut) for creating a blank. But not sure if it is worth the effort right now. 