### PR TITLE
fix(plugin-edusharing): allow focusing the plugin by clicking on the content

### DIFF
--- a/packages/editor/src/plugins/edusharing-asset/editor.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/editor.tsx
@@ -59,22 +59,33 @@ export function EdusharingAssetEditor({
     <>
       {renderPluginToolbar()}
       {renderModal(ltik)}
-      <EdusharingAssetRenderer
-        nodeId={
-          state.edusharingAsset.defined
-            ? state.edusharingAsset.nodeId.value
-            : undefined
-        }
-        repositoryId={
-          state.edusharingAsset.defined
-            ? state.edusharingAsset.repositoryId.value
-            : undefined
-        }
-        ltik={ltik}
-        contentWidth={contentWidth.defined ? contentWidth.value : undefined}
-      />
+      <div className="relative">
+        <EdusharingAssetRenderer
+          nodeId={
+            state.edusharingAsset.defined
+              ? state.edusharingAsset.nodeId.value
+              : undefined
+          }
+          repositoryId={
+            state.edusharingAsset.defined
+              ? state.edusharingAsset.repositoryId.value
+              : undefined
+          }
+          ltik={ltik}
+          contentWidth={contentWidth.defined ? contentWidth.value : undefined}
+        />
+        {renderOverlay()}
+      </div>
     </>
   )
+
+  // Transparent overlay while the edu-sharing plugin is unfocused. Clicking it will focus the plugin and let the user interact with the content.
+  // Explanation: Content is inside an iframe. Clicking within the iframe does sadly not change the editor focus automatically. Solutions I found are not easy and don't work reliably. So, we require an extra click from the user to be able to interact with the content in the editor.
+  function renderOverlay() {
+    if (focused) return null
+
+    return <div className="absolute left-0 top-0 z-[15] h-full w-full"></div>
+  }
 
   function renderPluginToolbar() {
     if (!focused) return null

--- a/packages/editor/src/plugins/edusharing-asset/editor.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/editor.tsx
@@ -72,6 +72,7 @@ export function EdusharingAssetEditor({
         }
         ltik={ltik}
         contentWidth={contentWidth.defined ? contentWidth.value : undefined}
+        id={id}
       />
     </>
   )

--- a/packages/editor/src/plugins/edusharing-asset/editor.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/editor.tsx
@@ -72,7 +72,6 @@ export function EdusharingAssetEditor({
         }
         ltik={ltik}
         contentWidth={contentWidth.defined ? contentWidth.value : undefined}
-        id={id}
       />
     </>
   )

--- a/packages/editor/src/plugins/edusharing-asset/renderer.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/renderer.tsx
@@ -41,8 +41,9 @@ export function EdusharingAssetRenderer(props: {
   repositoryId?: string
   ltik: string
   contentWidth: string | undefined
+  id?: string
 }) {
-  const { nodeId, repositoryId, ltik, contentWidth } = props
+  const { nodeId, repositoryId, ltik, contentWidth, id } = props
 
   const [embedHtml, setEmbedHtml] = useState<string | null>(null)
   const [defineContainerHeight, setDefineContainerHeight] =
@@ -327,14 +328,17 @@ export function EdusharingAssetRenderer(props: {
       >
         {defineContainerHeight ? (
           <iframe
+            id={id}
             srcDoc={embedHtml}
             style={{
               width: '100%',
               height: '100%',
             }}
+            onLoad={registerIframeClickHandler}
           />
         ) : (
           <MemoizedIframeResizer
+            id={id}
             heightCalculationMethod="lowestElement"
             checkOrigin={false}
             srcDoc={embedHtml}
@@ -342,10 +346,21 @@ export function EdusharingAssetRenderer(props: {
               width: '1px',
               minWidth: '100%',
             }}
+            onLoad={registerIframeClickHandler}
           />
         )}
       </div>
     )
+  }
+
+  // https://stackoverflow.com/a/6452599
+  function registerIframeClickHandler() {
+    const element = document.getElementById(id) as HTMLIFrameElement
+    if (!element) return
+    if (!element.contentWindow) return
+    element.contentWindow.document.body.onclick = () => {
+      console.log(`Clicked iframe id=${id}`)
+    }
   }
 }
 

--- a/packages/editor/src/plugins/edusharing-asset/renderer.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/renderer.tsx
@@ -41,9 +41,8 @@ export function EdusharingAssetRenderer(props: {
   repositoryId?: string
   ltik: string
   contentWidth: string | undefined
-  id?: string
 }) {
-  const { nodeId, repositoryId, ltik, contentWidth, id } = props
+  const { nodeId, repositoryId, ltik, contentWidth } = props
 
   const [embedHtml, setEmbedHtml] = useState<string | null>(null)
   const [defineContainerHeight, setDefineContainerHeight] =
@@ -328,17 +327,14 @@ export function EdusharingAssetRenderer(props: {
       >
         {defineContainerHeight ? (
           <iframe
-            id={id}
             srcDoc={embedHtml}
             style={{
               width: '100%',
               height: '100%',
             }}
-            onLoad={registerIframeClickHandler}
           />
         ) : (
           <MemoizedIframeResizer
-            id={id}
             heightCalculationMethod="lowestElement"
             checkOrigin={false}
             srcDoc={embedHtml}
@@ -346,21 +342,10 @@ export function EdusharingAssetRenderer(props: {
               width: '1px',
               minWidth: '100%',
             }}
-            onLoad={registerIframeClickHandler}
           />
         )}
       </div>
     )
-  }
-
-  // https://stackoverflow.com/a/6452599
-  function registerIframeClickHandler() {
-    const element = document.getElementById(id) as HTMLIFrameElement
-    if (!element) return
-    if (!element.contentWindow) return
-    element.contentWindow.document.body.onclick = () => {
-      console.log(`Clicked iframe id=${id}`)
-    }
   }
 }
 

--- a/packages/editor/src/plugins/edusharing-asset/renderer.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/renderer.tsx
@@ -95,7 +95,7 @@ export function EdusharingAssetRenderer(props: {
   }, [nodeId, repositoryId, ltik])
 
   return (
-    <figure className="w-full">
+    <figure className="relative z-[15] w-full">
       <div className="mx-side">
         {embedHtml ? (
           renderEmbed()
@@ -318,7 +318,7 @@ export function EdusharingAssetRenderer(props: {
     // - Missing `sandbox` -> Should put no restrictions on what the iframe can do: A) Make iframe send the same cookies as the host. B) Allow it to execute scripts. Both important to be able to fetch video.
     return (
       <div
-        className="max-w-full"
+        className="z-15 max-w-full"
         style={{
           width: contentWidth ? contentWidth : '100%',
           aspectRatio: defineContainerHeight ? '16/9' : undefined,

--- a/packages/editor/src/plugins/edusharing-asset/static.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/static.tsx
@@ -9,6 +9,7 @@ export function EdusharingAssetStaticRenderer(
 ) {
   const nodeId = props.state.edusharingAsset?.nodeId
   const repositoryId = props.state.edusharingAsset?.repositoryId
+  const id = props.id
 
   const { contentWidth: widthInPercent } = props.state
 
@@ -22,6 +23,7 @@ export function EdusharingAssetStaticRenderer(
       repositoryId={repositoryId}
       contentWidth={widthInPercent}
       ltik={ltik}
+      id={id}
     />
   )
 }

--- a/packages/editor/src/plugins/edusharing-asset/static.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/static.tsx
@@ -9,7 +9,6 @@ export function EdusharingAssetStaticRenderer(
 ) {
   const nodeId = props.state.edusharingAsset?.nodeId
   const repositoryId = props.state.edusharingAsset?.repositoryId
-  const id = props.id
 
   const { contentWidth: widthInPercent } = props.state
 
@@ -23,7 +22,6 @@ export function EdusharingAssetStaticRenderer(
       repositoryId={repositoryId}
       contentWidth={widthInPercent}
       ltik={ltik}
-      id={id}
     />
   )
 }


### PR DESCRIPTION
**Before**

Clicking on the embedded content did not focus the editor plugin because it is inside an iframe. It was nearly impossible to make the toolbar show up to select another type of content or change the size. 

**After**

Render an overlay over the iframe if the plugin is unfocused to detect if the user wants to focus the plugin. After this initial click to focus the plugin the user can interact with it. 