### PR TITLE
fix: render Karla font on serlo.org

### DIFF
--- a/apps/web/src/components/pages/editor/education-plugin-examples.tsx
+++ b/apps/web/src/components/pages/editor/education-plugin-examples.tsx
@@ -176,6 +176,7 @@ function ExampleWithEditSwitch({
               EditorPluginType.Injection,
               EditorPluginType.Anchor,
             ]}
+            styleReset={false}
             initialState={exampleState}
             onChange={(state) => {
               void debouncedSetState(state.document)

--- a/apps/web/src/pages/___editor_preview.tsx
+++ b/apps/web/src/pages/___editor_preview.tsx
@@ -70,6 +70,7 @@ function Content() {
         editorVariant="serlo-org"
         userId="serlo-preview-user"
         initialState={parseDocumentString(previewState)}
+        styleReset={false}
         onChange={(newState) => {
           const stringifiedNewState = JSON.stringify(newState.document)
           if (stringifiedNewState === previewState) return

--- a/apps/web/src/serlo-editor-integration/serlo-editor.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-editor.tsx
@@ -71,6 +71,7 @@ export function SerloEditor({
           EditorPluginType.H5p,
         ]}
         initialState={initialState}
+        styleReset={false}
         extraSerloPlugins={extraSerloPlugins}
         extraSerloRenderers={extraSerloRenderers}
       >

--- a/packages/editor/src/core/editor.tsx
+++ b/packages/editor/src/core/editor.tsx
@@ -54,9 +54,7 @@ export function Editor(props: EditorProps) {
           {!isSerlo ? <Toaster /> : null}
           <div
             className={cn(
-              // editor-core resets styles
-              'editor-core',
-              'mb-24 text-lg leading-cozy',
+              'editor-core mb-24 text-lg leading-cozy',
               // some undocumented style hacks
               '[&_h1]:hyphens-auto',
               '[&_a[data-key]]:hyphens-auto',

--- a/packages/editor/src/package/config.ts
+++ b/packages/editor/src/package/config.ts
@@ -31,4 +31,5 @@ export const defaultSerloEditorProps = {
   onChange: undefined,
   language: 'de' as SupportedLanguage,
   isProductionEnvironment: false,
+  styleReset: true,
 }

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -40,6 +40,7 @@ export interface SerloEditorProps {
   editorVariant: EditorVariant
   isProductionEnvironment?: boolean
   userId?: string
+  styleReset?: boolean
   _testingSecret?: string | null
   _ltik?: string
   /** @deprecated Only temporarily allowed for serlo.org. */
@@ -58,6 +59,7 @@ export function SerloEditor(props: SerloEditorProps) {
     plugins,
     isProductionEnvironment,
     userId,
+    styleReset,
     _testingSecret,
     _ltik,
     extraSerloPlugins,
@@ -97,12 +99,14 @@ export function SerloEditor(props: SerloEditorProps) {
           value={{ editorVariant, userId, ltik: _ltik }}
         >
           {isProductionEnvironment ? null : renderTestEnvironmentWarning()}
-          <Editor
-            initialState={migratedState.document}
-            onChange={handleDocumentChange}
-          >
-            {children}
-          </Editor>
+          <div className={styleReset ? 'serlo-editor-style-reset' : ''}>
+            <Editor
+              initialState={migratedState.document}
+              onChange={handleDocumentChange}
+            >
+              {children}
+            </Editor>
+          </div>
         </EditorMetaContext.Provider>
       </EditStringsProvider>
     </StaticStringsProvider>

--- a/packages/editor/src/tailwind/editor.css
+++ b/packages/editor/src/tailwind/editor.css
@@ -7,7 +7,7 @@
 * Reset all styles outside of the editor (trying to prevent style collisions)
 */
 @layer base {
-  .editor-core {
+  .serlo-editor-style-reset {
     all: initial;
     display: block;
 


### PR DESCRIPTION
Style reset has been introduced for the needs of Moodle integration here: https://github.com/serlo/frontend/pull/4372, but it's not compatible with serlo.org integration. This PR makes the style reset optional, by adding a `styleReset` property. Assuming that we want style reset for non-Serlo integrations, `styleReset` is on by default, and turned off for serlo.org.

Reintroduces Karla font to https://github.com/serlo/frontend/pull/4380.