### PR TITLE
Editor version 0.7.5: Fix/plugin blanks exercise prevent scroll

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/editor",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "homepage": "https://de.serlo.org/editor",
   "bugs": {
     "url": "https://github.com/serlo/frontend/issues"

--- a/packages/editor/src/core/components/dnd-wrapper.tsx
+++ b/packages/editor/src/core/components/dnd-wrapper.tsx
@@ -1,13 +1,14 @@
-import { HTML5toTouch } from 'rdndmb-html5-to-touch'
 import { ReactNode } from 'react'
-import { DndProvider } from 'react-dnd-multi-backend'
+import { DndProvider } from 'react-dnd'
+import { TouchBackend } from 'react-dnd-touch-backend'
 
 import { CustomDragLayer } from './custom-drag-layer'
 
 export const DndWrapper = ({ children }: { children: ReactNode }) => {
   return (
     <DndProvider
-      options={HTML5toTouch}
+      backend={TouchBackend}
+      options={{ enableMouseEvents: true }}
       context={typeof window === 'undefined' ? undefined : window}
     >
       <CustomDragLayer />

--- a/packages/editor/src/plugins/blanks-exercise/components/blank-draggable-answer.tsx
+++ b/packages/editor/src/plugins/blanks-exercise/components/blank-draggable-answer.tsx
@@ -19,7 +19,7 @@ export interface BlankAnswerDragItem {
 }
 
 export const dragAnswerStyle =
-  'cursor-grab rounded-full border border-brand bg-brand-50 px-2'
+  'cursor-grab rounded-full border border-brand bg-brand-50 px-2 select-none touch-none'
 
 export function BlankDraggableAnswer(props: BlankDraggableAnswerProps) {
   const { draggableId, text, isAnswerCorrect } = props


### PR DESCRIPTION
Fix for deprecated serlo-editor-for-edusharing docker image release.

Fixes bug where dragging an answer also scrolls the page making it impossible to drop the draggable.

Released npm version but no merge into staging.