### PR TITLE
test(320-save): update semver regex

### DIFF
--- a/e2e-tests/tests/320-save-and-check-api-result.ts
+++ b/e2e-tests/tests/320-save-and-check-api-result.ts
@@ -219,7 +219,7 @@ function stringifyAndRemoveDateTime(state: unknown) {
       // remove iso date time
       .replace(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+/g, '')
       // remove editor semver
-      .replace(/([0-9]+)\.([0-9]+)\.([0-9]+)/g, '')
+      .replace(/v?\d+\.\d+\.\d+(?:-[\da-z.-]+)?(?:\+[\da-z.-]+)?/gi, '')
   )
 }
 


### PR DESCRIPTION
Editor is currently at `0.23.0-beta.0`, which isn't covered by the current semver regex in 320 test suite.