### PR TITLE
refactor(exercise): move preview buttons to exercise toolbar

### DIFF
--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -1105,6 +1105,9 @@ export const loggedInData = {
           removeInteractive: 'Remove interactive element',
           createSolution: 'Create solution',
           removeSolution: 'Remove solution',
+          previewMode: 'Preview',
+          previewIsActiveHint: 'Preview mode is active',
+          previewIsDeactiveHint: 'Here you can edit',
         },
         inputExercise: {
           chooseType: 'Choose the exercise type',
@@ -1126,9 +1129,6 @@ export const loggedInData = {
           multipleChoice: 'Multiple-choice',
           chooseType: 'Choose the exercise type',
           addAnswer: 'Add answer',
-          previewMode: 'Preview',
-          previewIsActiveHint: 'Preview mode is active',
-          previewIsDeactiveHint: 'Here you can edit',
         },
         solution: {
           optionalExplanation: 'Optionally explain the solution strategy here',

--- a/apps/web/src/data/en/index.ts
+++ b/apps/web/src/data/en/index.ts
@@ -728,15 +728,15 @@ export const loggedInData = {
           },
           backgroundType: {
             description:
-              'Insert a background image or proceed with a blank background', // 'Füge ein Hintergrundbild hinzu oder starte mit leerem Hintergrund'
-            image: 'Background Image', // 'Hintergrundbild hinzufügen'
-            blank: 'Blank background', //  'Leerer Hintergrund'
+              'Insert a background image or proceed with a blank background',
+            image: 'Background Image',
+            blank: 'Blank background',
           },
           backgroundShapes: {
-            description: 'Choose the layout of the background', // 'Lege die Ausrichtung des Hintergrundes fest'
-            square: 'Square', //'Quadradtisch',
-            landscape: 'Landscape', //'Querformat',
-            portrait: 'Portrait', // 'Hochformat'
+            description: 'Choose the layout of the background',
+            square: 'Square',
+            landscape: 'Landscape',
+            portrait: 'Portrait',
           },
           or: 'or',
           modal: {

--- a/e2e-tests/tests/450-blanks-exercise.ts
+++ b/e2e-tests/tests/450-blanks-exercise.ts
@@ -167,7 +167,7 @@ Scenario(
 
     I.say('Change mode to preview and solve them incorrectly')
     I.click('$plugin-blanks-exercise-parent-button')
-    I.click('$plugin-blanks-exercise-preview-button')
+    I.click('$plugin-exercise-preview-button')
     I.seeNumberOfElements('$blank-input', 2)
     I.click(locate('$blank-input').first())
     // Adding the second gap solution to the first gap

--- a/packages/editor/src/editor-ui/plugin-toolbar/components/preview-button.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/components/preview-button.tsx
@@ -4,31 +4,29 @@ import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
 
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 
-interface PreviewButtonProps {
+export function PreviewButton({
+  previewActive,
+  setPreviewActive,
+}: {
   previewActive: boolean
-  dataQa?: string
   setPreviewActive: (value: boolean) => void
-}
-
-export function PreviewButton(props: PreviewButtonProps) {
-  const { previewActive, dataQa, setPreviewActive } = props
-  const scMcStrings = useEditorStrings().templatePlugins.scMcExercise
+}) {
+  const exStrings = useEditorStrings().templatePlugins.exercise
 
   return (
     <button
       onClick={() => setPreviewActive(!previewActive)}
       className="serlo-tooltip-trigger mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
-      data-qa={dataQa}
     >
       <EditorTooltip
         text={
           previewActive
-            ? scMcStrings.previewIsActiveHint
-            : scMcStrings.previewIsDeactiveHint
+            ? exStrings.previewIsActiveHint
+            : exStrings.previewIsDeactiveHint
         }
         className="-ml-5 !pb-1"
       />
-      {scMcStrings.previewMode}{' '}
+      {exStrings.previewMode}{' '}
       <FaIcon icon={previewActive ? faCheckCircle : faCircle} />
     </button>
   )

--- a/packages/editor/src/editor-ui/plugin-toolbar/components/preview-button.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/components/preview-button.tsx
@@ -17,6 +17,7 @@ export function PreviewButton({
     <button
       onClick={() => setPreviewActive(!previewActive)}
       className="serlo-tooltip-trigger mr-2 rounded-md border border-gray-500 px-1 text-sm transition-all hover:bg-editor-primary-200 focus-visible:bg-editor-primary-200"
+      data-qa="plugin-exercise-preview-button"
     >
       <EditorTooltip
         text={

--- a/packages/editor/src/plugins/blanks-exercise/editor.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/editor.tsx
@@ -7,13 +7,14 @@ import {
 } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import type { EditorBlanksExerciseDocument } from '@editor/types/editor-plugins'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import type { BlanksExerciseProps, BlanksExerciseMode } from '.'
 import { ExtraIncorrectAnswers } from './components/extra-incorrect-answers'
 import { BlanksExerciseRenderer } from './renderer'
 import { BlanksExerciseStaticRenderer } from './static'
 import { BlanksExerciseToolbar } from './toolbar'
+import { useIsPreviewActive } from '../exercise/context/preview-context'
 import { useEditorStrings } from '@/contexts/logged-in-data-context'
 import { cn } from '@/helper/cn'
 
@@ -38,7 +39,7 @@ const cellTextFormattingOptions = [
 export function BlanksExerciseEditor(props: BlanksExerciseProps) {
   const { focused, id, state } = props
   const { text: childPlugin, mode, extraDraggableAnswers } = state
-  const [previewActive, setPreviewActive] = useState(false)
+  const previewActive = useIsPreviewActive()
 
   const pluginStrings = useEditorStrings().plugins
   const blanksExerciseStrings = pluginStrings.blanksExercise
@@ -79,8 +80,6 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
       {focused ? (
         <BlanksExerciseToolbar
           {...props}
-          previewActive={previewActive}
-          setPreviewActive={setPreviewActive}
           childPluginType={childPluginState.plugin as EditorPluginType}
         />
       ) : (

--- a/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/toolbar.tsx
@@ -1,11 +1,6 @@
-import {
-  PluginToolbar,
-  PreviewButton,
-  ToolbarSelect,
-} from '@editor/editor-ui/plugin-toolbar'
+import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
-import { Dispatch, SetStateAction } from 'react'
 
 import { type BlanksExerciseProps } from '.'
 import { InteractiveToolbarTools } from '../exercise/toolbar/interactive-toolbar-tools'
@@ -13,12 +8,8 @@ import { InteractiveToolbarTools } from '../exercise/toolbar/interactive-toolbar
 export const BlanksExerciseToolbar = ({
   id,
   state,
-  previewActive,
-  setPreviewActive,
   childPluginType,
 }: BlanksExerciseProps & {
-  previewActive: boolean
-  setPreviewActive: Dispatch<SetStateAction<boolean>>
   childPluginType: EditorPluginType
 }) => {
   const pluginsStrings = useEditorStrings().plugins
@@ -34,11 +25,6 @@ export const BlanksExerciseToolbar = ({
       className="top-[-33px]"
       pluginSettings={
         <>
-          <PreviewButton
-            previewActive={previewActive}
-            setPreviewActive={setPreviewActive}
-            dataQa="plugin-blanks-exercise-preview-button"
-          />
           <ToolbarSelect
             tooltipText={blanksExerciseStrings.chooseType}
             value={state.mode.value}

--- a/packages/editor/src/plugins/dropzone-image/components/editor/background-type-select.tsx
+++ b/packages/editor/src/plugins/dropzone-image/components/editor/background-type-select.tsx
@@ -34,7 +34,6 @@ export function BackgroundTypeSelect({
           <IconImageBg />
           {backgroundTypeStrings.image}
         </button>
-        <span>oder</span>
         <button
           data-qa="plugin-dropzone-image-background-type-select-blank"
           className="qm-[20px] flex flex-col items-center justify-center gap-4 rounded-[5px] bg-orange-100 p-[10px] py-4 font-bold text-almost-black hover:bg-orange-200"

--- a/packages/editor/src/plugins/dropzone-image/editor.tsx
+++ b/packages/editor/src/plugins/dropzone-image/editor.tsx
@@ -3,7 +3,6 @@ import type {
   EditorDropzoneImageDocument,
   EditorImageDocument,
 } from '@editor/types/editor-plugins'
-import { useState } from 'react'
 
 import type { DropzoneImageProps } from '.'
 import { BackgroundShapeSelect } from './components/editor/background-shape-select'
@@ -11,6 +10,7 @@ import { BackgroundTypeSelect } from './components/editor/background-type-select
 import { EditingView } from './components/editor/editing-view'
 import { DropzoneImageToolbar } from './toolbar'
 import { BackgroundType } from './types'
+import { useIsPreviewActive } from '../exercise/context/preview-context'
 
 export function DropzoneImageEditor({
   state,
@@ -19,7 +19,7 @@ export function DropzoneImageEditor({
 }: DropzoneImageProps) {
   const { backgroundImage, dropzoneVisibility } = state
 
-  const [previewActive, setPreviewActive] = useState(false)
+  const previewActive = useIsPreviewActive()
 
   const staticDocument = useAppSelector(
     (storeState) =>
@@ -54,8 +54,6 @@ export function DropzoneImageEditor({
           showSettingsButton={isBackgroundTypeImage}
           backgroundImage={backgroundImage}
           dropzoneVisibility={dropzoneVisibility}
-          previewActive={previewActive}
-          setPreviewActive={setPreviewActive}
         />
       ) : null}
 

--- a/packages/editor/src/plugins/dropzone-image/toolbar.tsx
+++ b/packages/editor/src/plugins/dropzone-image/toolbar.tsx
@@ -1,8 +1,4 @@
-import {
-  PluginToolbar,
-  PreviewButton,
-  ToolbarSelect,
-} from '@editor/editor-ui/plugin-toolbar'
+import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { runChangeDocumentSaga, useAppDispatch } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { faCog, faSyncAlt } from '@fortawesome/free-solid-svg-icons'

--- a/packages/editor/src/plugins/dropzone-image/toolbar.tsx
+++ b/packages/editor/src/plugins/dropzone-image/toolbar.tsx
@@ -22,8 +22,6 @@ interface DropzoneImageToolbarProps {
   showSettings: boolean
   showSettingsButton?: boolean
   dropzoneVisibility?: DropzoneImageProps['state']['dropzoneVisibility']
-  previewActive?: boolean
-  setPreviewActive?: (active: boolean) => void
 }
 
 export function DropzoneImageToolbar({
@@ -32,8 +30,6 @@ export function DropzoneImageToolbar({
   showSettings,
   showSettingsButton = false,
   dropzoneVisibility,
-  previewActive,
-  setPreviewActive,
 }: DropzoneImageToolbarProps) {
   const [showSettingsModal, setShowSettingsModal] = useState(false)
   const editorStrings = useEditorStrings()
@@ -81,12 +77,6 @@ export function DropzoneImageToolbar({
             </button>
             {renderSettingsModal()}
           </>
-        ) : null}
-        {previewActive !== undefined && setPreviewActive !== undefined ? (
-          <PreviewButton
-            previewActive={previewActive}
-            setPreviewActive={setPreviewActive}
-          />
         ) : null}
         {dropzoneVisibility ? (
           <ToolbarSelect

--- a/packages/editor/src/plugins/exercise/context/preview-context.tsx
+++ b/packages/editor/src/plugins/exercise/context/preview-context.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react'
+
+const PreviewContext = createContext<boolean>(false)
+
+export const PreviewProvider = PreviewContext.Provider
+
+export function useIsPreviewActive() {
+  return useContext(PreviewContext)
+}

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -6,10 +6,11 @@ import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FaIcon } from '@serlo/frontend/src/components/fa-icon'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 
 import { type ExerciseProps } from '.'
 import { InteractiveExercisesSelection } from './components/interactive-exercises-selection'
+import { PreviewProvider } from './context/preview-context'
 import { interactivePluginTypes } from './interactive-plugin-types'
 import { ExerciseToolbar } from './toolbar/toolbar'
 import { createOption } from '../rows/utils/plugin-menu'
@@ -30,6 +31,8 @@ export function ExerciseEditor(props: ExerciseProps) {
   const exTemplateStrings = editorStrings.templatePlugins.exercise
   const exPluginStrings = editorStrings.plugins.exercise
 
+  const [previewActive, setPreviewActive] = useState(false)
+
   const interactivePluginOptions = interactivePluginTypes
     .filter((type) => editorPlugins.isSupported(type))
     .map((type) => createOption(type, editorStrings.plugins))
@@ -41,79 +44,83 @@ export function ExerciseEditor(props: ExerciseProps) {
   const isFocused = focused || isFocusedInside
 
   return (
-    <div
-      data-qa="plugin-exercise"
-      className={cn(
-        'group/exercise rounded-b-xl border-3 border-transparent pb-6',
-        'focus-within:rounded-tl-xl focus-within:!border-gray-100 focus-within:border-gray-100',
-        isFocused && '!rounded-tl-xl !border-gray-100'
-      )}
-    >
-      {isSerlo ? (
-        <SerloLicenseChooser
-          licenseId={licenseId}
-          className="!right-[84px] !top-[-30px]"
-        />
-      ) : null}
+    <PreviewProvider value={previewActive}>
       <div
+        data-qa="plugin-exercise"
         className={cn(
-          'group-focus-within/exercise:block',
-          isFocused ? 'block' : 'hidden'
+          'group/exercise rounded-b-xl border-3 border-transparent pb-6',
+          'focus-within:rounded-tl-xl focus-within:!border-gray-100 focus-within:border-gray-100',
+          isFocused && '!rounded-tl-xl !border-gray-100'
         )}
       >
-        <ExerciseToolbar
-          {...props}
-          interactivePluginOptions={interactivePluginOptions}
-        />
-      </div>
-      <div className="h-10"></div>
-      {content.render({
-        config: {
-          textPluginPlaceholder: exPluginStrings.placeholder,
-        },
-      })}
-      <div className="mx-side">
-        {interactive.defined ? (
-          <>
-            {interactive.render()}
-            {hideInteractiveInitially.defined ? (
-              <small className="bg-editor-primary-200 p-1">
-                [{exPluginStrings.hideInteractiveInitially.info}]
-              </small>
-            ) : null}
-          </>
-        ) : (
-          <InteractiveExercisesSelection
-            interactivePluginOptions={interactivePluginOptions}
-            interactive={interactive}
+        {isSerlo ? (
+          <SerloLicenseChooser
+            licenseId={licenseId}
+            className="!right-[84px] !top-[-30px]"
           />
-        )}
-        {solution.defined ? (
-          <div className="-ml-side mt-block">
-            <nav className="flex justify-end">
-              <button
-                className="serlo-button-editor-secondary serlo-tooltip-trigger relative top-7 z-20 mr-side"
-                onClick={() => solution.remove()}
-              >
-                <EditorTooltip text={exTemplateStrings.removeSolution} />
-                <FaIcon icon={faTrashAlt} />
-              </button>
-            </nav>
-            {solution.render()}
-          </div>
-        ) : (
-          <div
-            className={cn(
-              'mt-12 hidden max-w-[50%] group-focus-within/exercise:block',
-              isFocused ? 'block' : 'hidden'
-            )}
-          >
-            <AddButton onClick={() => solution.create()}>
-              {exTemplateStrings.createSolution}
-            </AddButton>
-          </div>
-        )}
+        ) : null}
+        <div
+          className={cn(
+            'group-focus-within/exercise:block',
+            isFocused ? 'block' : 'hidden'
+          )}
+        >
+          <ExerciseToolbar
+            {...props}
+            interactivePluginOptions={interactivePluginOptions}
+            previewActive={previewActive}
+            setPreviewActive={setPreviewActive}
+          />
+        </div>
+        <div className="h-10"></div>
+        {content.render({
+          config: {
+            textPluginPlaceholder: exPluginStrings.placeholder,
+          },
+        })}
+        <div className="mx-side">
+          {interactive.defined ? (
+            <>
+              {interactive.render()}
+              {hideInteractiveInitially.defined ? (
+                <small className="bg-editor-primary-200 p-1">
+                  [{exPluginStrings.hideInteractiveInitially.info}]
+                </small>
+              ) : null}
+            </>
+          ) : (
+            <InteractiveExercisesSelection
+              interactivePluginOptions={interactivePluginOptions}
+              interactive={interactive}
+            />
+          )}
+          {solution.defined ? (
+            <div className="-ml-side mt-block">
+              <nav className="flex justify-end">
+                <button
+                  className="serlo-button-editor-secondary serlo-tooltip-trigger relative top-7 z-20 mr-side"
+                  onClick={() => solution.remove()}
+                >
+                  <EditorTooltip text={exTemplateStrings.removeSolution} />
+                  <FaIcon icon={faTrashAlt} />
+                </button>
+              </nav>
+              {solution.render()}
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'mt-12 hidden max-w-[50%] group-focus-within/exercise:block',
+                isFocused ? 'block' : 'hidden'
+              )}
+            >
+              <AddButton onClick={() => solution.create()}>
+                {exTemplateStrings.createSolution}
+              </AddButton>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </PreviewProvider>
   )
 }

--- a/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
+++ b/packages/editor/src/plugins/exercise/toolbar/toolbar.tsx
@@ -1,4 +1,8 @@
-import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
+import {
+  PluginToolbar,
+  PreviewButton,
+  ToolbarSelect,
+} from '@editor/editor-ui/plugin-toolbar'
 import { DropdownButton } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/dropdown-button'
 import { PluginDefaultTools } from '@editor/editor-ui/plugin-toolbar/plugin-tool-menu/plugin-default-tools'
 import { PluginMenuItemType } from '@editor/plugins/rows/contexts/plugin-menu/types'
@@ -14,30 +18,40 @@ export const ExerciseToolbar = ({
   id,
   state,
   interactivePluginOptions,
+  previewActive,
+  setPreviewActive,
 }: ExerciseProps & {
   interactivePluginOptions: PluginMenuItemType[]
+  previewActive: boolean
+  setPreviewActive: (active: boolean) => void
 }) => {
   const { interactive } = state
   const exTemplateStrings = useEditorStrings().templatePlugins.exercise
   const exPluginStrings = useEditorStrings().plugins.exercise
 
-  const currentlySelected = interactive.defined
+  const interactivePlugin = interactive.defined
     ? selectDocument(store.getState(), interactive.id)?.plugin
     : undefined
 
-  const pluginSettings = currentlySelected ? (
-    <ToolbarSelect
-      tooltipText={exTemplateStrings.changeInteractive}
-      value={currentlySelected ?? ''}
-      changeValue={(value) => {
-        if (interactive.defined)
-          interactive.replace(value as InteractivePluginType)
-      }}
-      options={interactivePluginOptions.map(({ pluginType, title }) => ({
-        value: pluginType,
-        text: title,
-      }))}
-    />
+  const pluginSettings = interactivePlugin ? (
+    <>
+      <PreviewButton
+        previewActive={previewActive}
+        setPreviewActive={setPreviewActive}
+      />
+      <ToolbarSelect
+        tooltipText={exTemplateStrings.changeInteractive}
+        value={interactivePlugin}
+        changeValue={(value) => {
+          if (interactive.defined)
+            interactive.replace(value as InteractivePluginType)
+        }}
+        options={interactivePluginOptions.map(({ pluginType, title }) => ({
+          value: pluginType,
+          text: title,
+        }))}
+      />
+    </>
   ) : undefined
 
   return (

--- a/packages/editor/src/plugins/input-exercise/editor.tsx
+++ b/packages/editor/src/plugins/input-exercise/editor.tsx
@@ -1,7 +1,7 @@
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { EditorInputExerciseDocument } from '@editor/types/editor-plugins'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import type { InputExerciseProps } from '.'
 import { InputExerciseStaticRenderer } from './static'
@@ -19,6 +19,7 @@ import {
   useAppDispatch,
   useAppSelector,
 } from '../../store'
+import { useIsPreviewActive } from '../exercise/context/preview-context'
 
 export function InputExerciseEditor(props: InputExerciseProps) {
   const { state, id, focused } = props
@@ -27,8 +28,8 @@ export function InputExerciseEditor(props: InputExerciseProps) {
 
   const dispatch = useAppDispatch()
 
-  const [previewActive, setPreviewActive] = useState(false)
   const newestAnswerRef = useRef<HTMLInputElement>(null)
+  const previewActive = useIsPreviewActive()
 
   const staticDocument = useAppSelector(
     (storeState) =>
@@ -56,13 +57,7 @@ export function InputExerciseEditor(props: InputExerciseProps) {
 
   return (
     <div className="mb-12 mt-24 pt-4">
-      {showUi ? (
-        <InputExerciseToolbar
-          {...props}
-          previewActive={previewActive}
-          setPreviewActive={setPreviewActive}
-        />
-      ) : null}
+      {showUi ? <InputExerciseToolbar {...props} /> : null}
 
       <PreviewOverlaySimple previewActive={previewActive} fullOpacity={!showUi}>
         <InputExerciseStaticRenderer {...staticDocument} />

--- a/packages/editor/src/plugins/input-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/input-exercise/toolbar.tsx
@@ -1,9 +1,5 @@
 import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
-import {
-  PluginToolbar,
-  PreviewButton,
-  ToolbarSelect,
-} from '@editor/editor-ui/plugin-toolbar'
+import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'

--- a/packages/editor/src/plugins/input-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/input-exercise/toolbar.tsx
@@ -7,21 +7,12 @@ import {
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
 import { cn } from '@serlo/frontend/src/helper/cn'
-import { Dispatch, SetStateAction } from 'react'
 
 import type { InputExerciseProps } from '.'
 import { InputExerciseType } from './input-exercise-type'
 import { InteractiveToolbarTools } from '../exercise/toolbar/interactive-toolbar-tools'
 
-export const InputExerciseToolbar = ({
-  state,
-  previewActive,
-  setPreviewActive,
-  id,
-}: InputExerciseProps & {
-  previewActive: boolean
-  setPreviewActive: Dispatch<SetStateAction<boolean>>
-}) => {
+export const InputExerciseToolbar = ({ state, id }: InputExerciseProps) => {
   const inputExStrings = useEditorStrings().templatePlugins.inputExercise
 
   return (
@@ -29,10 +20,6 @@ export const InputExerciseToolbar = ({
       pluginType={EditorPluginType.InputExercise}
       pluginSettings={
         <>
-          <PreviewButton
-            previewActive={previewActive}
-            setPreviewActive={setPreviewActive}
-          />
           <ToolbarSelect
             tooltipText={inputExStrings.chooseType}
             value={state.type.value}

--- a/packages/editor/src/plugins/sc-mc-exercise/editor.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/editor.tsx
@@ -1,6 +1,5 @@
 import { EditorScMcExerciseDocument } from '@editor/types/editor-plugins'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
-import { useState } from 'react'
 
 import type { ScMcExerciseProps } from '.'
 import { ScMcExerciseStaticRenderer } from './static'
@@ -16,6 +15,7 @@ import {
   selectStaticDocument,
   useAppSelector,
 } from '../../store'
+import { useIsPreviewActive } from '../exercise/context/preview-context'
 
 export function ScMcExerciseEditor(props: ScMcExerciseProps) {
   const { state, id, focused } = props
@@ -41,7 +41,7 @@ export function ScMcExerciseEditor(props: ScMcExerciseProps) {
   const handleAddButtonClick = () => answers.insert()
   const removeAnswer = (index: number) => () => answers.remove(index)
 
-  const [previewActive, setPreviewActive] = useState(false)
+  const previewActive = useIsPreviewActive()
 
   const isAnyAnswerFocused = answers.some(({ content, feedback }) => {
     const focusedId = selectFocused(store.getState())
@@ -70,13 +70,7 @@ export function ScMcExerciseEditor(props: ScMcExerciseProps) {
 
   return (
     <div className="mb-12 mt-24 pt-4">
-      {showUi ? (
-        <ScMcExerciseToolbar
-          {...props}
-          previewActive={previewActive}
-          setPreviewActive={setPreviewActive}
-        />
-      ) : null}
+      {showUi ? <ScMcExerciseToolbar {...props} /> : null}
       <PreviewOverlaySimple previewActive={previewActive} fullOpacity={!showUi}>
         {/* margin-hack */}
         <div className="[&_.ml-4.flex]:mb-block">

--- a/packages/editor/src/plugins/sc-mc-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/toolbar.tsx
@@ -1,11 +1,6 @@
-import {
-  PluginToolbar,
-  PreviewButton,
-  ToolbarSelect,
-} from '@editor/editor-ui/plugin-toolbar'
+import { PluginToolbar, ToolbarSelect } from '@editor/editor-ui/plugin-toolbar'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import { useEditorStrings } from '@serlo/frontend/src/contexts/logged-in-data-context'
-import type { Dispatch, SetStateAction } from 'react'
 
 import type { ScMcExerciseProps } from '.'
 import { InteractiveToolbarTools } from '../exercise/toolbar/interactive-toolbar-tools'

--- a/packages/editor/src/plugins/sc-mc-exercise/toolbar.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/toolbar.tsx
@@ -10,15 +10,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import type { ScMcExerciseProps } from '.'
 import { InteractiveToolbarTools } from '../exercise/toolbar/interactive-toolbar-tools'
 
-export const ScMcExerciseToolbar = ({
-  state,
-  previewActive,
-  setPreviewActive,
-  id,
-}: ScMcExerciseProps & {
-  previewActive: boolean
-  setPreviewActive: Dispatch<SetStateAction<boolean>>
-}) => {
+export const ScMcExerciseToolbar = ({ state, id }: ScMcExerciseProps) => {
   const scMcStrings = useEditorStrings().templatePlugins.scMcExercise
 
   const handleChange = (value: string) => {
@@ -31,21 +23,15 @@ export const ScMcExerciseToolbar = ({
     <PluginToolbar
       pluginType={EditorPluginType.ScMcExercise}
       pluginSettings={
-        <>
-          <PreviewButton
-            previewActive={previewActive}
-            setPreviewActive={setPreviewActive}
-          />
-          <ToolbarSelect
-            tooltipText={scMcStrings.chooseType}
-            value={state.isSingleChoice.value ? 'sc' : 'mc'}
-            changeValue={handleChange}
-            options={[
-              { value: 'mc', text: scMcStrings.multipleChoice },
-              { value: 'sc', text: scMcStrings.singleChoice },
-            ]}
-          />
-        </>
+        <ToolbarSelect
+          tooltipText={scMcStrings.chooseType}
+          value={state.isSingleChoice.value ? 'sc' : 'mc'}
+          changeValue={handleChange}
+          options={[
+            { value: 'mc', text: scMcStrings.multipleChoice },
+            { value: 'sc', text: scMcStrings.singleChoice },
+          ]}
+        />
       }
       pluginControls={<InteractiveToolbarTools id={id} />}
     />


### PR DESCRIPTION
PE-165

[Demo](https://frontend-git-move-preview-button-to-parent-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22exercise%22%2C%22state%22%3A%7B%22content%22%3A%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22ae4f5b73-20d3-4ab8-ae8c-e45090405943%22%7D%5D%2C%22id%22%3A%22b9ca2631-7a1e-454a-98e4-109fec5fe476%22%7D%2C%22interactive%22%3A%7B%22plugin%22%3A%22scMcExercise%22%2C%22state%22%3A%7B%22isSingleChoice%22%3Afalse%2C%22answers%22%3A%5B%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%2234c32fdd-7994-4c96-b3e6-b408d33d7202%22%7D%2C%22isCorrect%22%3Afalse%2C%22feedback%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%2265e5d262-561d-43fc-b221-4f8ea6a5d7c9%22%7D%7D%2C%7B%22content%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%22d0a814ed-bb60-463f-b752-0be311cf1834%22%7D%2C%22isCorrect%22%3Afalse%2C%22feedback%22%3A%7B%22plugin%22%3A%22text%22%2C%22state%22%3A%5B%7B%22type%22%3A%22p%22%2C%22children%22%3A%5B%7B%22text%22%3A%22%22%7D%5D%7D%5D%2C%22id%22%3A%2224856ff7-6a80-4de9-ae26-d31cf35daacd%22%7D%7D%5D%7D%2C%22id%22%3A%2207a43be7-2463-4e40-9271-a42374102114%22%7D%7D%2C%22id%22%3A%221eb09ad8-85ee-4cf2-81d5-4988208d43c9%22%7D%5D%7D)