### PR TITLE
fix(plugin-edusharing): keep overlay but let pointer events pass through

### DIFF
--- a/packages/editor/src/editor-ui/assets/edusharing.svg
+++ b/packages/editor/src/editor-ui/assets/edusharing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" xml:space="preserve">
 	<path fill="#58819B" d="m18.214 21.509-3.708-6.426 3.708-6.426h7.417l3.708 6.426-3.708 6.426z" />
 	<path fill="#9AC4D8" d="M5.208 13.853 1.5 7.426 5.208 1h7.417l3.708 6.426-3.708 6.427z" />
 	<path fill="#2F5775" d="M5.208 29.167 1.5 22.738l3.708-6.425h7.417l3.708 6.425-3.708 6.429z" />

--- a/packages/editor/src/plugins/edusharing-asset/editor.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/editor.tsx
@@ -1,6 +1,7 @@
 import { EditorMetaContext } from '@editor/core/contexts/editor-meta-context'
 import { EditorModal } from '@editor/editor-ui/editor-modal'
 import { useEditStrings } from '@editor/i18n/edit-strings-provider'
+import { cn } from '@editor/utils/cn'
 import * as t from 'io-ts'
 import { useContext, useEffect, useRef, useState } from 'react'
 
@@ -79,12 +80,20 @@ export function EdusharingAssetEditor({
     </>
   )
 
-  // Transparent overlay while the edu-sharing plugin is unfocused. Clicking it will focus the plugin and let the user interact with the content.
+  // Transparent overlay. If the plugin is ...
+  // ... unfocused -> Clicking it will focus the plugin
+  // ... focused -> Clicking it does nothing and the events are handled in the iframe behind it
   // Explanation: Content is inside an iframe. Clicking within the iframe does sadly not change the editor focus automatically. Solutions I found are not easy and don't work reliably. So, we require an extra click from the user to be able to interact with the content in the editor.
   function renderOverlay() {
-    if (focused) return null
-
-    return <div className="absolute left-0 top-0 z-[15] h-full w-full"></div>
+    const captureClick = !focused
+    return (
+      <div
+        className={cn(
+          'absolute left-0 top-0 z-[15] h-full w-full',
+          captureClick ? 'pointer-events-auto' : 'pointer-events-none'
+        )}
+      ></div>
+    )
   }
 
   function renderPluginToolbar() {

--- a/packages/editor/src/plugins/edusharing-asset/renderer.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/renderer.tsx
@@ -100,8 +100,8 @@ export function EdusharingAssetRenderer(props: {
         {embedHtml ? (
           renderEmbed()
         ) : (
-          <div className="flex justify-center">
-            <EdusharingIcon />
+          <div className="flex aspect-[16/9] w-full items-center justify-center">
+            <EdusharingIcon style={{ width: '5rem', height: '5rem' }} />
           </div>
         )}
       </div>


### PR DESCRIPTION
**Before** 
Clicking the overlay focused the plugin but also removed the overlay. This caused the toolbar to stay but the plugin focus shadow to disappear. 

**After**
The overlay stays (becomes `document.activeElement`) but lets pointer events pass through so that the user can interact with the iframe behind. 

Still somehow broken because the plugin focus shadow disappears when clicking the iframe again. But I would leave it like that. 