### PR TITLE
refactor(image-plugin): Show better error messages when the image upload fails

### DIFF
--- a/packages/editor/src/editor-integration/image-with-testing-config.ts
+++ b/packages/editor/src/editor-integration/image-with-testing-config.ts
@@ -127,7 +127,10 @@ export function createReadAndUploadFile(secret: string) {
 
     const { data } = (await response.json()) as { data: MediaUploadQuery }
 
-    if (!data?.media?.newUpload) {
+    if (
+      !data?.media?.newUpload?.uploadUrl ||
+      !data.media.newUpload.urlAfterUpload
+    ) {
       // eslint-disable-next-line no-console
       console.error('Server responded with following invalid data: ', data)
       throw new Error('Invalid response format from server')
@@ -141,10 +144,6 @@ export function createReadAndUploadFile(secret: string) {
 
     if (!uploadResponse.ok) {
       throw new Error(`Upload failed with status: ${uploadResponse.status}`)
-    }
-
-    if (!data?.media?.newUpload?.urlAfterUpload) {
-      throw new Error('Invalid response format from server')
     }
 
     return {

--- a/packages/editor/src/editor-integration/image-with-testing-config.ts
+++ b/packages/editor/src/editor-integration/image-with-testing-config.ts
@@ -76,7 +76,7 @@ export const createTestingImagePlugin = (secret: string) => {
 }
 
 function createUploadImageHandler(secret: string) {
-  const readFile = createReadFile(secret)
+  const readAndUploadFile = createReadAndUploadFile(secret)
   return async function uploadImageHandler(file: File): Promise<string> {
     const validation = validateFile(file)
     if (!validation.valid) {
@@ -86,7 +86,7 @@ function createUploadImageHandler(secret: string) {
     }
 
     try {
-      const result = await readFile(file)
+      const result = await readAndUploadFile(file)
       return result.dataUrl
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -99,8 +99,8 @@ function createUploadImageHandler(secret: string) {
   }
 }
 
-export function createReadFile(secret: string) {
-  return async function readFile(file: File): Promise<LoadedFile> {
+export function createReadAndUploadFile(secret: string) {
+  return async function readAndUploadFile(file: File): Promise<LoadedFile> {
     if (!secret) {
       throw new Error('Missing secret for image plugin!')
     }

--- a/packages/editor/src/editor-integration/image-with-testing-config.ts
+++ b/packages/editor/src/editor-integration/image-with-testing-config.ts
@@ -45,6 +45,10 @@ enum FileErrorCode {
   BAD_EXTENSION,
   FILE_TOO_BIG,
   UPLOAD_FAILED,
+  UNAUTHORIZED,
+  SECRET_MISSING,
+  INVALID_RESPONSE,
+  NETWORK_ERROR,
 }
 
 export interface FileError {
@@ -91,7 +95,12 @@ function createUploadImageHandler(secret: string) {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Upload failed:', error)
-      const errors = handleErrors([FileErrorCode.UPLOAD_FAILED])
+      const errorCode =
+        error instanceof Error
+          ? Number(error.message) || FileErrorCode.UPLOAD_FAILED
+          : FileErrorCode.UPLOAD_FAILED
+
+      const errors = handleErrors([errorCode])
       showErrorToast(errors)
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
       return Promise.reject(errors)
@@ -99,10 +108,20 @@ function createUploadImageHandler(secret: string) {
   }
 }
 
+interface GraphQlResponse {
+  data: MediaUploadQuery | null
+  errors?: Array<{
+    message: string
+    extensions?: {
+      code?: string
+    }
+  }>
+}
+
 export function createReadAndUploadFile(secret: string) {
   return async function readAndUploadFile(file: File): Promise<LoadedFile> {
     if (!secret) {
-      throw new Error('Missing secret for image plugin!')
+      throw new Error(FileErrorCode.SECRET_MISSING.toString())
     }
 
     const endpoint = 'https://api.serlo-staging.dev/graphql'
@@ -122,18 +141,28 @@ export function createReadAndUploadFile(secret: string) {
     })
 
     if (!response.ok) {
-      throw new Error(`Failed to get upload URL: ${response.status}`)
+      throw new Error(FileErrorCode.NETWORK_ERROR.toString())
     }
 
-    const { data } = (await response.json()) as { data: MediaUploadQuery }
+    const { data, errors } = (await response.json()) as GraphQlResponse
+
+    if (errors?.length) {
+      // eslint-disable-next-line no-console
+      console.error('GraphQL errors:', errors)
+      if (errors[0]?.extensions?.code === 'UNAUTHENTICATED') {
+        throw new Error(FileErrorCode.UNAUTHORIZED.toString())
+      }
+      throw new Error(FileErrorCode.UPLOAD_FAILED.toString())
+    }
 
     if (
+      !data ||
       !data?.media?.newUpload?.uploadUrl ||
       !data.media.newUpload.urlAfterUpload
     ) {
       // eslint-disable-next-line no-console
       console.error('Server responded with following invalid data: ', data)
-      throw new Error('Invalid response format from server')
+      throw new Error(FileErrorCode.INVALID_RESPONSE.toString())
     }
 
     const uploadResponse = await fetch(data.media.newUpload.uploadUrl, {
@@ -143,7 +172,7 @@ export function createReadAndUploadFile(secret: string) {
     })
 
     if (!uploadResponse.ok) {
-      throw new Error(`Upload failed with status: ${uploadResponse.status}`)
+      throw new Error(FileErrorCode.UPLOAD_FAILED.toString())
     }
 
     return {
@@ -181,6 +210,14 @@ function errorCodeToMessage(error: FileErrorCode) {
       return 'Filesize is too big'
     case FileErrorCode.UPLOAD_FAILED:
       return 'Error while uploading'
+    case FileErrorCode.UNAUTHORIZED:
+      return 'You are not authorized to upload images. Ensure the testingSecret is correct!'
+    case FileErrorCode.SECRET_MISSING:
+      return 'Missing authentication credentials (testingSecret)!'
+    case FileErrorCode.INVALID_RESPONSE:
+      return 'Server returned invalid data'
+    case FileErrorCode.NETWORK_ERROR:
+      return 'Network error while uploading'
   }
 }
 

--- a/packages/editor/src/editor-integration/image-with-testing-config.ts
+++ b/packages/editor/src/editor-integration/image-with-testing-config.ts
@@ -80,62 +80,77 @@ function createUploadImageHandler(secret: string) {
   return async function uploadImageHandler(file: File): Promise<string> {
     const validation = validateFile(file)
     if (!validation.valid) {
-      onError(validation.errors)
+      showErrorToast(validation.errors)
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
       return Promise.reject(validation.errors)
     }
 
-    return (await readFile(file)).dataUrl
+    try {
+      const result = await readFile(file)
+      return result.dataUrl
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Upload failed:', error)
+      const errors = handleErrors([FileErrorCode.UPLOAD_FAILED])
+      showErrorToast(errors)
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+      return Promise.reject(errors)
+    }
   }
 }
 
 export function createReadFile(secret: string) {
   return async function readFile(file: File): Promise<LoadedFile> {
-    return new Promise((resolve, reject) => {
-      async function runFetch() {
-        const endpoint = 'https://api.serlo-staging.dev/graphql'
-        const response = await fetch(endpoint, {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            'X-SERLO-EDITOR-TESTING': secret,
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            query: uploadUrlQuery,
-            variables: {
-              mediaType: mimeTypesToMediaType[file.type as SupportedMimeType],
-            },
-          }),
-        })
-        const { data } = (await response.json()) as { data: MediaUploadQuery }
-        const reader = new FileReader()
+    if (!secret) {
+      throw new Error('Missing secret for image plugin!')
+    }
 
-        reader.onload = async function (e: ProgressEvent) {
-          if (!e.target) return
-
-          try {
-            const response = await fetch(data.media.newUpload.uploadUrl, {
-              method: 'PUT',
-              headers: { 'Content-Type': file.type },
-              body: file,
-            })
-
-            if (response.status !== 200) reject()
-            resolve({
-              file,
-              dataUrl: data.media.newUpload.urlAfterUpload,
-            })
-          } catch {
-            reject()
-          }
-        }
-
-        reader.readAsDataURL(file)
-      }
-
-      void runFetch()
+    const endpoint = 'https://api.serlo-staging.dev/graphql'
+    const response = await fetch(endpoint, {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-SERLO-EDITOR-TESTING': secret,
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        query: uploadUrlQuery,
+        variables: {
+          mediaType: mimeTypesToMediaType[file.type as SupportedMimeType],
+        },
+      }),
     })
+
+    if (!response.ok) {
+      throw new Error(`Failed to get upload URL: ${response.status}`)
+    }
+
+    const { data } = (await response.json()) as { data: MediaUploadQuery }
+
+    if (!data?.media?.newUpload) {
+      // eslint-disable-next-line no-console
+      console.error('Server responded with following invalid data: ', data)
+      throw new Error('Invalid response format from server')
+    }
+
+    const uploadResponse = await fetch(data.media.newUpload.uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': file.type },
+      body: file,
+    })
+
+    if (!uploadResponse.ok) {
+      throw new Error(`Upload failed with status: ${uploadResponse.status}`)
+    }
+
+    if (!data?.media?.newUpload?.urlAfterUpload) {
+      throw new Error('Invalid response format from server')
+    }
+
+    return {
+      file,
+      dataUrl: data.media.newUpload.urlAfterUpload,
+    }
   }
 }
 
@@ -151,7 +166,7 @@ function handleErrors(errors: FileErrorCode[]): FileError[] {
   }))
 }
 
-function onError(errors: FileError[]): void {
+function showErrorToast(errors: FileError[]): void {
   showToastNotice(errors.map((error) => error.message).join('\n'), 'warning')
 }
 

--- a/packages/editor/src/plugins/image/utils/upload-file.ts
+++ b/packages/editor/src/plugins/image/utils/upload-file.ts
@@ -60,16 +60,31 @@ async function uploadFile({
     handleError(errorMessage)
   })
 
-  const data = (await result?.json()) as {
+  if (result && !result.ok) {
+    const error = new Error('Failed to get signed URL')
+    handleError(error.message)
+    return Promise.reject(error)
+  }
+
+  const data = (await result?.json().catch(() => null)) as {
     signedUrl: string
     fileUrl: string
+  } | null
+  if (!data) {
+    const error = new Error('Failed to get signed URL')
+    handleError(error.message)
+
+    return Promise.reject(error)
   }
-  if (!data) return Promise.reject(new Error('Could not get signed URL'))
 
   const { signedUrl, fileUrl } = data
 
   const success = await uploadToBucket({ file, signedUrl })
-  if (!success) return Promise.reject(new Error('Could not upload file'))
+  if (!success) {
+    const error = new Error('Failed to upload file')
+    handleError(error.message)
+    return Promise.reject(error)
+  }
   return Promise.resolve(fileUrl)
 }
 


### PR DESCRIPTION
**Before**

No error message 

**After** (old upload)

![image](https://github.com/user-attachments/assets/ae02ab37-a001-45c6-9eb2-822348f609e9)
