### PR TITLE
feat(blanks): hide exercise task until child plugin is selected, focus child plugin after selection

### DIFF
--- a/packages/editor/src/plugins/blanks-exercise/components/child-plugin-selection.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/components/child-plugin-selection.tsx
@@ -2,6 +2,7 @@ import IconTable from '@editor/editor-ui/assets/plugin-icons/icon-table.svg'
 import IconText from '@editor/editor-ui/assets/plugin-icons/icon-text.svg'
 import { SelectionCard } from '@editor/editor-ui/selection-card'
 import { useEditStrings } from '@editor/i18n/edit-strings-provider'
+import { useAppDispatch, focus } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
 
 import type { BlanksExerciseProps } from '..'
@@ -16,15 +17,18 @@ export function ChildPluginSelection({
   const pluginStrings = useEditStrings().plugins
   const description = pluginStrings.blanksExercise.childPluginSelection
 
+  const dispatch = useAppDispatch()
+
   function handleClick(plugin: EditorPluginType) {
     setShowSelection(false)
     childPlugin.replace(plugin)
+    dispatch(focus(childPlugin.id))
   }
 
   return (
     <>
       <div className="py-6 text-center text-gray-500">{description}</div>
-      <div className="flex justify-center gap-6 [&_svg]:min-w-20">
+      <div className="blanks-child-plugin-selection flex justify-center gap-6 [&_svg]:min-w-20">
         <SelectionCard
           onClick={() => handleClick(EditorPluginType.Text)}
           icon={<IconText />}

--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -84,11 +84,15 @@ export function ExerciseEditor(props: ExerciseProps) {
           />
         </div>
         <div className="h-10"></div>
-        {content.render({
-          config: {
-            textPluginPlaceholder: exStrings.placeholder,
-          },
-        })}
+        {/* Special case for the blanks exercise: Until the child plugin is selected we hide the task to avoid confusion */}
+        {/* Background: Users often add their blanks-text to the task */}
+        <div className="group-has-[.blanks-child-plugin-selection]/exercise:hidden">
+          {content.render({
+            config: {
+              textPluginPlaceholder: exStrings.placeholder,
+            },
+          })}
+        </div>
         <div className="mx-side">
           {interactive.defined ? (
             <>


### PR DESCRIPTION
> Background: Users often add their blanks-text to the task

PE-203

[Demo](https://frontend-git-blanks-ux-serlo.vercel.app/___editor_preview?state=%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"exercise"%2C"state"%3A%7B"content"%3A%7B"plugin"%3A"rows"%2C"state"%3A%5B%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"82f9f95a-2f2d-4206-8f52-f85510a2747b"%7D%5D%2C"id"%3A"4387b96b-c01d-4baa-89f8-8fdda379b0d7"%7D%2C"interactive"%3A%7B"plugin"%3A"blanksExercise"%2C"state"%3A%7B"text"%3A%7B"plugin"%3A"text"%2C"state"%3A%5B%7B"type"%3A"p"%2C"children"%3A%5B%7B"text"%3A""%7D%5D%7D%5D%2C"id"%3A"4b5313a8-a77c-412a-9fe2-fb7110f0e7a7"%7D%2C"mode"%3A"typing"%7D%2C"id"%3A"072f4c51-5eb2-4227-930e-f0a7f9be4d0a"%7D%7D%2C"id"%3A"380ec1fc-f23b-4112-86f3-cbefe1333b86"%7D%5D%7D)