### PR TITLE
fix(editor): Render visual/latex select in math toolbar

### DIFF
--- a/packages/editor/src/math/editor.tsx
+++ b/packages/editor/src/math/editor.tsx
@@ -163,7 +163,11 @@ export function MathEditor(props: MathEditorProps) {
     const isShadowRootNode = isShadowRoot(root)
     const target =
       (isShadowRootNode || isDocument
-        ? root.querySelector<HTMLDivElement>('.toolbar-controls-target')
+        ? root.querySelector<HTMLDivElement>(
+            // Either equations and toolbar, or plugin-text and toolbar (for
+            // nested math plugins)
+            '.plugin-text .toolbar-controls-target, .plugin-equations .toolbar-controls-target'
+          )
         : document.body) ?? document.body
 
     return createPortal(children, target)

--- a/packages/editor/src/math/editor.tsx
+++ b/packages/editor/src/math/editor.tsx
@@ -163,9 +163,7 @@ export function MathEditor(props: MathEditorProps) {
     const isShadowRootNode = isShadowRoot(root)
     const target =
       (isShadowRootNode || isDocument
-        ? root.querySelector<HTMLDivElement>(
-            '.plugin-text .toolbar-controls-target'
-          )
+        ? root.querySelector<HTMLDivElement>('.toolbar-controls-target')
         : document.body) ?? document.body
 
     return createPortal(children, target)


### PR DESCRIPTION
**Before**
![image](https://github.com/user-attachments/assets/853f6613-86f8-466b-84a8-79c9d1898872)


**After**
![image](https://github.com/user-attachments/assets/cba7dba4-eee0-4303-b039-a4d013e7d212)
