### PR TITLE
refactor: remove unnecessary selectors

### DIFF
--- a/packages/editor/src/core/editor-children.tsx
+++ b/packages/editor/src/core/editor-children.tsx
@@ -14,7 +14,6 @@ import {
   selectPendingChanges,
   selectHasUndoActions,
   selectHasRedoActions,
-  selectDocuments,
   selectStaticDocument,
   useStore,
 } from '../store'
@@ -39,7 +38,7 @@ export function EditorChildren({ children }: { children: EditorRenderProps }) {
 
   const pendingChanges = useAppSelector(selectPendingChanges)
   const dispatchPersistHistory = useCallback(() => {
-    const documents = selectDocuments(store.getState())
+    const documents = store.getState().documents
     void dispatch(persistHistory(documents))
   }, [dispatch, store])
 

--- a/packages/editor/src/plugins/equations/editor/editor.tsx
+++ b/packages/editor/src/plugins/equations/editor/editor.tsx
@@ -6,7 +6,6 @@ import {
   focus,
   focusNext,
   focusPrevious,
-  selectFocused,
   selectIsDocumentEmpty,
   useAppSelector,
   useAppDispatch,
@@ -39,7 +38,7 @@ export function EquationsEditor(props: EquationsProps) {
 
   const dispatch = useAppDispatch()
   const store = useStore()
-  const focusedElement = useAppSelector(selectFocused)
+  const focusedElement = store.getState().focus
   const nestedFocus =
     focused ||
     includes(

--- a/packages/editor/src/plugins/input-exercise/editor.tsx
+++ b/packages/editor/src/plugins/input-exercise/editor.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../editor-ui'
 import {
   focus,
-  selectFocused,
   selectStaticDocument,
   useStore,
   useAppDispatch,
@@ -52,7 +51,7 @@ export function InputExerciseEditor(props: InputExerciseProps) {
   useEffect(() => overwriteFocus, [])
 
   const isAnyAnswerFocused = answers.some(
-    ({ feedback }) => feedback.id === selectFocused(store.getState())
+    ({ feedback }) => feedback.id === store.getState().focus
   )
 
   const showUi = focused || isAnyAnswerFocused

--- a/packages/editor/src/plugins/sc-mc-exercise/editor.tsx
+++ b/packages/editor/src/plugins/sc-mc-exercise/editor.tsx
@@ -9,12 +9,7 @@ import {
   InteractiveAnswer,
   PreviewOverlaySimple,
 } from '../../editor-ui'
-import {
-  useStore,
-  selectFocused,
-  selectStaticDocument,
-  useAppSelector,
-} from '../../store'
+import { useStore, selectStaticDocument, useAppSelector } from '../../store'
 import { useIsPreviewActive } from '../exercise/context/preview-context'
 
 export function ScMcExerciseEditor(props: ScMcExerciseProps) {
@@ -45,7 +40,7 @@ export function ScMcExerciseEditor(props: ScMcExerciseProps) {
   const previewActive = useIsPreviewActive()
 
   const isAnyAnswerFocused = answers.some(({ content, feedback }) => {
-    const focusedId = selectFocused(store.getState())
+    const focusedId = store.getState().focus
     return focusedId === content.id || focusedId === feedback.id
   })
 

--- a/packages/editor/src/plugins/serlo-table/editor.tsx
+++ b/packages/editor/src/plugins/serlo-table/editor.tsx
@@ -4,10 +4,8 @@ import { useEditStrings } from '@editor/i18n/edit-strings-provider'
 import { editorPlugins } from '@editor/plugin/helpers/editor-plugins'
 import {
   useStore,
-  selectFocused,
   selectIsDocumentEmpty,
   focus,
-  useAppSelector,
   useAppDispatch,
 } from '@editor/store'
 import { EditorPluginType } from '@editor/types/editor-plugin-type'
@@ -32,7 +30,6 @@ export function SerloTableEditor(props: SerloTableProps) {
   const [, setUpdateHack] = useState(0)
 
   const dispatch = useAppDispatch()
-  const focusedElement = useAppSelector(selectFocused)
   const { focusedRowIndex, focusedColIndex, nestedFocus } = findFocus()
 
   const tableStrings = useEditStrings().plugins.serloTable
@@ -332,7 +329,7 @@ export function SerloTableEditor(props: SerloTableProps) {
 
     rows.some((row, rowIndex) =>
       row.columns.some((cell, colIndex) => {
-        if (cell.content.id === focusedElement) {
+        if (cell.content.id === store.getState().focus) {
           focusedRowIndex = rowIndex
           focusedColIndex = colIndex
           return true

--- a/packages/editor/src/store/documents/selectors.ts
+++ b/packages/editor/src/store/documents/selectors.ts
@@ -16,11 +16,6 @@ import { State } from '../types'
 
 const selectSelf = (state: State) => state.documents
 
-export const selectDocuments = createSelector(
-  selectSelf,
-  (documents) => documents
-)
-
 export const selectDocument = createSelector(
   [selectSelf, (_state, id: string | null) => id],
   (documents, id) => {

--- a/packages/editor/src/store/focus/selectors.ts
+++ b/packages/editor/src/store/focus/selectors.ts
@@ -6,8 +6,6 @@ import { State } from '../types'
 
 const selectSelf = (state: State) => state.focus
 
-export const selectFocused = createSelector(selectSelf, (focus) => focus)
-
 export const selectIsFocused = createSelector(
   [selectSelf, (_state, id: string) => id],
   (focus, id: string) => focus === id
@@ -18,7 +16,6 @@ export const selectHasFocusedChild = createSelector(
   (state, id: string) => {
     const tree = selectChildTree(state, id)
     if (!tree || !tree.children) return false
-    const focused = selectFocused(state)
-    return R.any((node) => node.id === focused, tree.children)
+    return R.any((node) => node.id === state.focus, tree.children)
   }
 )

--- a/packages/editor/src/store/root/saga.ts
+++ b/packages/editor/src/store/root/saga.ts
@@ -1,9 +1,8 @@
 import { all, call, put, select, takeEvery } from 'redux-saga/effects'
 
 import { runInitRootSaga } from '.'
-import type { ReversibleAction } from '..'
+import type { ReversibleAction, State } from '..'
 import { ROOT } from './constants'
-import { selectDocuments } from '../documents'
 import { handleRecursiveInserts } from '../documents/saga'
 import { persistHistory } from '../history'
 
@@ -24,7 +23,8 @@ function* initRootSaga(action: ReturnType<typeof runInitRootSaga>) {
 
   yield all(actions.map((reversible) => put(reversible.action)))
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const documents: ReturnType<typeof selectDocuments> =
-    yield select(selectDocuments)
+  const documents: State['documents'] = yield select(
+    (state: State) => state.documents
+  )
   yield put(persistHistory(documents))
 }


### PR DESCRIPTION
Motivation for PR - console warning:
> The result function returned its own inputs without modification. e.g
`createSelector([state => state.todos], todos => todos)`
This could lead to inefficient memoization and unnecessary re-renders.
Ensure transformation logic is in the result function, and extraction logic is in the input selectors.

Makes sense, `createSelector` tries to memoize, but there's no need for memoization, as there's no transformation to memoize. So this PR removes selectors without transformation, and their usage is replaced with simple property access.