### PR TITLE
fix(moodle): prevent style collision in moodle

### DIFF
--- a/packages/editor/src/editor-ui/preview-overlay-simple.tsx
+++ b/packages/editor/src/editor-ui/preview-overlay-simple.tsx
@@ -16,7 +16,7 @@ export function PreviewOverlaySimple({
       <div
         className={cn(
           'absolute top-0 z-20 h-full w-full',
-          previewActive ? 'hidden' : 'bg-white bg-opacity-80',
+          previewActive ? 'hidden' : 'bg-[#fefefe] bg-opacity-80',
           fullOpacity ? 'bg-opacity-0' : ''
         )}
       />

--- a/packages/editor/src/plugins/image-gallery/components/drag-and-drop-overlay.tsx
+++ b/packages/editor/src/plugins/image-gallery/components/drag-and-drop-overlay.tsx
@@ -36,7 +36,7 @@ export function DragAndDropOverlay({
       ref={ref}
       onClick={onClick}
       className={cn(
-        'absolute inset-0 bg-white active:bg-opacity-60',
+        'absolute inset-0 bg-[#fefefe] active:bg-opacity-60',
         isDragging
           ? 'cursor-grabbing bg-opacity-20'
           : 'cursor-grab bg-opacity-0'


### PR DESCRIPTION
Super quick & dirty. 

Class `bg-white` is overwritten by outside context in moodle. So we use `bg-[#FEFEFE]` (barely white) instead. 

This fixes the image gallery images not showing up and the exercise preview not showing up. 

Followup: Setup tailwind prefixes. I guess this will not be the last case where we could have css class name collisions. 