### PR TITLE
hotfix(editor): always enable InteractiveVideo

### DIFF
--- a/packages/editor/src/editor-integration/create-plugins.tsx
+++ b/packages/editor/src/editor-integration/create-plugins.tsx
@@ -54,20 +54,6 @@ export interface ExtraSerloPlugins {
   image: EditorPlugin<ImagePluginState, ImagePluginConfig>
 }
 
-function isLocalOrDevOrStaging() {
-  if (process.env.NEXT_PUBLIC_ENV === 'staging') return true
-
-  if (typeof window === 'undefined') return false
-  const host = window.location.hostname
-
-  return (
-    process.env.NODE_ENV === 'development' ||
-    host === 'editor.serlo.dev' ||
-    host === 'editor.serlo-staging.dev' ||
-    host === 'localhost'
-  )
-}
-
 export function createPlugins(
   plugins: (EditorPluginType | TemplatePluginType)[],
   testingSecret?: string | null,
@@ -160,14 +146,10 @@ export function createPlugins(
       type: EditorPluginType.DropzoneImage,
       plugin: createDropzoneImagePlugin(),
     },
-    ...(isLocalOrDevOrStaging()
-      ? [
-          {
-            type: EditorPluginType.InteractiveVideo,
-            plugin: interactiveVideoPlugin,
-          },
-        ]
-      : []),
+    {
+      type: EditorPluginType.InteractiveVideo,
+      plugin: interactiveVideoPlugin,
+    },
 
     // Special plugins, never visible in suggestions
     // ===================================================


### PR DESCRIPTION
Interactive video plugin was disabled in production, probably while solving merge conflicts between its development and big refactorings. This hotfix re-enables it in production.