### PR TITLE
fix(editor): remove fixed size from text area icon

### DIFF
--- a/packages/editor/src/editor-ui/assets/plugin-icons/icon-text-area.svg
+++ b/packages/editor/src/editor-ui/assets/plugin-icons/icon-text-area.svg
@@ -1,4 +1,4 @@
-<svg width="90" height="60" viewBox="0 0 90 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 90 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="90" height="60" rx="4" fill="#FFEFDA"/>
 <rect x="22.5" y="13" width="45" height="3" fill="#FFBE5D"/>
 <rect x="22.5" y="19" width="30" height="3" fill="#FFBE5D"/>


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/d298528f-b7d7-4612-b682-60b3236b96dd)
