### PR TITLE
fix(editor): Inline math should not have a line break when opening latex editor

### DIFF
--- a/packages/editor/src/math/editor.tsx
+++ b/packages/editor/src/math/editor.tsx
@@ -54,7 +54,7 @@ export function MathEditor(props: MathEditorProps) {
   const isVisualMode = (visual && !hasError) || false
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} className={props.inline ? 'inline-block' : ''}>
       <MathHelpModal isHelpOpen={isHelpOpen} setIsHelpOpen={setIsHelpOpen} />
       {renderChildren()}
     </div>

--- a/packages/editor/src/math/math-editor-overlay.tsx
+++ b/packages/editor/src/math/math-editor-overlay.tsx
@@ -14,7 +14,7 @@ export function MathEditorOverlay({
 
   return (
     <div
-      className="fixed bottom-0 z-50 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
+      className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 rounded-t-xl bg-editor-primary-100 p-3 shadow-menu"
       // Stops double/triple clicks inside the textArea field / modal to close
       // the overlay (see #2700)
       onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
Fixes https://github.com/serlo/frontend/issues/3898