### PR TITLE
fix(editor): fixing some minor things

### DIFF
--- a/packages/editor/src/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
+++ b/packages/editor/src/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options.tsx
@@ -297,7 +297,8 @@ function createToolbarControls(
       group: 'default',
       renderIcon: (editor: SlateEditor) => {
         const colorIndex = getColorIndex(editor)
-        const color = colorIndex ? textColors[colorIndex].value : 'black'
+        const color =
+          colorIndex !== undefined ? textColors[colorIndex].value : 'black'
         return <ColorTextIcon color={color} />
       },
       subMenuButtons: [

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -98,7 +98,7 @@ export function SerloEditor(props: SerloEditorProps) {
         <EditorMetaContext.Provider
           value={{ editorVariant, userId, ltik: _ltik }}
         >
-          {isProductionEnvironment ? null : renderTestEnvironmentWarning()}
+          {renderTestEnvironmentWarning()}
           <div className={styleReset ? 'serlo-editor-style-reset' : ''}>
             <Editor
               initialState={migratedState.document}
@@ -126,8 +126,9 @@ export function SerloEditor(props: SerloEditorProps) {
   }
 
   function renderTestEnvironmentWarning() {
+    if (isProductionEnvironment) return null
     return (
-      <div className="test-environment-warning bg-editor-primary-100 px-1.5 py-0.5 text-sm">
+      <div className="test-environment-warning my-3 bg-editor-primary-100 px-1.5 py-0.5 text-sm">
         {editStrings.savedContentMightDisappearWarning}
       </div>
     )

--- a/packages/editor/src/plugins/blanks-exercise/editor.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/editor.tsx
@@ -73,6 +73,9 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
 
   if (!childPluginState || !staticDocument) return null
 
+  const showToolbar =
+    isChildPluginFocused && childPluginState.plugin === EditorPluginType.Text
+
   return (
     <div
       className={cn(
@@ -104,16 +107,15 @@ export function BlanksExerciseEditor(props: BlanksExerciseProps) {
         <BlanksExerciseRenderer
           isEditing
           childPlugin={
-            <>
-              {isChildPluginFocused ? (
+            <div className="[&_.plugin-toolbar]:!-top-12 [&_.plugin-toolbar]:!left-0">
+              {showToolbar ? (
                 <PluginToolbar
                   pluginType={EditorPluginType.Text}
-                  className="!-top-12 !left-0"
                   noWhiteShadow
                 />
               ) : null}
               {childPlugin.render({ config: childPluginConfig })}
-            </>
+            </div>
           }
           childPluginState={childPluginState}
           extraDraggableAnswers={staticDocument.state.extraDraggableAnswers}

--- a/packages/editor/src/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -1,6 +1,5 @@
 import { useFormattingOptions } from '@editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options'
 import { isSelectionWithinList } from '@editor/editor-ui/plugin-toolbar/text-controls/utils/list'
-import { EditorPluginType } from '@editor/package'
 import {
   PluginMenuContext,
   PluginMenuActionTypes,
@@ -14,6 +13,7 @@ import {
   useAppDispatch,
   selectParentPluginType,
 } from '@editor/store'
+import { EditorPluginType } from '@editor/types/editor-plugin-type'
 import isHotkey from 'is-hotkey'
 import { useCallback, useContext } from 'react'
 import { Editor as SlateEditor, Range, Node, Transforms } from 'slate'

--- a/packages/editor/src/plugins/text/hooks/use-editable-key-down-handler.tsx
+++ b/packages/editor/src/plugins/text/hooks/use-editable-key-down-handler.tsx
@@ -1,5 +1,6 @@
 import { useFormattingOptions } from '@editor/editor-ui/plugin-toolbar/text-controls/hooks/use-formatting-options'
 import { isSelectionWithinList } from '@editor/editor-ui/plugin-toolbar/text-controls/utils/list'
+import { EditorPluginType } from '@editor/package'
 import {
   PluginMenuContext,
   PluginMenuActionTypes,
@@ -11,6 +12,7 @@ import {
   selectChildTreeOfParent,
   useStore,
   useAppDispatch,
+  selectParentPluginType,
 } from '@editor/store'
 import isHotkey from 'is-hotkey'
 import { useCallback, useContext } from 'react'
@@ -59,9 +61,15 @@ export const useEditableKeydownHandler = (
           const { path } = selection.focus
           const node = Node.get(editor, path)
 
+          const parentType = selectParentPluginType(store.getState(), id)
           const parent = selectChildTreeOfParent(store.getState(), id)
 
-          if (Object.hasOwn(node, 'text') && node.text.length === 0 && parent) {
+          if (
+            parentType === EditorPluginType.Rows &&
+            Object.hasOwn(node, 'text') &&
+            node.text.length === 0 &&
+            parent
+          ) {
             const currentIndex = parent.children?.findIndex(
               (child) => child.id === id
             )


### PR DESCRIPTION
[Demo](https://frontend-git-this-and-that-serlo.vercel.app/entity/repository/add-revision/277232)

- [chore(editor): add margin to staging warning bar](https://github.com/serlo/frontend/pull/4449/commits/4974bbe2f3f2d84f22653936ddde2ef3f697a0ce)
[4974bbe](https://github.com/serlo/frontend/pull/4449/commits/4974bbe2f3f2d84f22653936ddde2ef3f697a0ce)
- [fix(plugin-text): fix blue color icon](https://github.com/serlo/frontend/pull/4449/commits/ca58947f8cee9aeeb3771623e6d02620ce1c7793)
[ca58947](https://github.com/serlo/frontend/pull/4449/commits/ca58947f8cee9aeeb3771623e6d02620ce1c7793)
- [fix(plugin-text): only open plugin menu inside rows (not table for example](https://github.com/serlo/frontend/pull/4449/commits/7d05788f53393971b8a361210505596b965e250f) 
[7d05788](https://github.com/serlo/frontend/pull/4449/commits/7d05788f53393971b8a361210505596b965e250f)
- [fix(plugin-blanks): fix double and misplaced toolbar in table mode](https://github.com/serlo/frontend/pull/4449/commits/17129a3d942716589f7f71cefa3de1d194fc150f)