### PR TITLE
feat(editor): add `loading="lazy"` to images

### DIFF
--- a/packages/editor/src/editor-ui/embed-wrapper.tsx
+++ b/packages/editor/src/editor-ui/embed-wrapper.tsx
@@ -70,6 +70,7 @@ export function EmbedWrapper({
             className="w-full object-contain opacity-50"
             src={previewImageUrl}
             alt={`${embedStrings.previewImage}`}
+            loading="lazy"
           />
         </div>
         <div

--- a/packages/editor/src/plugins/edusharing-asset/helper/use-embed-fetch.tsx
+++ b/packages/editor/src/plugins/edusharing-asset/helper/use-embed-fetch.tsx
@@ -169,6 +169,7 @@ function getEmbedHtml(
                 src={iconURL}
                 alt="Word-File icon"
                 className="-mt-1 inline-block h-4 w-4 opacity-50"
+                loading="lazy"
               />{' '}
               Word-Datei: {name}
             </>

--- a/packages/editor/src/plugins/image/components/editor-image.tsx
+++ b/packages/editor/src/plugins/image/components/editor-image.tsx
@@ -9,7 +9,7 @@ import { ImgHTMLAttributes } from 'react'
  */
 export function EditorImage(props: ImgHTMLAttributes<HTMLImageElement>) {
   const isSerlo = useIsSerlo()
-  return <img {...props} src={getSrc(isSerlo, props.src)} />
+  return <img {...props} src={getSrc(isSerlo, props.src)} loading="lazy" />
 }
 
 function getSrc(isSerlo?: boolean, src?: string) {


### PR DESCRIPTION
☺️ 

follow up: we could load the first image in an article (the one in the intro) eagerly or make other rules