### PR TITLE
fix(exercise): make sure math controls end up in text toolbar not in exercise toolbar

### DIFF
--- a/packages/editor/src/math/editor.tsx
+++ b/packages/editor/src/math/editor.tsx
@@ -163,7 +163,9 @@ export function MathEditor(props: MathEditorProps) {
     const isShadowRootNode = isShadowRoot(root)
     const target =
       (isShadowRootNode || isDocument
-        ? root.querySelector<HTMLDivElement>('.toolbar-controls-target')
+        ? root.querySelector<HTMLDivElement>(
+            '.plugin-text .toolbar-controls-target'
+          )
         : document.body) ?? document.body
 
     return createPortal(children, target)


### PR DESCRIPTION
fixes #4209