### PR TITLE
feat(web): add oam banners again

### DIFF
--- a/apps/web/src/components/exams-info-box.tsx
+++ b/apps/web/src/components/exams-info-box.tsx
@@ -110,6 +110,9 @@ export function ExamsInfoBox({ examsFolderId }: { examsFolderId: number }) {
             #secondary-menu {
               display: none !important;
             }
+            #oam-banner {
+              display: none !important;
+            }
           `}
         </style>
       </div>

--- a/apps/web/src/components/navigation/header/header.tsx
+++ b/apps/web/src/components/navigation/header/header.tsx
@@ -1,4 +1,3 @@
-import { faHeart } from '@fortawesome/free-solid-svg-icons'
 import { Router, useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
@@ -6,7 +5,7 @@ import { Logo } from './logo'
 import { Menu } from './menu/menu'
 import { MobileMenuButton } from './mobile-menu-button'
 import { SkipMenu } from './skip-menu'
-import { FaIcon } from '@/components/fa-icon'
+import { Link } from '@/components/content/link'
 import { Quickbar } from '@/components/navigation/quickbar'
 import { useInstanceData } from '@/contexts/instance-context'
 import { Instance } from '@/fetcher/graphql-types/operations'
@@ -40,42 +39,44 @@ export function Header() {
   }, [])
 
   return (
-    <header
-      className={cn(
-        `
+    <>
+      {renderTempExamsBanner()}
+      <header
+        className={cn(
+          `
         bg-[url("/_assets/img/header-curve.svg")] bg-[length:100vw_3rem]
           bg-bottom bg-no-repeat pb-9 pt-3 text-almost-black
         `,
-        hideQuickbar ? '' : 'bg-brand-100'
-      )}
-    >
-      <SkipMenu />
-      <div className="px-side pb-6 pt-3 lg:px-side-lg">
-        <div className="flex-wrap mobileExt:flex mobileExt:justify-between lg:flex-nowrap">
-          <Logo foldOnMobile />
-          <div
-            className={cn(
-              `order-last mt-[1.7rem] min-h-[50px] w-full
+          hideQuickbar ? '' : 'bg-brand-100'
+        )}
+      >
+        <SkipMenu />
+        <div className="px-side pb-6 pt-3 lg:px-side-lg">
+          <div className="flex-wrap mobileExt:flex mobileExt:justify-between lg:flex-nowrap">
+            <Logo foldOnMobile />
+            <div
+              className={cn(
+                `order-last mt-[1.7rem] min-h-[50px] w-full
               md:order-none md:mt-8 md:block
               md:w-auto lg:order-last`,
-              mobileMenuOpen ? '' : 'hidden'
-            )}
-          >
-            <Menu isMobile={mobileMenuOpen} />
+                mobileMenuOpen ? '' : 'hidden'
+              )}
+            >
+              <Menu isMobile={mobileMenuOpen} />
+            </div>
+            <div className="hidden h-0 basis-full md:block lg:hidden" />
+            {renderQuickbar()}
+            <MobileMenuButton
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              open={mobileMenuOpen}
+            />
           </div>
-          <div className="hidden h-0 basis-full md:block lg:hidden" />
-          {renderQuickbar()}
-          <MobileMenuButton
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            open={mobileMenuOpen}
-          />
         </div>
-      </div>
-    </header>
+      </header>
+    </>
   )
 
   function renderQuickbar() {
-    if (isLanding && lang === Instance.De) return renderSpecialDonationButton()
     if (hideQuickbar) return null
 
     return (
@@ -91,17 +92,47 @@ export function Header() {
     )
   }
 
-  function renderSpecialDonationButton() {
+  function renderTempExamsBanner() {
+    if (lang !== Instance.De) return null
+    const isInMath = router.asPath.startsWith('/mathe/')
+    if (
+      !['/serlo', '/search', '/community', '/mitmachen'].includes(
+        router.asPath
+      ) &&
+      !isInMath
+    )
+      return null
+
     return (
-      <button
-        className="py-0.75 serlo-button-green absolute right-4 top-32 text-[0.9rem] md:right-6 md:top-[1.15rem] lg:right-12"
+      <Link
+        id="oam-banner"
         onClick={() => {
-          submitEvent('spenden-header-menu-click-landing')
-          void router.push('/spenden')
+          if (isInMath) submitEvent('oam-banner-click-math')
+          else submitEvent('oam-banner-click-meta')
         }}
+        href="/mathe-pruefungen"
+        className="group block bg-newgreen bg-opacity-20 p-3 text-black hover:!no-underline mobile:text-center sm:py-2"
       >
-        <FaIcon icon={faHeart} /> Jetzt Spenden
-      </button>
+        🎓 Ui, schon Prüfungszeit?{' '}
+        <b className="serlo-link group-hover:underline">
+          Hier geht&apos;s zur Mathe-Prüfungsvorbereitung
+        </b>
+        .
+      </Link>
     )
   }
+
+  // function renderSpecialDonationButton() {
+  //   return (
+  //     <button
+  //       className="py-0.75 serlo-button-green absolute right-4 top-32 text-[0.9rem] md:right-6 md:top-[1.15rem] lg:right-12"
+  //       onClick={() => {
+  //         submitEvent('spenden-header-menu-click-landing')
+  //         void router.push('/spenden')
+  //       }}
+  //     >
+  //       <FaIcon icon={faHeart} /> Jetzt Spenden
+  //     </button>
+  //   )
+  // }
 }

--- a/apps/web/src/components/pages/landing-de.tsx
+++ b/apps/web/src/components/pages/landing-de.tsx
@@ -12,6 +12,7 @@ import { LandingSubjectsNew } from '@/components/landing/rework/landing-subjects
 import { InstanceLandingData } from '@/data-types'
 import { breakpoints } from '@/helper/breakpoints'
 import { cn } from '@/helper/cn'
+import { submitEvent } from '@/helper/submit-event'
 import { serloDomain } from '@/helper/urls/serlo-domain'
 
 export interface LandingDEProps {
@@ -32,7 +33,7 @@ export function LandingDE({ data }: LandingDEProps) {
       <LandingJsonLd />
       <Header />
       <main id="content" className="text-almost-black">
-        <section className="mx-auto mt-20 max-w-3xl px-2 text-center font-bold md:mt-[11vh]">
+        <section className="mx-auto mt-10 max-w-3xl px-2 text-center font-bold sm:mt-0">
           <p className="serlo-add-eyebrows font-handwritten text-3xl text-brand">
             <WelcomeMessage />
           </p>
@@ -57,6 +58,17 @@ export function LandingDE({ data }: LandingDEProps) {
         </section>
 
         <section className="mt-10">
+          <Link
+            onClick={() => submitEvent('oam-banner-click-landing')}
+            href="/mathe-pruefungen"
+            className="group mb-10 block bg-newgreen bg-opacity-20 p-3 text-lg text-black hover:!no-underline mobile:text-center sm:py-4 md:text-[22px] lg:mb-0"
+          >
+            🎓 Ui, schon Prüfungszeit?{' '}
+            <b className="serlo-link group-hover:underline">
+              Hier geht&apos;s zur Mathe-Prüfungsvorbereitung
+            </b>
+            .
+          </Link>
           <LandingSubjectsNew data={subjectsData} />
         </section>
 
@@ -142,6 +154,9 @@ export function LandingDE({ data }: LandingDEProps) {
       </main>
       <FooterNew />
       <style jsx>{`
+        {/* :global(body) {
+          margin-top: 40px;
+        } */}
         /* special donation button on landing */
         :global(.navtrigger[href='/spenden']) {
           display: none;

--- a/apps/web/src/components/pages/subject-landing-content.tsx
+++ b/apps/web/src/components/pages/subject-landing-content.tsx
@@ -1,4 +1,5 @@
 import type { deSubjectLandingSubjects } from './subject-landing'
+import { Link } from '../content/link'
 import { HeadTags } from '../head-tags'
 import { FooterNew } from '../landing/rework/footer-new'
 import { SubjectIcon } from '../landing/rework/subject-icon'
@@ -14,6 +15,7 @@ import { Instance } from '@/fetcher/graphql-types/operations'
 import { breakpoints } from '@/helper/breakpoints'
 import { cn } from '@/helper/cn'
 import { getServerSideStrings } from '@/helper/feature-i18n'
+import { submitEvent } from '@/helper/submit-event'
 import { serloDomain } from '@/helper/urls/serlo-domain'
 
 interface SubjectLandingContentProps {
@@ -68,7 +70,20 @@ export function SubjectLandingContent({
           </div>
           {renderIcon()}
         </section>
-        <section className="mx-auto mt-10 max-w-3xl text-center sm:mt-16 sm:text-left">
+        {subject === 'mathe' ? (
+          <Link
+            onClick={() => submitEvent('oam-banner-click-math-landing')}
+            href="/mathe-pruefungen"
+            className="group mb-10 mt-10 block bg-newgreen bg-opacity-20 p-3 text-lg text-black hover:!no-underline mobile:text-center sm:py-4 md:text-[22px] lg:mb-0"
+          >
+            🎓 Ui, schon Prüfungszeit?{' '}
+            <b className="serlo-link group-hover:underline">
+              Hier geht&apos;s zur Mathe-Prüfungsvorbereitung
+            </b>
+            .
+          </Link>
+        ) : null}
+        <section className="mx-auto mt-10 max-w-3xl text-center sm:mt-12 sm:text-left">
           <h2 className="mb-2 text-lg font-bold text-almost-black">
             Durchsuche den Bereich {data.title}
           </h2>


### PR DESCRIPTION
on landing and math landing page:
<img width="901" alt="image" src="https://github.com/user-attachments/assets/2732d01a-73a5-4f37-8242-8ef47a4b0e80" />

in content within the math section:
<img width="1389" alt="image" src="https://github.com/user-attachments/assets/5b3b06a0-f055-49c3-b47c-9eacb6374b4e" />
