### PR TITLE
e2e: blanks exercise fixes after editor package in web

### DIFF
--- a/e2e-tests/tests/450-blanks-exercise.ts
+++ b/e2e-tests/tests/450-blanks-exercise.ts
@@ -144,6 +144,7 @@ Scenario(
     createNewEditorEntity(I, 'exercise')
 
     I.click(BlanksExerciseButton)
+    I.waitForElement('$plugin-blanks-child-text-button', 20)
     I.click('$plugin-blanks-child-text-button')
     I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 

--- a/e2e-tests/tests/450-blanks-exercise.ts
+++ b/e2e-tests/tests/450-blanks-exercise.ts
@@ -10,10 +10,15 @@ const BlanksExerciseButton = '$add-exercise-blanksExercise'
 
 const initialTextPluginCount = 1
 
+function selectBlanksExercise(I: CodeceptJS.I) {
+  I.click(BlanksExerciseButton)
+  I.waitForElement('$plugin-blanks-child-text-button', 20)
+}
+
 Scenario('Create and remove fill in the blanks exercise', async ({ I }) => {
   createNewEditorEntity(I, 'exercise')
 
-  I.click(BlanksExerciseButton)
+  selectBlanksExercise(I)
   I.see('Aufgabe: Lückentext')
   I.click('$plugin-blanks-child-text-button')
   I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
@@ -32,7 +37,7 @@ Scenario(
   async ({ I }) => {
     createNewEditorEntity(I, 'exercise')
 
-    I.click(BlanksExerciseButton)
+    selectBlanksExercise(I)
     I.click('$plugin-blanks-child-text-button')
     I.see('Aufgabe: Lückentext')
 
@@ -45,7 +50,7 @@ Scenario(
 Scenario('Create and remove blanks through toolbar', async ({ I }) => {
   createNewEditorEntity(I, 'exercise')
 
-  I.click(BlanksExerciseButton)
+  selectBlanksExercise(I)
   I.click('$plugin-blanks-child-text-button')
   I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 
@@ -71,7 +76,7 @@ Scenario('Create and remove blanks through toolbar', async ({ I }) => {
 Scenario('Create a blank blank and type in it', async ({ I }) => {
   createNewEditorEntity(I, 'exercise')
 
-  I.click(BlanksExerciseButton)
+  selectBlanksExercise(I)
   I.click('$plugin-blanks-child-text-button')
   I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 
@@ -90,7 +95,7 @@ Scenario('Create a blank blank and type in it', async ({ I }) => {
 Scenario('Create and delete blanks with backspace/del', async ({ I }) => {
   createNewEditorEntity(I, 'exercise')
 
-  I.click(BlanksExerciseButton)
+  selectBlanksExercise(I)
   I.click('$plugin-blanks-child-text-button')
   I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 
@@ -117,7 +122,7 @@ Scenario.todo(
   async ({ I }) => {
     createNewEditorEntity(I, 'exercise')
 
-    I.click(BlanksExerciseButton)
+    selectBlanksExercise(I)
     I.click('$plugin-blanks-child-text-button')
     I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 
@@ -143,8 +148,7 @@ Scenario(
   async ({ I }) => {
     createNewEditorEntity(I, 'exercise')
 
-    I.click(BlanksExerciseButton)
-    I.waitForElement('$plugin-blanks-child-text-button', 20)
+    selectBlanksExercise(I)
     I.click('$plugin-blanks-child-text-button')
     I.seeNumberOfElements('$plugin-text-editor', initialTextPluginCount + 1)
 


### PR DESCRIPTION
Not sure why this is needed. All tests pass in local, and only fail occasionally in the workflow. The only clue was the failed screenshot, where the exercise type buttons were still visible. So this was my first idea, and it seems like it worked. I'll merge the PR, but adding you as reviewer in case you have some better ideas.

Edit: Didn't work anyway.