### PR TITLE
fix(editor): commit temporary actions to history only after resolving them

### DIFF
--- a/packages/editor/src/store/history/saga-actions.ts
+++ b/packages/editor/src/store/history/saga-actions.ts
@@ -9,5 +9,5 @@ export const runCommitActionToHistorySaga = createAction<ReversibleAction[]>(
 
 export const runCommitTemporaryActionToHistorySaga = createAction<{
   initial: ReversibleAction[]
-  executor?: StateExecutor<ReversibleAction[]>
+  executor: StateExecutor<ReversibleAction[]>
 }>('history/commitTemporaryActionToHistory')

--- a/packages/editor/src/store/history/saga.ts
+++ b/packages/editor/src/store/history/saga.ts
@@ -58,12 +58,12 @@ function* resolveSaga(chan: Channel<ChannelAction>) {
     const payload: ChannelAction = yield take(chan)
     const actions = payload.resolve || payload.reject || []
 
-    yield put(pureCommitActionToHistory({ combine: false, actions }))
-
     // Saga will silently fail if a frozen action is passed to `put`.
     // Therefore, we first clone the action.
     // More info: https://github.com/redux-saga/redux-saga/issues/1254
     yield all(actions.map((a) => put(R.clone(a.action))))
+
+    yield put(pureCommitActionToHistory({ combine: false, actions }))
 
     if (payload.resolve || payload.reject) {
       break

--- a/packages/editor/src/store/history/saga.ts
+++ b/packages/editor/src/store/history/saga.ts
@@ -39,13 +39,11 @@ function* temporaryCommitSaga(
     }
   }
 
-  if (action.payload.executor) {
-    action.payload.executor(
-      createPutToChannel('resolve'),
-      createPutToChannel('reject')
-    )
-    yield call(resolveSaga, chan)
-  }
+  action.payload.executor(
+    createPutToChannel('resolve'),
+    createPutToChannel('reject')
+  )
+  yield call(resolveSaga, chan)
 }
 
 interface ChannelAction {


### PR DESCRIPTION
Resolves #4241 

Note: First commit is only cleaning up, second commit fixes the bug.

This took way longer to figure out than I'd like to admit 😬
The editor emits `onChange` events when actions are committed to history, not when actions are resolved.
For most changes, this doesn't matter, as we first resolve actions, then commit them to history.
There are, however, these "temporary" actions, used in `asyncScalar`. One use-case of `asyncScalar` is uploading an image, where we had the bug. And in these "temporary" actions, we were first committing actions to history, then resolving them, which led the editor to emit `onChange` before its state was updated.

I snooped around the code to see if I could find any reason for this difference between regular and "temporary" actions, and I couldn't find any. I also tested the editor, and everything seems to work fine, but it would be great if you could test a bit as well.

Explanation for "temporary" actions (`asyncScalar`): I believe these were initially created to support loading states of async actions. So once a user uploads an image, a temporary action would show a loading screen, and then a normal action would show the uploaded image and the temporary action would be removed from history. That would make sure that undo/redo works as expected -- never showing the loading screen. I couldn't figure out how to use this, though. Either the feature was never finished, or we broke it unknowingly.

@elbotho This also fixes the ___editor_preview -- the right side will now show the image as soon as it's uploaded.