### PR TITLE
chore(editor-dev): simulate cross origin with one dev server

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -31,8 +31,7 @@
   "scripts": {
     "_eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "_prettier": "prettier .",
-    "dev": "echo 'Demo page ready under \n\nhttp://localhost:3000/\n\nDo not open the demo page on port 3001!' && npm-run-all --parallel 'vite --port 3000' 'vite --port 3001'",
-    "vite": "vite",
+    "dev": "vite",
     "build": "vite build",
     "format": "npm-run-all --continue-on-error \"format:*\"",
     "format:eslint": "yarn _eslint --fix",

--- a/packages/editor/src/___dev-demo/iframed-editor-and-preview.tsx
+++ b/packages/editor/src/___dev-demo/iframed-editor-and-preview.tsx
@@ -3,8 +3,9 @@ import { createRoot } from 'react-dom/client'
 createRoot(document.getElementById('root')!).render(
   <iframe
     style={{ width: '100%', height: '100%', borderWidth: '0' }}
-    // Embedding localhost:3001 on host page localhost:3000 simulates cross-origin. Important because a lot of iframe, cookie, CSP security measures are only in effect for cross-origin iframes.
-    src="http://localhost:3001/demo/react-preview/"
+    // Embedding from subdomain (cross-origin-mock) on host page localhost:5173 simulates cross-origin.
+    // Important because a lot of iframe, cookie, CSP security measures are only in effect for cross-origin iframes.
+    src="http://cross-origin-mock.localhost:5173/demo/react-preview/"
     sandbox={`
       allow-downloads
       allow-forms


### PR DESCRIPTION
After some research I'm pretty sure that (unless we change some settings) using a subdomain should have exactly the same effects (and in my testing the behaviour is the exact same as with localhost:3001/localhost:3000)