### PR TITLE
fix(editor): plugin menu restrictions

### DIFF
--- a/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -39,5 +39,10 @@ export function checkIsAllowedNesting(
     return Boolean(hasValidRoot)
   }
 
+  // Special `PageLayout` plugin only available in Page entities
+  if (pluginType === EditorPluginType.PageLayout) {
+    return typesOfAncestors.includes(TemplatePluginType.Page)
+  }
+
   return true
 }

--- a/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
+++ b/packages/editor/src/plugins/rows/utils/check-is-allowed-nesting.ts
@@ -18,7 +18,12 @@ export function checkIsAllowedNesting(
 
   const rootPluginType = typesOfAncestors.at(0)
 
-  if (pluginType === EditorPluginType.Exercise) {
+  if (
+    pluginType === EditorPluginType.Exercise ||
+    // Interactive video is a special interactive plugin,
+    // in that it's not a child of the Exercise plugin
+    pluginType === EditorPluginType.InteractiveVideo
+  ) {
     // Restrict Exercise->Exercise nesting
     if (
       typesOfAncestors.includes(EditorPluginType.Exercise) ||


### PR DESCRIPTION
Fixes:
1. `PageLayout` plugin appearing in Plugin Menu Modal outside `Page` entity ([slack thread](https://serlo.slack.com/archives/C05QWHQP1HT/p1740993956398599))
2. `InteractiveVideo` appearing as the only interactive plugin on `Page` entity. I'm not 100% sure about this one, but it seems logical to me that we want to restrict `InteractiveVideo` wherever `Exercise` is restricted.