### PR TITLE
fix(plugin-image): upload pixabay images to our bucket

### DIFF
--- a/packages/editor/src/i18n/strings/de/edit.ts
+++ b/packages/editor/src/i18n/strings/de/edit.ts
@@ -184,6 +184,8 @@ export const editStrings = {
       searching: 'Suche nach Bildern ...',
       loadingImage: 'Bilder werden heruntergeladen ...',
       noImagesFound: 'Keine Bilder gefunden',
+      pixabayUploadFailed:
+        'Sorry, das Bild konnte grade nicht hochgeladen werden.',
     },
     imageGallery: {
       title: 'Bilder Galerie',

--- a/packages/editor/src/i18n/strings/en/edit.ts
+++ b/packages/editor/src/i18n/strings/en/edit.ts
@@ -178,6 +178,7 @@ export const editStrings = {
       searching: 'Searching for images ...',
       loadingImage: 'Downloading image ...',
       noImagesFound: 'No images found',
+      pixabayUploadFailed: 'Sorry, the image could not be uploaded right now',
     },
     imageGallery: {
       title: 'Image Gallery',

--- a/packages/editor/src/plugins/image/components/image-selection-screen.tsx
+++ b/packages/editor/src/plugins/image/components/image-selection-screen.tsx
@@ -1,4 +1,5 @@
 import { EditorTooltip } from '@editor/editor-ui/editor-tooltip'
+import { showToastNotice } from '@editor/editor-ui/show-toast-notice'
 import { useEditStrings } from '@editor/i18n/edit-strings-provider'
 import { isTempFile } from '@editor/plugin'
 import { cn } from '@editor/utils/cn'
@@ -8,6 +9,7 @@ import type { ImageProps } from '..'
 import { PixabaySearch } from './pixabay-search/pixabay-search'
 import { UploadButton } from '../controls/upload-button'
 import { isImageUrl } from '../utils/check-image-url'
+import { useUploadFile } from '../utils/upload-file'
 
 interface ImageSelectionScreenProps {
   config: ImageProps['config']
@@ -24,6 +26,7 @@ export function ImageSelectionScreen({
 }: ImageSelectionScreenProps) {
   const editorStrings = useEditStrings()
   const { src, licence } = state
+  const upload = useUploadFile(config.upload)
 
   const imageStrings = editorStrings.plugins.image
   const disableFileUpload = config.disableFileUpload // HACK: Temporary solution to make image plugin available in Moodle & Chancenwerk integration with file upload disabled.
@@ -37,13 +40,29 @@ export function ImageSelectionScreen({
   const imageUrl = src.value as string
   const showErrorMessage = imageUrl.length > 5 && !isImageUrl(imageUrl)
 
-  const onSelectPixabayImage = (imageUrl: string) => {
-    state.src.set(imageUrl)
+  function onSelectPixabayImage(pixabayUrl: string) {
+    // get file extension from url
+    const filesArray = pixabayUrl.split('.')
+    const fileExtension = filesArray[filesArray.length - 1].split('?')[0]
 
-    if (!licence.defined) licence.create('Pixabay')
-    else licence.set('Pixabay')
+    try {
+      // pixbay supports cors so we can directly fetch the image
+      void fetch(pixabayUrl)
+        .then((res) => res.blob())
+        .then((blob) => {
+          const file = new File([blob], 'image.' + fileExtension, blob)
+          void src.upload(file, upload).then(() => {
+            if (!licence.defined) licence.create('Pixabay')
+            else licence.set('Pixabay')
 
-    config.onMultipleUpload?.([])
+            config.onMultipleUpload?.([])
+          })
+        })
+    } catch (error) {
+      showToastNotice(imageStrings.pixabayUploadFailed, 'warning')
+      // eslint-disable-next-line no-console
+      console.log(error)
+    }
   }
 
   return (


### PR DESCRIPTION
https://linear.app/serlo/issue/EDTR-293/pixabay-images-break

(with this at least we don't produce more breaking images, not sure what we should do with all the already broken images to be honest)

[Demo](https://frontend-git-fix-plugin-image-upload-pixabay-serlo.vercel.app/___editor_preview)