### PR TITLE
ci: Write body of releases from our generated changelog

### DIFF
--- a/.github/workflows/editor-changelog.yaml
+++ b/.github/workflows/editor-changelog.yaml
@@ -6,7 +6,7 @@ on:
       - '**' # Runs on all branches
 
 jobs:
-  generate-changelog:
+  generate-editor-changelog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -133,8 +133,10 @@ jobs:
 
             if echo "$FILES" | jq -r '.[].filename' | grep -q "^packages/editor/"; then
               PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+              PR_URL=$(echo "$PR_DATA" | jq -r '.html_url')
+              PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
               echo "PR #$pr touches editor package. Title: $PR_TITLE"
-              PR_TITLES="${PR_TITLES}- ${PR_TITLE}\n"
+              PR_TITLES="${PR_TITLES}- ${PR_TITLE}. Thank you @${PR_AUTHOR} in ${PR_URL}\n"
             else
               echo "PR #$pr does not touch editor package"
             fi
@@ -157,6 +159,8 @@ jobs:
           echo "## Changelog for version $CURRENT_VERSION" > packages/editor/CHANGELOG.md
           echo "" >> packages/editor/CHANGELOG.md  # Adds a newline after the heading
           echo -e "$PR_TITLES" >> packages/editor/CHANGELOG.md
+          echo "" >> packages/editor/CHANGELOG.md  # Adds a newline after the PR list
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/v$NPM_VERSION...v$CURRENT_VERSION" >> packages/editor/CHANGELOG.md
 
       - name: Run Prettier on Changelog
         if: env.version_changed == 'true' && env.no_editor_changes == 'false' && env.PR_TITLES != 'No relevant PRs found'

--- a/.github/workflows/editor.yaml
+++ b/.github/workflows/editor.yaml
@@ -61,13 +61,16 @@ jobs:
         if: steps.check_published.outputs.already_published == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           curl -X POST \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/releases \
-            -d '{
-              "tag_name": "v${{ steps.get_version.outputs.version }}",
-              "name": "Serlo Editor - v${{ steps.get_version.outputs.version }}",
-              "body": ${{ toJson(env.RELEASE_NOTES) }}
-            }'
+            -d @- << EOF
+          {
+            "tag_name": "v${RELEASE_VERSION}",
+            "name": "Serlo Editor - v${RELEASE_VERSION}",
+            "body": $(echo "$RELEASE_NOTES" | jq -Rs .)
+          }
+          EOF

--- a/.github/workflows/editor.yaml
+++ b/.github/workflows/editor.yaml
@@ -59,12 +59,15 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_published.outputs.already_published == 'false'
-        uses: elgohr/Github-Release-Action@v5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: v${{ steps.get_version.outputs.version }}
-          title: 'Serlo Editor - v${{ steps.get_version.outputs.version }}'
-          body: |
-            ## Serlo Editor Release Notes
-            ${{ env.RELEASE_NOTES }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d '{
+              "tag_name": "v${{ steps.get_version.outputs.version }}",
+              "name": "Serlo Editor - v${{ steps.get_version.outputs.version }}",
+              "body": ${{ toJson(env.RELEASE_NOTES) }}
+            }'


### PR DESCRIPTION
Our [plugin from the market place](https://github.com/elgohr/Github-Release-Action/blob/main/README.md) did not allow me to write the body of the release. Therefore, the first release here contains the default release notes (a summary of all PRs in the frontend repo), instead of only the ones of the editor package that we care about.

https://github.com/serlo/frontend/releases/tag/v0.16.0

I took inspiration from it and changed it, so that the changelog will thank the authors, link to the pull request and also summarize all changes/commits in the code.

I then changed the `editor.yaml` to use curl so that we can POST the body of the release notes to the github endpoint. Docs https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

