### PR TITLE
fix(plugin-interactive-video): solve 'stuck when playing video' in edu-sharing preview.

### DIFF
--- a/packages/editor/src/plugins/interactive-video/renderer/renderer.tsx
+++ b/packages/editor/src/plugins/interactive-video/renderer/renderer.tsx
@@ -25,7 +25,6 @@ export function InteractiveVideoRenderer({
   videoSrc,
   marks,
   tools,
-  isEditMode,
   checkSeekAndPlay,
   learnerInteractions,
 }: {
@@ -50,7 +49,7 @@ export function InteractiveVideoRenderer({
         src={videoSrc}
         playsInline
         className="[&_.vds-chapter-title]:opacity-0"
-        load={isSerlo ? 'eager' : isEditMode ? 'visible' : 'play'}
+        load={isSerlo ? 'eager' : 'visible'}
         autoPlay={isSerlo ? true : false} // autoplay after wrapper
         aspectRatio="16:9"
         onMediaPlayRequest={(nativeEvent) => {


### PR DESCRIPTION
In the edu-sharing preview we have `SerloRenderer` plus iframe without allow attribute. I still do not understand why it did not work before, but this change fixes it for now. 