### PR TITLE
fix(editor): Modal in moodle

### DIFF
--- a/packages/editor/src/editor-ui/editor-modal.tsx
+++ b/packages/editor/src/editor-ui/editor-modal.tsx
@@ -104,6 +104,8 @@ export function EditorModal({
   )
 }
 
+// The moodle navigation bar has a z-index of 1030... We are using 1040 to make
+// sure the modal can be on top and is not cut off
 export const defaultModalOverlayStyles = cn(
-  'fixed bottom-0 left-0 right-0 top-0 z-[101] bg-white bg-opacity-75'
+  'fixed bottom-0 left-0 right-0 top-0 z-[1040] bg-white bg-opacity-75'
 )


### PR DESCRIPTION
I don't love it, but for the modal to not collide with the navigation bar of Moodle, we'd need a z-index higher than 1030 😬 

![image](https://github.com/user-attachments/assets/dedbe708-4ac7-49a1-af76-f4fb2f71553a)
