### PR TITLE
feat(editor): show user a warning in test environments that content might disappear

### DIFF
--- a/packages/editor/src/i18n/strings/de/edit.ts
+++ b/packages/editor/src/i18n/strings/de/edit.ts
@@ -5,6 +5,8 @@ export const editStrings = {
   confirmRouteChange:
     'Willst du wirklich die Seite verlassen ohne zu speichern?',
   noChangesWarning: 'Bisher hast du nichts geändert',
+  savedContentMightDisappearWarning:
+    '⚠️ Dies ist eine Testumgebung. Bitte erstell hier noch keine Inhalte, die du langfristig behalten willst.',
   addPluginsModal: {
     searchInputPlaceholder: 'Suche...',
     basicPluginsTitle: 'Inhalte',

--- a/packages/editor/src/i18n/strings/de/edit.ts
+++ b/packages/editor/src/i18n/strings/de/edit.ts
@@ -6,7 +6,7 @@ export const editStrings = {
     'Willst du wirklich die Seite verlassen ohne zu speichern?',
   noChangesWarning: 'Bisher hast du nichts geändert',
   savedContentMightDisappearWarning:
-    '⚠️ Dies ist eine Testumgebung. Bitte erstell hier noch keine Inhalte, die du langfristig behalten willst.',
+    '⚠️ Dies ist eine Testumgebung. Bitte erstelle hier noch keine Inhalte, die du langfristig behalten willst.',
   addPluginsModal: {
     searchInputPlaceholder: 'Suche...',
     basicPluginsTitle: 'Inhalte',

--- a/packages/editor/src/i18n/strings/en/edit.ts
+++ b/packages/editor/src/i18n/strings/en/edit.ts
@@ -4,6 +4,8 @@ export const editStrings = {
   lang: 'en',
   confirmRouteChange: 'Are you sure you want to leave without saving?',
   noChangesWarning: 'Nothing changed so there is no need to save yet',
+  savedContentMightDisappearWarning:
+    '⚠️ This is a test environment. Please do not create content that you want to keep long term here.',
   addPluginsModal: {
     searchInputPlaceholder: 'Search...',
     basicPluginsTitle: 'Content Elements',

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -29,4 +29,5 @@ export const defaultSerloEditorProps = {
   plugins: defaultPlugins,
   onChange: undefined,
   language: 'de' as SupportedLanguage,
+  isProductionEnvironment: false,
 }

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -31,6 +31,7 @@ export interface SerloEditorProps {
   onChange?: (state: StorageFormat) => void
   language?: SupportedLanguage
   editorVariant: EditorVariant
+  isProductionEnvironment?: boolean
   _testingSecret?: string | null
   _ltik?: string
 }
@@ -43,6 +44,7 @@ export function SerloEditor(props: SerloEditorProps) {
     onChange,
     language,
     plugins,
+    isProductionEnvironment,
     _testingSecret,
     _ltik,
   } = {
@@ -72,6 +74,7 @@ export function SerloEditor(props: SerloEditorProps) {
     <StaticStringsProvider value={staticStrings}>
       <EditStringsProvider value={editStrings}>
         <LtikContext.Provider value={_ltik}>
+          {!isProductionEnvironment ? renderTestEnvironmentWarning() : null}
           <Editor
             initialState={migratedState.document}
             onChange={handleDocumentChange}
@@ -94,5 +97,13 @@ export function SerloEditor(props: SerloEditorProps) {
       editorVersion: getEditorVersion(),
       document,
     })
+  }
+
+  function renderTestEnvironmentWarning() {
+    return (
+      <div className="bg-editor-primary-100 px-1.5 py-0.5 text-sm">
+        {editStrings.savedContentMightDisappearWarning}
+      </div>
+    )
   }
 }

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -76,7 +76,7 @@ export function SerloEditor(props: SerloEditorProps) {
       <EditStringsProvider value={editStrings}>
         <EditorVariantContext.Provider value={editorVariant}>
           <LtikContext.Provider value={_ltik}>
-            {!isProductionEnvironment ? renderTestEnvironmentWarning() : null}
+            {isProductionEnvironment ? null : renderTestEnvironmentWarning()}
             <Editor
               initialState={migratedState.document}
               onChange={handleDocumentChange}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/206604ad-257a-4c01-ab30-53051b5670fd)

Background: Some people were excited to use the editor and started to create content they want to keep even in the test environments. But for the devs this makes it more complicated. 

Change: All test environments show a warning label above the editor. 

@elbotho @GregorZupan Any wishes in terms of design / wording? Would you prefer to not have something like this?