### PR TITLE
fix(interactive-video): fix focus bug when creating new exercise

### DIFF
--- a/packages/editor/src/plugins/interactive-video/editor/overlay-content-modal.tsx
+++ b/packages/editor/src/plugins/interactive-video/editor/overlay-content-modal.tsx
@@ -36,6 +36,7 @@ export function OverlayContentModal({
         ref={titleRef}
         onBlur={(e) => {
           // hack to prevent the exercise from stealing focus when loading
+          // it seems it's being blured more than once and "> 2" worked well in testing
           if (refocusedCount.current > 2) return
           setTimeout(() => e.target.focus())
           refocusedCount.current++

--- a/packages/editor/src/plugins/interactive-video/editor/overlay-content-modal.tsx
+++ b/packages/editor/src/plugins/interactive-video/editor/overlay-content-modal.tsx
@@ -18,6 +18,7 @@ export function OverlayContentModal({
   const pluginStrings = useEditStrings().plugins.interactiveVideo
 
   const titleRef = useRef<HTMLInputElement>(null)
+  const refocusedCount = useRef<number>(0)
 
   return (
     <EditorModal
@@ -33,6 +34,12 @@ export function OverlayContentModal({
       </div>
       <input
         ref={titleRef}
+        onBlur={(e) => {
+          // hack to prevent the exercise from stealing focus when loading
+          if (refocusedCount.current > 2) return
+          setTimeout(() => e.target.focus())
+          refocusedCount.current++
+        }}
         value={title.value}
         onChange={(e) => title.set(e.target.value)}
         className={cn(


### PR DESCRIPTION
For https://linear.app/serlo/issue/EDTR-257/focus-jumps-from-title-to-exercise

[Demo](https://frontend-git-fix-interactive-vid-focus-hack-serlo.vercel.app/___editor_preview?state=%7B%22plugin%22%3A%22rows%22%2C%22state%22%3A%5B%7B%22plugin%22%3A%22interactiveVideo%22%2C%22state%22%3A%7B%22video%22%3A%7B%22plugin%22%3A%22video%22%2C%22state%22%3A%7B%22src%22%3A%22https%3A%2F%2Fwww.youtube-nocookie.com%2Fembed%2Fh116QoLFK0o%3Fautoplay%3D1%26html5%3D1%22%2C%22alt%22%3A%22%22%7D%2C%22id%22%3A%2293b3a0d7-9598-40ff-a3c8-0fb7a4160f11%22%7D%2C%22marks%22%3A%5B%5D%7D%2C%22id%22%3A%225e3f244e-5d90-4060-93ef-7f714bd7d3a4%22%7D%5D%7D)


@hejtful are you okay with this level of focus hacking?