### PR TITLE
fix(editor): add migration exception for unrevised serlo.org content

### DIFF
--- a/packages/editor/__tests__/migration-state.test.ts
+++ b/packages/editor/__tests__/migration-state.test.ts
@@ -1,7 +1,8 @@
 import { migrate } from '@editor/package/storage-format'
 import { expect, test } from 'vitest'
 
-test('A document not being in the storage format can be migrated', () => {
+// Temporarily disabled, until https://linear.app/serlo/issue/EDTR-98/ is done
+test.todo('A document not being in the storage format can be migrated', () => {
   const { stateChanged, migratedState } = migrate({ plugin: 'rows' }, 'unknown')
 
   expect(stateChanged).toBe(true)

--- a/packages/editor/src/package/storage-format.ts
+++ b/packages/editor/src/package/storage-format.ts
@@ -37,6 +37,13 @@ type Migration = (
   state: OldStorageFormat | StorageFormat
 ) => OldStorageFormat | StorageFormat
 
+const OldSerloFormatType = t.partial({
+  plugin: t.string,
+  state: t.unknown,
+  id: t.string,
+  serloContext: t.unknown,
+})
+
 const OldStorageFormatType_0 = t.type({
   type: t.literal(documentType),
   variant: EditorVariantType,
@@ -134,6 +141,24 @@ export function migrate(
   migratedState: StorageFormat
   stateChanged: boolean
 } {
+  // Temporary, until https://linear.app/serlo/issue/EDTR-98/ is done
+  if (OldSerloFormatType.is(stateBeforeMigration)) {
+    return {
+      migratedState: {
+        id: '',
+        type: documentType,
+        variant: 'serlo-org',
+        version: 0,
+        dateModified: getCurrentDatetime(),
+        document: deepCopy(stateBeforeMigration) as EditorState,
+        editorVersion: getEditorVersion(),
+        domainOrigin:
+          typeof window !== 'undefined' ? window.location.origin : 'server',
+      },
+      stateChanged: false,
+    }
+  }
+
   if (
     !OldStorageFormatType_0.is(stateBeforeMigration) &&
     !OldStorageFormatType_1.is(stateBeforeMigration) &&


### PR DESCRIPTION
This is just a short term solution to restore current serlo.org production behavior to staging.

I added a work item for this case to [EDTR-98](https://linear.app/serlo/issue/EDTR-98/) issue. But, I'm not exactly sure how to solve this one long-term.