### PR TITLE
fix(exercise): add suspense to avoid error

### DIFF
--- a/packages/editor/src/plugins/exercise/editor.tsx
+++ b/packages/editor/src/plugins/exercise/editor.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '@editor/utils/cn'
 import { IsSerloContext } from '@editor/utils/is-serlo-context'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
-import { lazy, useContext, useEffect, useState } from 'react'
+import { Suspense, lazy, useContext, useEffect, useState } from 'react'
 
 import { type ExerciseProps } from '.'
 import { InteractiveExercisesSelection } from './components/interactive-exercises-selection'
@@ -66,10 +66,12 @@ export function ExerciseEditor(props: ExerciseProps) {
         )}
       >
         {isSerlo ? (
-          <SerloLicenseChooser
-            licenseId={licenseId}
-            className="!right-[84px] !top-[-30px]"
-          />
+          <Suspense>
+            <SerloLicenseChooser
+              licenseId={licenseId}
+              className="!right-[84px] !top-[-30px]"
+            />
+          </Suspense>
         ) : null}
         <div
           className={cn(

--- a/packages/editor/src/plugins/solution/editor.tsx
+++ b/packages/editor/src/plugins/solution/editor.tsx
@@ -2,7 +2,7 @@ import { showToastNotice } from '@editor/editor-ui/show-toast-notice'
 import { useEditStrings } from '@editor/i18n/edit-strings-provider'
 import { SerloAddButton } from '@editor/plugin/helpers/serlo-editor-button'
 import { IsSerloContext } from '@editor/utils/is-serlo-context'
-import { lazy, useContext, useEffect, useState } from 'react'
+import { Suspense, lazy, useContext, useEffect, useState } from 'react'
 
 import type { SolutionProps } from '.'
 import { SolutionRenderer } from './renderer'
@@ -32,7 +32,11 @@ export function SolutionEditor({ state, focused }: SolutionProps) {
   return (
     <SolutionRenderer
       elementBeforePrerequisite={
-        isSerlo ? <SerloLicenseChooser licenseId={licenseId} /> : null
+        isSerlo ? (
+          <Suspense>
+            <SerloLicenseChooser licenseId={licenseId} />
+          </Suspense>
+        ) : null
       }
       prerequisite={isSerlo ? renderPrerequisiteContent() : null}
       strategy={


### PR DESCRIPTION
[Report](https://serlo.slack.com/archives/C0BMSC431/p1729460715627289)

Full error msg:
> A component suspended while responding to synchronous input. This will cause the UI to be replaced with a loading indicator. To fix, updates that suspend should be wrapped with startTransition.

Some [background](https://dev.to/mingming-ma/minified-react-error-426-317k).

I still don't fully understand the problem (and suggested solution with `startTransition`). If someone want's to dig deeper here they are welcome.
But wrapping the lazyloaded comp in `<Suspense />` seems to work.


