### PR TITLE
refactor: export dispatchReplaceRootDocument from package

### DIFF
--- a/apps/web/src/serlo-editor-integration/components/external-revision-loader.tsx
+++ b/apps/web/src/serlo-editor-integration/components/external-revision-loader.tsx
@@ -1,6 +1,4 @@
-import { TemplatePluginType } from '@editor/package'
-import { runReplaceDocumentSaga, useAppDispatch } from '@editor/store'
-import { ROOT } from '@editor/store/root/constants'
+import { type BaseEditor, TemplatePluginType } from '@editor/package'
 import { faFileImport } from '@fortawesome/free-solid-svg-icons'
 import request from 'graphql-request'
 import NProgress from 'nprogress'
@@ -41,25 +39,20 @@ const pluginsWithContentLoaders = Object.keys(templateTypeToUuidType)
 
 export function ExternalRevisionLoader<T>({
   templateType,
+  dispatchReplaceRootDocument,
 }: {
   templateType: TemplatePluginType
+  dispatchReplaceRootDocument: BaseEditor['dispatchReplaceRootDocument']
 }) {
   const [showRevisions, setShowRevisions] = useState(false)
 
   const { strings } = useInstanceData()
 
-  const dispatch = useAppDispatch()
   const handleReplace = useCallback(
     (newState: unknown) => {
-      dispatch(
-        runReplaceDocumentSaga({
-          id: ROOT,
-          pluginType: templateType,
-          state: newState,
-        })
-      )
+      dispatchReplaceRootDocument(templateType, newState)
     },
-    [dispatch, templateType]
+    [dispatchReplaceRootDocument, templateType]
   )
 
   if (!pluginsWithContentLoaders.includes(templateType)) return null

--- a/apps/web/src/serlo-editor-integration/serlo-editor.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-editor.tsx
@@ -81,6 +81,9 @@ export function SerloEditor({
                   templateType={
                     (initialState as { plugin: TemplatePluginType }).plugin
                   }
+                  dispatchReplaceRootDocument={
+                    editor.dispatchReplaceRootDocument
+                  }
                 />
               ) : null}
               {editor.element}

--- a/packages/editor/src/core/editor-children.tsx
+++ b/packages/editor/src/core/editor-children.tsx
@@ -10,6 +10,7 @@ import {
   persistHistory,
   undo,
   redo,
+  runReplaceDocumentSaga,
   selectPendingChanges,
   selectHasUndoActions,
   selectHasRedoActions,
@@ -45,6 +46,12 @@ export function EditorChildren({ children }: { children: EditorRenderProps }) {
   const selectRootDocument = useCallback(() => {
     return selectStaticDocument(store.getState(), ROOT)
   }, [store])
+  const dispatchReplaceRootDocument = useCallback(
+    (pluginType: string, state: unknown) => {
+      dispatch(runReplaceDocumentSaga({ id: ROOT, pluginType, state }))
+    },
+    [dispatch]
+  )
 
   const editor = <SubDocument id={ROOT} />
 
@@ -72,5 +79,6 @@ export function EditorChildren({ children }: { children: EditorRenderProps }) {
       dispatchPersistHistory,
     },
     selectRootDocument,
+    dispatchReplaceRootDocument,
   })
 }

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -28,6 +28,7 @@ export interface BaseEditor {
   i18n: LanguageData
   history: HistoryData
   selectRootDocument: () => AnyEditorDocument
+  dispatchReplaceRootDocument: (pluginType: string, state: unknown) => void
 }
 
 export type GetDocument = () => DocumentState | null

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -28,6 +28,7 @@ export interface BaseEditor {
   i18n: LanguageData
   history: HistoryData
   selectRootDocument: () => AnyEditorDocument
+  /** @deprecated Only temporarily exported for serlo.org. */
   dispatchReplaceRootDocument: (pluginType: string, state: unknown) => void
 }
 


### PR DESCRIPTION
Not sure if there should be a comment that it's only exported for serlo.org, other consumers might find it handy as well.