### PR TITLE
feat(editor): add optional showUndoRedoButtons prop

### DIFF
--- a/apps/web/src/serlo-editor-integration/serlo-editor.tsx
+++ b/apps/web/src/serlo-editor-integration/serlo-editor.tsx
@@ -83,6 +83,7 @@ export function SerloEditor({
         isProductionEnvironment={isProduction}
         initialState={initialState}
         styleReset={false}
+        showUndoRedoButtons
         extraSerloPlugins={extraSerloPlugins}
         extraSerloRenderers={extraSerloRenderers}
         onChange={(state) => {

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -122,11 +122,15 @@ See below for the current API specification.
 
 - **`onChange` (optional)**: To receive state changes of the editor and persist the content into your own infrastructure, use the `onChange` callback of the `SerloEditor` component. It's a function with the signature `(state: StorageFormat) => void`.
 
-- **`language` (optional)**: The default language is `de`.
+- **`language` (optional)**: The default language is `de`. Currently the only other option is `en`.
 
 - **`editorVariant`**: The variant (integration) of the Serlo editor. For example `edusharing` or `serlo-org`. The editor adds this information to the `StorageFormat` that will be saved. Might become useful for example if we need to apply a migration only to one variant of the editor.
 
-- **`_testingSecret` (optional)**: A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **To be deprecated once a long term solution is agreed on.**
+- **`isProductionEnvironment`(optional)**: Tell the editor if it runs in an production environment. In all other environments there will be a warning and experimental features might be active.
+
+- **`showUndoRedoButtons`(optional)**: Set to true to show the default undo/redo buttons. (Defaults to false).
+
+- **`_testingSecret` (optional)**: A key used by integrations for uploading files into the serlo-editor-testing bucket, while testing the Editor. **Deprecated**
 
 - **`_ltik` (optional)**: Required by the custom plugin `edusharingAsset` only used in `serlo-editor-for-edusharing`. **To be removed once a better solution is found or the plugin is removed.**
 

--- a/packages/editor/src/core/editor.tsx
+++ b/packages/editor/src/core/editor.tsx
@@ -38,15 +38,13 @@ export function Editor(props: EditorProps) {
     <ReduxProvider store={store}>
       <DndWrapper>
         <HotkeysProvider initiallyActiveScopes={['global']}>
+          {props.showUndoRedoButtons ? <EditorToolbar /> : null}
           {/* only on serlo for now */}
           {isSerlo && !isSerloEditorPreviewPage ? (
-            <>
-              <EditorToolbar />
-              <LocalStorageNotice
-                useStored={useStored}
-                setUseStored={setUseStored}
-              />
-            </>
+            <LocalStorageNotice
+              useStored={useStored}
+              setUseStored={setUseStored}
+            />
           ) : null}
           {/* For non serlo environments, we need to render the toaster
           (already gets rendered in the web project) */}

--- a/packages/editor/src/core/types.ts
+++ b/packages/editor/src/core/types.ts
@@ -18,6 +18,7 @@ export interface EditorProps {
     state?: unknown
   }
   onChange: OnEditorChange
+  showUndoRedoButtons?: boolean
 }
 
 export type EditorRenderProps = ReactNode | ((editor: BaseEditor) => ReactNode)

--- a/packages/editor/src/package/editor.tsx
+++ b/packages/editor/src/package/editor.tsx
@@ -43,6 +43,9 @@ export interface SerloEditorProps {
   isProductionEnvironment?: boolean
   userId?: string
   styleReset?: boolean
+  /** Shows default Undo/Redo UI. Defaults to false for now */
+  showUndoRedoButtons?: boolean
+  /** @deprecated Please do not use for new setups */
   _testingSecret?: string | null
   _ltik?: string
   /** @deprecated Only temporarily allowed for serlo.org. */
@@ -62,6 +65,7 @@ export function SerloEditor(props: SerloEditorProps) {
     isProductionEnvironment,
     userId,
     styleReset,
+    showUndoRedoButtons,
     _testingSecret,
     _ltik,
     extraSerloPlugins,
@@ -107,6 +111,7 @@ export function SerloEditor(props: SerloEditorProps) {
             <Editor
               initialState={migratedState.document}
               onChange={handleDocumentChange}
+              showUndoRedoButtons={showUndoRedoButtons}
             >
               {children}
             </Editor>


### PR DESCRIPTION
For https://linear.app/serlo/issue/EDTR-103/integrate-undo-redo-inside-the-editor-for-serloorg-all-integrations

(deployment breaks for … staging reasons, very likely unrelated)